### PR TITLE
Add base identity service implementation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ scala:
   - 2.12.8
 
 jdk:
-- oraclejdk8
+- openjdk8
 - openjdk11
 
 script:

--- a/build.sbt
+++ b/build.sbt
@@ -30,6 +30,10 @@ lazy val client = (project in file("./client"))
   )
   .dependsOn(shared % "compile->compile;test->test")
 
+lazy val identity = (project in file("./identity"))
+  .settings(commonSettings)
+  .dependsOn(core % "compile->compile;test->test")
+
 lazy val shared = (project in file("./shared"))
   .settings(commonSettings)
   .settings(
@@ -51,7 +55,7 @@ lazy val core = (project in file("./core"))
       "com.typesafe.akka"       %% "akka-http2-support"   % akkaHttpVersion,
       "com.typesafe.play"       %% "play-json"            % "2.7.0",
       "de.heikoseeberger"       %% "akka-http-play-json"  % "1.23.0",
-      "org.bitbucket.b_c"       %  "jose4j"               % "0.6.4",
+      "org.bitbucket.b_c"       %  "jose4j"               % "0.6.5",
       "org.apache.geode"        %  "geode-core"           % "1.8.0"           % Provided,
       "com.typesafe.slick"      %% "slick"                % "3.2.3"           % Provided,
       "com.h2database"          %  "h2"                   % "1.4.197"         % Test,

--- a/core/src/main/scala/stasis/core/security/jwt/JwtNodeAuthenticator.scala
+++ b/core/src/main/scala/stasis/core/security/jwt/JwtNodeAuthenticator.scala
@@ -1,0 +1,36 @@
+package stasis.core.security.jwt
+
+import java.util.UUID
+
+import org.jose4j.jwt.JwtClaims
+import stasis.core.routing.Node
+import stasis.core.security.NodeAuthenticator
+import stasis.core.security.exceptions.AuthenticationFailure
+
+import scala.concurrent.{ExecutionContext, Future}
+import scala.util.{Failure, Try}
+
+class JwtNodeAuthenticator(underlying: JwtAuthenticator)(implicit ec: ExecutionContext)
+    extends NodeAuthenticator[String] {
+
+  override def authenticate(credentials: String): Future[Node.Id] =
+    for {
+      claims <- underlying.authenticate(credentials)
+      node <- extractNodeFromClaims(claims)
+    } yield {
+      node
+    }
+
+  private def extractNodeFromClaims(claims: JwtClaims): Future[Node.Id] =
+    Future.fromTry(
+      for {
+        subject <- Try(claims.getSubject)
+        node <- Try(UUID.fromString(subject)).recoverWith {
+          case _: IllegalArgumentException =>
+            Failure(AuthenticationFailure(s"Invalid node ID encountered: [$subject]"))
+        }
+      } yield {
+        node
+      }
+    )
+}

--- a/core/src/main/scala/stasis/core/security/psk/PreSharedKeyNodeAuthenticator.scala
+++ b/core/src/main/scala/stasis/core/security/psk/PreSharedKeyNodeAuthenticator.scala
@@ -10,7 +10,7 @@ import stasis.core.security.exceptions.AuthenticationFailure
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success, Try}
 
-class PreSharedKeyAuthenticator(
+class PreSharedKeyNodeAuthenticator(
   backend: KeyValueBackend[String, String]
 )(implicit ec: ExecutionContext)
     extends NodeAuthenticator[(String, String)] {

--- a/core/src/test/resources/application.conf
+++ b/core/src/test/resources/application.conf
@@ -5,6 +5,6 @@ akka {
   http.server.preview.enable-http2 = on
 
   test {
-    timefactor = 3.0
+    timefactor = 5.0
   }
 }

--- a/core/src/test/scala/stasis/test/specs/unit/core/security/jwt/JwtNodeAuthenticatorSpec.scala
+++ b/core/src/test/scala/stasis/test/specs/unit/core/security/jwt/JwtNodeAuthenticatorSpec.scala
@@ -1,0 +1,66 @@
+package stasis.test.specs.unit.core.security.jwt
+
+import org.jose4j.jwk.JsonWebKey
+import stasis.core.routing.Node
+import stasis.core.security.jwt.{JwtAuthenticator, JwtNodeAuthenticator}
+import stasis.test.specs.unit.AsyncUnitSpec
+import stasis.test.specs.unit.core.security.jwt.mocks.{MockJwksGenerators, MockJwtKeyProvider, MockJwtsGenerators}
+
+import scala.concurrent.duration._
+import scala.util.control.NonFatal
+
+class JwtNodeAuthenticatorSpec extends AsyncUnitSpec {
+  private val jwk: JsonWebKey = MockJwksGenerators.generateRandomRsaKey(Some("rsa-0"))
+
+  "A JwtNodeAuthenticator" should "successfully authenticate nodes with valid tokens" in {
+    val underlying = new JwtAuthenticator(
+      provider = MockJwtKeyProvider(jwk),
+      audience = "self",
+      expirationTolerance = 10.seconds
+    )
+
+    val authenticator = new JwtNodeAuthenticator(underlying)
+
+    val expectedNode: Node.Id = Node.generateId()
+    val nodeToken: String = MockJwtsGenerators.generateJwt(
+      issuer = "self",
+      audience = "self",
+      subject = expectedNode.toString,
+      signingKey = jwk
+    )
+
+    for {
+      actualNode <- authenticator.authenticate(credentials = nodeToken)
+    } yield {
+      actualNode should be(expectedNode)
+    }
+  }
+
+  it should s"refuse authentication attempts with invalid node IDs" in {
+    val underlying = new JwtAuthenticator(
+      provider = MockJwtKeyProvider(jwk),
+      audience = "self",
+      expirationTolerance = 10.seconds
+    )
+
+    val authenticator = new JwtNodeAuthenticator(underlying)
+
+    val expectedNode = "some-node"
+    val nodeToken: String = MockJwtsGenerators.generateJwt(
+      issuer = "self",
+      audience = "self",
+      subject = expectedNode,
+      signingKey = jwk
+    )
+
+    authenticator
+      .authenticate(credentials = nodeToken)
+      .map { response =>
+        fail(s"Received unexpected response from authenticator: [$response]")
+      }
+      .recover {
+        case NonFatal(e) =>
+          e.getMessage should be(s"Invalid node ID encountered: [$expectedNode]")
+      }
+  }
+}

--- a/core/src/test/scala/stasis/test/specs/unit/core/security/psk/PreSharedKeyNodeAuthenticatorSpec.scala
+++ b/core/src/test/scala/stasis/test/specs/unit/core/security/psk/PreSharedKeyNodeAuthenticatorSpec.scala
@@ -4,21 +4,21 @@ import akka.actor.typed.scaladsl.Behaviors
 import akka.actor.typed.{ActorSystem, Behavior, SpawnProtocol}
 import stasis.core.persistence.backends.memory.MemoryBackend
 import stasis.core.routing.Node
-import stasis.core.security.psk.PreSharedKeyAuthenticator
+import stasis.core.security.psk.PreSharedKeyNodeAuthenticator
 import stasis.test.specs.unit.AsyncUnitSpec
 
 import scala.util.control.NonFatal
 
-class PreSharedKeyAuthenticatorSpec extends AsyncUnitSpec {
+class PreSharedKeyNodeAuthenticatorSpec extends AsyncUnitSpec {
 
   private implicit val system: ActorSystem[SpawnProtocol] = ActorSystem(
     Behaviors.setup(_ => SpawnProtocol.behavior): Behavior[SpawnProtocol],
-    "PreSharedKeyAuthenticatorSpec"
+    "PreSharedKeyNodeAuthenticatorSpec"
   )
 
-  "A PreSharedKeyAuthenticator" should "authenticate nodes with valid secrets" in {
+  "A PreSharedKeyNodeAuthenticator" should "authenticate nodes with valid secrets" in {
     val backend = MemoryBackend[String, String]("psk-authenticator-store")
-    val authenticator = new PreSharedKeyAuthenticator(backend)
+    val authenticator = new PreSharedKeyNodeAuthenticator(backend)
 
     val expectedNode: Node.Id = Node.generateId()
     val nodeSecret: String = "some-secret"
@@ -34,7 +34,7 @@ class PreSharedKeyAuthenticatorSpec extends AsyncUnitSpec {
 
   it should "refuse authentication attempts with invalid secrets" in {
     val backend = MemoryBackend[String, String]("psk-authenticator-store")
-    val authenticator = new PreSharedKeyAuthenticator(backend)
+    val authenticator = new PreSharedKeyNodeAuthenticator(backend)
 
     val expectedNode: Node.Id = Node.generateId()
     val nodeSecret: String = "some-secret"
@@ -54,7 +54,7 @@ class PreSharedKeyAuthenticatorSpec extends AsyncUnitSpec {
 
   it should "refuse authentication attempts with invalid node IDs" in {
     val backend = MemoryBackend[String, String]("psk-authenticator-store")
-    val authenticator = new PreSharedKeyAuthenticator(backend)
+    val authenticator = new PreSharedKeyNodeAuthenticator(backend)
 
     val node = "some-node"
     val nodeSecret: String = "some-secret"
@@ -72,7 +72,7 @@ class PreSharedKeyAuthenticatorSpec extends AsyncUnitSpec {
 
   it should "refuse authentication attempts for missing nodes" in {
     val backend = MemoryBackend[String, String]("psk-authenticator-store")
-    val authenticator = new PreSharedKeyAuthenticator(backend)
+    val authenticator = new PreSharedKeyNodeAuthenticator(backend)
 
     val expectedNode: Node.Id = Node.generateId()
     val nodeSecret: String = "some-secret"

--- a/identity/src/main/resources/application.conf
+++ b/identity/src/main/resources/application.conf
@@ -1,0 +1,20 @@
+stasis {
+  identity {
+    secrets {
+      client {
+        algorithm = "PBKDF2WithHmacSHA512"
+        iterations = 10000
+        derived-key-size = 64 // in bytes
+        salt-size = 64 // in bytes
+        authentication-delay = 500ms
+      }
+      resource-owner {
+        algorithm = "PBKDF2WithHmacSHA512"
+        iterations = 10000
+        derived-key-size = 64 // in bytes
+        salt-size = 64 // in bytes
+        authentication-delay = 500ms
+      }
+    }
+  }
+}

--- a/identity/src/main/scala/stasis/identity/api/Formats.scala
+++ b/identity/src/main/scala/stasis/identity/api/Formats.scala
@@ -1,0 +1,167 @@
+package stasis.identity.api
+
+import akka.http.scaladsl.unmarshalling.Unmarshaller
+import play.api.libs.json._
+import stasis.identity.api.manage.requests._
+import stasis.identity.api.manage.responses.CreatedClient
+import stasis.identity.model.apis.Api
+import stasis.identity.model.clients.Client
+import stasis.identity.model.codes.{AuthorizationCode, StoredAuthorizationCode}
+import stasis.identity.model.errors.{AuthorizationError, TokenError}
+import stasis.identity.model.owners.ResourceOwner
+import stasis.identity.model.realms.Realm
+import stasis.identity.model.tokens.{AccessToken, RefreshToken, StoredRefreshToken, TokenType}
+import stasis.identity.model.{GrantType, ResponseType, Seconds}
+
+object Formats {
+  implicit val authorizationErrorFormat: Writes[AuthorizationError] = Writes[AuthorizationError] { error =>
+    Json.obj(
+      "error" -> JsString(error.error),
+      "error_description" -> JsString(error.error_description),
+      "state" -> JsString(error.state)
+    )
+  }
+
+  implicit val tokenErrorFormat: Writes[TokenError] = Writes[TokenError] { error =>
+    Json.obj(
+      "error" -> JsString(error.error),
+      "error_description" -> JsString(error.error_description)
+    )
+  }
+
+  implicit val tokenTypeFormat: Format[TokenType] = Format[TokenType](
+    fjs = Reads[TokenType](_.validate[String].map { case "bearer" => TokenType.Bearer }),
+    tjs = Writes[TokenType](tokenType => JsString(tokenType.toString.toLowerCase))
+  )
+
+  implicit val grantTypeFormat: Format[GrantType] = Format[GrantType](
+    fjs = Reads[GrantType](_.validate[String].map(convertStringToGrantType)),
+    tjs = Writes[GrantType](grantType => JsString(convertGrantTypeToString(grantType)))
+  )
+
+  implicit val responseTypeFormat: Format[ResponseType] = Format[ResponseType](
+    fjs = Reads[ResponseType](_.validate[String].map(convertStringToResponseType)),
+    tjs = Writes[ResponseType](responseType => JsString(convertResponseTypeToString(responseType)))
+  )
+
+  implicit val accessTokenFormat: Format[AccessToken] =
+    Format(
+      fjs = Reads[AccessToken](_.validate[String].map(AccessToken)),
+      tjs = Writes[AccessToken](token => JsString(token.value))
+    )
+
+  implicit val refreshTokenFormat: Format[RefreshToken] =
+    Format(
+      fjs = Reads[RefreshToken](_.validate[String].map(RefreshToken)),
+      tjs = Writes[RefreshToken](token => JsString(token.value))
+    )
+
+  implicit val authorizationCodeFormat: Format[AuthorizationCode] =
+    Format(
+      fjs = Reads[AuthorizationCode](_.validate[String].map(AuthorizationCode)),
+      tjs = Writes[AuthorizationCode](code => JsString(code.value))
+    )
+
+  implicit val secondsFormat: Format[Seconds] =
+    Format(
+      fjs = Reads[Seconds](_.validate[Long].map(Seconds.apply)),
+      tjs = Writes[Seconds](seconds => JsNumber(seconds.value))
+    )
+
+  implicit val apiFormat: Format[Api] = Json.format[Api]
+
+  implicit val clientFormat: Writes[Client] =
+    Writes[Client](
+      client =>
+        Json.obj(
+          "id" -> Json.toJson(client.id),
+          "realm" -> Json.toJson(client.realm),
+          "allowedScopes" -> Json.toJson(client.allowedScopes),
+          "redirectUri" -> Json.toJson(client.redirectUri),
+          "tokenExpiration" -> Json.toJson(client.tokenExpiration),
+          "active" -> Json.toJson(client.active)
+      )
+    )
+
+  implicit val storedAuthorizationCodeFormat: Writes[StoredAuthorizationCode] =
+    Writes[StoredAuthorizationCode](
+      code =>
+        Json.obj(
+          "code" -> Json.toJson(code.code),
+          "owner" -> Json.toJson(code.owner.username),
+          "scope" -> Json.toJson(code.scope)
+      )
+    )
+
+  implicit val resourceOwnerFormat: Writes[ResourceOwner] =
+    Writes[ResourceOwner](
+      owner =>
+        Json.obj(
+          "username" -> Json.toJson(owner.username),
+          "realm" -> Json.toJson(owner.realm),
+          "allowedScopes" -> Json.toJson(owner.allowedScopes),
+          "active" -> Json.toJson(owner.active)
+      )
+    )
+
+  implicit val realmFormat: Format[Realm] = Json.format[Realm]
+
+  implicit val storedRefreshTokenFormat: Writes[StoredRefreshToken] =
+    Writes[StoredRefreshToken](
+      token =>
+        Json.obj(
+          "token" -> Json.toJson(token.token),
+          "owner" -> Json.toJson(token.owner.username),
+          "scope" -> Json.toJson(token.scope)
+      )
+    )
+
+  implicit val crateApiFormat: Format[CreateApi] = Json.format[CreateApi]
+  implicit val createClientFormat: Format[CreateClient] = Json.format[CreateClient]
+  implicit val updateClientFormat: Format[UpdateClient] = Json.format[UpdateClient]
+  implicit val updateClientCredentialsFormat: Format[UpdateClientCredentials] = Json.format[UpdateClientCredentials]
+  implicit val createdClientFormat: Format[CreatedClient] = Json.format[CreatedClient]
+  implicit val createOwnerFormat: Format[CreateOwner] = Json.format[CreateOwner]
+  implicit val updateOwnerFormat: Format[UpdateOwner] = Json.format[UpdateOwner]
+  implicit val updateOwnerCredentialsFormat: Format[UpdateOwnerCredentials] = Json.format[UpdateOwnerCredentials]
+  implicit val createRealmFormat: Format[CreateRealm] = Json.format[CreateRealm]
+
+  implicit val stringToResponseType: Unmarshaller[String, ResponseType] =
+    Unmarshaller.strict { convertStringToResponseType }
+
+  implicit val stringToGrantType: Unmarshaller[String, GrantType] =
+    Unmarshaller.strict { convertStringToGrantType }
+
+  implicit val stringToAuthorizationCode: Unmarshaller[String, AuthorizationCode] =
+    Unmarshaller.strict(AuthorizationCode)
+
+  implicit val stringToUuid: Unmarshaller[String, java.util.UUID] =
+    Unmarshaller.strict(java.util.UUID.fromString)
+
+  implicit val stringToRefreshToken: Unmarshaller[String, RefreshToken] =
+    Unmarshaller.strict(RefreshToken)
+
+  private def convertStringToResponseType(string: String): ResponseType = string match {
+    case "code"  => ResponseType.Code
+    case "token" => ResponseType.Token
+  }
+
+  private def convertResponseTypeToString(responseType: ResponseType): String =
+    responseType.toString.toLowerCase
+
+  private def convertStringToGrantType(string: String): GrantType = string match {
+    case "authorization_code" => GrantType.AuthorizationCode
+    case "client_credentials" => GrantType.ClientCredentials
+    case "implicit"           => GrantType.Implicit
+    case "refresh_token"      => GrantType.RefreshToken
+    case "password"           => GrantType.Password
+  }
+
+  private def convertGrantTypeToString(grantType: GrantType): String = grantType match {
+    case GrantType.AuthorizationCode => "authorization_code"
+    case GrantType.ClientCredentials => "client_credentials"
+    case GrantType.Implicit          => "implicit"
+    case GrantType.RefreshToken      => "refresh_token"
+    case GrantType.Password          => "password"
+  }
+}

--- a/identity/src/main/scala/stasis/identity/api/IdentityEndpoint.scala
+++ b/identity/src/main/scala/stasis/identity/api/IdentityEndpoint.scala
@@ -1,0 +1,77 @@
+package stasis.identity.api
+
+import akka.actor.ActorSystem
+import akka.event.{Logging, LoggingAdapter}
+import akka.http.scaladsl.Http
+import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.server.Directives._
+import akka.http.scaladsl.server._
+import akka.stream.ActorMaterializer
+import org.jose4j.jwk.JsonWebKey
+import stasis.identity.api.manage.setup.{Config => ManageConfig, Providers => ManageProviders}
+import stasis.identity.api.oauth.setup.{Providers => OAuthProviders}
+
+import scala.concurrent.Future
+import scala.util.control.NonFatal
+
+class IdentityEndpoint(
+  keys: Seq[JsonWebKey],
+  oauthProviders: OAuthProviders,
+  manageProviders: ManageProviders,
+  manageConfig: ManageConfig
+)(implicit system: ActorSystem) {
+
+  private val log: LoggingAdapter = Logging(system, this.getClass.getName)
+  private implicit val mat: ActorMaterializer = ActorMaterializer()
+
+  private val oauth = new OAuth(oauthProviders)
+  private val jwks = new Jwks(keys)
+  private val manage = new Manage(manageProviders, manageConfig)
+
+  private implicit def sanitizingExceptionHandler: ExceptionHandler =
+    ExceptionHandler {
+      case NonFatal(e) =>
+        extractRequestEntity { entity =>
+          val _ = entity.discardBytes()
+          val failureReference = java.util.UUID.randomUUID()
+
+          log.error(
+            e,
+            "Unhandled exception encountered: [{}]; failure reference is [{}]",
+            e.getMessage,
+            failureReference
+          )
+
+          complete(
+            StatusCodes.InternalServerError,
+            s"Failed to process request; failure reference is [$failureReference]"
+          )
+        }
+    }
+
+  private implicit def rejectionHandler: RejectionHandler =
+    RejectionHandler
+      .newBuilder()
+      .handle {
+        case MissingQueryParamRejection(parameterName) =>
+          extractRequestEntity { entity =>
+            val _ = entity.discardBytes()
+
+            val message = s"Parameter [$parameterName] is missing, invalid or malformed"
+            log.warning(message)
+            complete(StatusCodes.BadRequest, message)
+          }
+      }
+      .result()
+      .seal
+
+  val routes: Route =
+    concat(
+      pathPrefix("oauth") { oauth.routes },
+      pathPrefix("jwks") { jwks.routes },
+      pathPrefix("manage") { manage.routes }
+    )
+
+  def start(hostname: String, port: Int): Future[Http.ServerBinding] =
+    Http().bindAndHandle(routes, hostname, port)
+}

--- a/identity/src/main/scala/stasis/identity/api/Jwks.scala
+++ b/identity/src/main/scala/stasis/identity/api/Jwks.scala
@@ -1,0 +1,41 @@
+package stasis.identity.api
+
+import akka.actor.ActorSystem
+import akka.event.{Logging, LoggingAdapter}
+import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.server.Directives._
+import akka.http.scaladsl.server._
+import org.jose4j.jwk.JsonWebKey
+
+class Jwks(keys: Seq[JsonWebKey])(implicit system: ActorSystem) {
+  import Jwks._
+  import de.heikoseeberger.akkahttpplayjson.PlayJsonSupport._
+
+  private val log: LoggingAdapter = Logging(system, this.getClass.getName)
+
+  def routes: Route =
+    path("jwks.json") {
+      get {
+        extractClientIP { remoteAddress =>
+          log.debug("Successfully provided [{}] JWKs to [{}]", keys.size, remoteAddress)
+
+          complete(
+            StatusCodes.OK,
+            JwksResponse(keys = keys)
+          )
+        }
+      }
+    }
+}
+
+object Jwks {
+  import play.api.libs.json._
+
+  implicit val jwksResponseFormat: Writes[JwksResponse] = Writes[JwksResponse] { jwks =>
+    Json.obj(
+      "keys" -> JsArray(jwks.keys.map(jwk => JsString(jwk.toJson)))
+    )
+  }
+
+  final case class JwksResponse(keys: Seq[JsonWebKey])
+}

--- a/identity/src/main/scala/stasis/identity/api/Manage.scala
+++ b/identity/src/main/scala/stasis/identity/api/Manage.scala
@@ -1,0 +1,87 @@
+package stasis.identity.api
+
+import akka.actor.ActorSystem
+import akka.event.{Logging, LoggingAdapter}
+import akka.http.scaladsl.server.Directives._
+import akka.http.scaladsl.server._
+import akka.stream.Materializer
+import stasis.identity.api.manage._
+import stasis.identity.api.manage.directives.{RealmExtraction, UserAuthentication, UserAuthorization}
+import stasis.identity.api.manage.setup.{Config, Providers}
+import stasis.identity.authentication.manage.ResourceOwnerAuthenticator
+import stasis.identity.model.realms.{Realm, RealmStoreView}
+
+class Manage(
+  providers: Providers,
+  config: Config
+)(implicit system: ActorSystem, override val mat: Materializer)
+    extends RealmExtraction
+    with UserAuthentication
+    with UserAuthorization {
+  import Manage._
+
+  override protected def log: LoggingAdapter = Logging(system, this.getClass.getName)
+  override protected def authenticator: ResourceOwnerAuthenticator = providers.ownerAuthenticator
+  override protected def realmStore: RealmStoreView = providers.realmStore.view
+
+  private val apis = new Apis(providers.apiStore)
+  private val clients = new Clients(providers.clientStore, config.clientSecrets)
+  private val codes = new Codes(providers.codeStore)
+  private val owners = new Owners(providers.ownerStore, config.ownerSecrets)
+  private val realms = new Realms(providers.realmStore)
+  private val tokens = new Tokens(providers.tokenStore)
+
+  def routes: Route =
+    concat(
+      pathPrefix(Segment) {
+        case Realm.Master =>
+          authenticate(Realm.Master) { user =>
+            authorize(user, Realm.Master, Scopes.ManageMaster) {
+              concat(
+                pathPrefix("realms") {
+                  realms.routes(user.username)
+                },
+                pathPrefix("codes") {
+                  codes.routes(user.username)
+                },
+                pathPrefix("tokens") {
+                  tokens.routes(user.username)
+                }
+              )
+            }
+          }
+
+        case realmId: Realm.Id =>
+          extractRealm(realmId) { realm =>
+            authenticate(realmId) { user =>
+              concat(
+                pathPrefix("apis") {
+                  authorize(user, realm.id, Scopes.ManageApis) {
+                    apis.routes(user.username, realmId)
+                  }
+                },
+                pathPrefix("clients") {
+                  authorize(user, realm.id, Scopes.ManageClients) {
+                    clients.routes(user.username, realmId)
+                  }
+                },
+                pathPrefix("owners") {
+                  authorize(user, realm.id, Scopes.ManageOwners) {
+                    owners.routes(user.username, realmId)
+                  }
+                }
+              )
+            }
+          }
+      }
+    )
+}
+
+object Manage {
+  object Scopes {
+    final val ManageMaster: String = "manage:master"
+    final val ManageApis: String = "manage:apis"
+    final val ManageClients: String = "manage:clients"
+    final val ManageOwners: String = "manage:owners"
+  }
+}

--- a/identity/src/main/scala/stasis/identity/api/OAuth.scala
+++ b/identity/src/main/scala/stasis/identity/api/OAuth.scala
@@ -1,0 +1,60 @@
+package stasis.identity.api
+
+import akka.actor.ActorSystem
+import akka.event.{Logging, LoggingAdapter}
+import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.server.Directives._
+import akka.http.scaladsl.server._
+import akka.stream.Materializer
+import stasis.identity.api.manage.directives.RealmExtraction
+import stasis.identity.api.oauth._
+import stasis.identity.api.oauth.setup.Providers
+import stasis.identity.model.realms.RealmStoreView
+
+class OAuth(
+  providers: Providers
+)(implicit system: ActorSystem, override val mat: Materializer)
+    extends RealmExtraction {
+
+  override protected def log: LoggingAdapter = Logging(system, this.getClass.getName)
+  override protected def realmStore: RealmStoreView = providers.realmStore.view
+
+  private val authorizationCodeGrant = new AuthorizationCodeGrant(providers)
+  private val clientCredentialsGrant = new ClientCredentialsGrant(providers)
+  private val implicitGrant = new ImplicitGrant(providers)
+  private val refreshTokenGrant = new RefreshTokenGrant(providers)
+  private val passwordCredentialsGrant = new ResourceOwnerPasswordCredentialsGrant(providers)
+
+  def routes: Route =
+    concat(
+      pathPrefix(Segment) { realmId =>
+        extractRealm(realmId) {
+          realm =>
+            concat(
+              path("authorization") {
+                parameter("response_type".as[String]) {
+                  case "code"  => authorizationCodeGrant.authorization(realm)
+                  case "token" => implicitGrant.authorization(realm)
+                  case responseType =>
+                    val message = s"Realm [$realmId]: The request includes an invalid response type: [$responseType]"
+                    log.warning(message)
+                    complete(StatusCodes.BadRequest, message)
+                }
+              },
+              path("token") {
+                parameter("grant_type".as[String]) {
+                  case "authorization_code" => authorizationCodeGrant.token(realm)
+                  case "client_credentials" => clientCredentialsGrant.token(realm)
+                  case "refresh_token"      => refreshTokenGrant.token(realm)
+                  case "password"           => passwordCredentialsGrant.token(realm)
+                  case grantType =>
+                    val message = s"Realm [$realmId]: The request includes an invalid grant type: [$grantType]"
+                    log.warning(message)
+                    complete(StatusCodes.BadRequest, message)
+                }
+              }
+            )
+        }
+      }
+    )
+}

--- a/identity/src/main/scala/stasis/identity/api/directives/BaseApiDirective.scala
+++ b/identity/src/main/scala/stasis/identity/api/directives/BaseApiDirective.scala
@@ -1,0 +1,29 @@
+package stasis.identity.api.directives
+
+import akka.http.scaladsl.server.Directives._
+import akka.http.scaladsl.server.{Directive, Directive0}
+import akka.stream.Materializer
+import akka.stream.scaladsl.Sink
+import akka.util.ByteString
+
+trait BaseApiDirective {
+  protected implicit def mat: Materializer
+
+  def discardEntity: Directive0 =
+    Directive { inner =>
+      extractRequestEntity { entity =>
+        val _ = entity.dataBytes.runWith(Sink.cancelled[ByteString])
+        inner(())
+      }
+    }
+
+  def consumeEntity: Directive0 =
+    Directive { inner =>
+      extractRequestEntity { entity =>
+        val result = entity.dataBytes.runWith(Sink.ignore)
+        onSuccess(result) { _ =>
+          inner(())
+        }
+      }
+    }
+}

--- a/identity/src/main/scala/stasis/identity/api/manage/Apis.scala
+++ b/identity/src/main/scala/stasis/identity/api/manage/Apis.scala
@@ -1,0 +1,64 @@
+package stasis.identity.api.manage
+
+import akka.actor.ActorSystem
+import akka.event.{Logging, LoggingAdapter}
+import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.server.Directives._
+import akka.http.scaladsl.server._
+import akka.stream.Materializer
+import stasis.identity.api.manage.directives.RealmValidation
+import stasis.identity.api.manage.requests.CreateApi
+import stasis.identity.model.apis.{Api, ApiStore}
+import stasis.identity.model.owners.ResourceOwner
+import stasis.identity.model.realms.Realm
+
+import scala.concurrent.ExecutionContext
+
+class Apis(store: ApiStore)(implicit system: ActorSystem, materializer: Materializer) extends RealmValidation[Api] {
+  import de.heikoseeberger.akkahttpplayjson.PlayJsonSupport._
+  import stasis.identity.api.Formats._
+
+  override implicit protected def mat: Materializer = materializer
+  private implicit val ec: ExecutionContext = system.dispatcher
+  protected def log: LoggingAdapter = Logging(system, this.getClass.getName)
+
+  override implicit protected def extractor: RealmValidation.Extractor[Api] = _.realm
+
+  def routes(user: ResourceOwner.Id, realm: Realm.Id): Route =
+    concat(
+      pathEndOrSingleSlash {
+        concat(
+          get {
+            filterRealm(realm, store.apis) { apis =>
+              log.info("Realm [{}]: User [{}] successfully retrieved [{}] APIs", realm, user, apis.size)
+              complete(apis.values)
+            }
+          },
+          post {
+            entity(as[CreateApi]) { request =>
+              onSuccess(store.put(request.toApi(realm))) { _ =>
+                log.info("Realm [{}]: User [{}] successfully created API [{}]", realm, user, request.id)
+                complete(StatusCodes.OK)
+              }
+            }
+          }
+        )
+      },
+      path(Segment) { apiId =>
+        validateRealm(realm, store.get(apiId)) { api =>
+          concat(
+            get {
+              log.info("Realm [{}]: User [{}] successfully retrieved API [{}]", realm, user, apiId)
+              complete(api)
+            },
+            delete {
+              onSuccess(store.delete(apiId)) { _ =>
+                log.info("Realm [{}]: User [{}] successfully deleted API [{}]", realm, user, apiId)
+                complete(StatusCodes.OK)
+              }
+            }
+          )
+        }
+      }
+    )
+}

--- a/identity/src/main/scala/stasis/identity/api/manage/Clients.scala
+++ b/identity/src/main/scala/stasis/identity/api/manage/Clients.scala
@@ -1,0 +1,111 @@
+package stasis.identity.api.manage
+
+import akka.actor.ActorSystem
+import akka.event.{Logging, LoggingAdapter}
+import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.server.Directives._
+import akka.http.scaladsl.server._
+import akka.stream.Materializer
+import stasis.identity.api.Formats._
+import stasis.identity.api.manage.directives.RealmValidation
+import stasis.identity.api.manage.requests.{CreateClient, UpdateClient, UpdateClientCredentials}
+import stasis.identity.api.manage.responses.CreatedClient
+import stasis.identity.model.clients.{Client, ClientStore}
+import stasis.identity.model.owners.ResourceOwner
+import stasis.identity.model.realms.Realm
+import stasis.identity.model.secrets.Secret
+
+import scala.concurrent.ExecutionContext
+
+class Clients(
+  store: ClientStore,
+  clientSecretConfig: Secret.ClientConfig
+)(implicit system: ActorSystem, materializer: Materializer)
+    extends RealmValidation[Client] {
+  import de.heikoseeberger.akkahttpplayjson.PlayJsonSupport._
+
+  override implicit protected def mat: Materializer = materializer
+  private implicit val ec: ExecutionContext = system.dispatcher
+  protected def log: LoggingAdapter = Logging(system, this.getClass.getName)
+
+  override implicit protected def extractor: RealmValidation.Extractor[Client] = _.realm
+
+  private implicit val secretConfig: Secret.ClientConfig = clientSecretConfig
+
+  def routes(user: ResourceOwner.Id, realm: Realm.Id): Route =
+    concat(
+      pathEndOrSingleSlash {
+        concat(
+          get {
+            filterRealm(realm, store.clients) { clients =>
+              log.info("Realm [{}]: User [{}] successfully retrieved [{}] clients", realm, user, clients.size)
+              complete(clients.values)
+            }
+          },
+          post {
+            entity(as[CreateClient]) { request =>
+              val client = request.toClient(realm)
+              onSuccess(store.put(client)) { _ =>
+                log.info("Realm [{}]: User [{}] successfully created client [{}]", realm, user, client.id)
+                complete(CreatedClient(client.id))
+              }
+            }
+          }
+        )
+      },
+      pathPrefix(JavaUUID) { clientId =>
+        validateRealm(realm, store.get(clientId)) {
+          client =>
+            concat(
+              path("credentials") {
+                put {
+                  entity(as[UpdateClientCredentials]) { request =>
+                    val (secret, salt) = request.toSecret()
+
+                    onSuccess(store.put(client.copy(secret = secret, salt = salt))) { _ =>
+                      log.info(
+                        "Realm [{}]: User [{}] successfully updated credentials for client [{}]",
+                        realm,
+                        user,
+                        clientId
+                      )
+                      complete(StatusCodes.OK)
+                    }
+                  }
+                }
+              },
+              pathEndOrSingleSlash {
+                concat(
+                  get {
+                    log.info("Realm [{}]: User [{}] successfully retrieved client [{}]", realm, user, clientId)
+                    complete(client)
+                  },
+                  put {
+                    entity(as[UpdateClient]) { request =>
+                      onSuccess(
+                        store.put(
+                          client.copy(
+                            allowedScopes = request.allowedScopes,
+                            tokenExpiration = request.tokenExpiration,
+                            active = request.active
+                          )
+                        )
+                      ) { _ =>
+                        log.info("Realm [{}]: User [{}] successfully updated client [{}]", realm, user, clientId)
+                        complete(StatusCodes.OK)
+                      }
+                    }
+                  },
+                  delete {
+                    onSuccess(store.delete(clientId)) { _ =>
+                      log.info("Realm [{}]: User [{}] successfully deleted client [{}]", realm, user, clientId)
+                      complete(StatusCodes.OK)
+                    }
+                  }
+                )
+              }
+            )
+        }
+      }
+    )
+}

--- a/identity/src/main/scala/stasis/identity/api/manage/Codes.scala
+++ b/identity/src/main/scala/stasis/identity/api/manage/Codes.scala
@@ -1,0 +1,62 @@
+package stasis.identity.api.manage
+
+import akka.actor.ActorSystem
+import akka.event.{Logging, LoggingAdapter}
+import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.server.Directives._
+import akka.http.scaladsl.server._
+import stasis.identity.model.codes.AuthorizationCodeStore
+import stasis.identity.model.owners.ResourceOwner
+
+class Codes(store: AuthorizationCodeStore)(implicit system: ActorSystem) {
+  import de.heikoseeberger.akkahttpplayjson.PlayJsonSupport._
+  import stasis.identity.api.Formats._
+
+  private val log: LoggingAdapter = Logging(system, this.getClass.getName)
+
+  def routes(user: ResourceOwner.Id): Route =
+    concat(
+      pathEndOrSingleSlash {
+        get {
+          onSuccess(store.codes) { codes =>
+            log.info("User [{}] successfully retrieved [{}] authorization codes", user, codes.size)
+            complete(codes.values)
+          }
+        }
+      },
+      path(JavaUUID) { clientId =>
+        concat(
+          get {
+            onSuccess(store.get(clientId)) {
+              case Some(code) =>
+                log.info(
+                  "User [{}] successfully retrieved authorization code for client [{}]",
+                  user,
+                  clientId
+                )
+                complete(code)
+
+              case None =>
+                log.warning(
+                  "User [{}] requested an authorization code for client [{}] but none was found",
+                  user,
+                  clientId
+                )
+                complete(StatusCodes.NotFound)
+            }
+          },
+          delete {
+            onSuccess(store.delete(clientId)) { deleted =>
+              if (deleted) {
+                log.info("User [{}] successfully deleted authorization code for client [{}]", user, clientId)
+                complete(StatusCodes.OK)
+              } else {
+                log.warning("User [{}] failed to delete authorization code for client [{}]", user, clientId)
+                complete(StatusCodes.NotFound)
+              }
+            }
+          }
+        )
+      }
+    )
+}

--- a/identity/src/main/scala/stasis/identity/api/manage/Owners.scala
+++ b/identity/src/main/scala/stasis/identity/api/manage/Owners.scala
@@ -1,0 +1,134 @@
+package stasis.identity.api.manage
+
+import akka.actor.ActorSystem
+import akka.event.{Logging, LoggingAdapter}
+import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.server.Directives._
+import akka.http.scaladsl.server._
+import akka.stream.Materializer
+import stasis.identity.api.manage.directives.RealmValidation
+import stasis.identity.api.manage.requests.{CreateOwner, UpdateOwner, UpdateOwnerCredentials}
+import stasis.identity.model.owners.{ResourceOwner, ResourceOwnerStore}
+import stasis.identity.model.realms.Realm
+import stasis.identity.model.secrets.Secret
+
+import scala.concurrent.ExecutionContext
+
+class Owners(
+  store: ResourceOwnerStore,
+  ownerSecretConfig: Secret.ResourceOwnerConfig
+)(implicit system: ActorSystem, materializer: Materializer)
+    extends RealmValidation[ResourceOwner] {
+  import de.heikoseeberger.akkahttpplayjson.PlayJsonSupport._
+  import stasis.identity.api.Formats._
+
+  override implicit protected def mat: Materializer = materializer
+  private implicit val ec: ExecutionContext = system.dispatcher
+  protected def log: LoggingAdapter = Logging(system, this.getClass.getName)
+
+  override implicit protected def extractor: RealmValidation.Extractor[ResourceOwner] = _.realm
+
+  private implicit val secretConfig: Secret.ResourceOwnerConfig = ownerSecretConfig
+
+  def routes(user: ResourceOwner.Id, realm: Realm.Id): Route =
+    concat(
+      pathEndOrSingleSlash {
+        concat(
+          get {
+            filterRealm(realm, store.owners) { owners =>
+              log.info(
+                "Realm [{}]: User [{}] successfully retrieved [{}] resource owners",
+                realm,
+                user,
+                owners.size
+              )
+              complete(owners.values)
+            }
+          },
+          post {
+            entity(as[CreateOwner]) { request =>
+              val owner = request.toResourceOwner(realm)
+              onSuccess(store.put(owner)) { _ =>
+                log.info(
+                  "Realm [{}]: User [{}] successfully created resource owner [{}]",
+                  realm,
+                  user,
+                  owner.username
+                )
+                complete(StatusCodes.OK)
+              }
+            }
+          }
+        )
+      },
+      pathPrefix(Segment) { ownerUsername =>
+        validateRealm(realm, store.get(ownerUsername)) {
+          owner =>
+            concat(
+              path("credentials") {
+                put {
+                  entity(as[UpdateOwnerCredentials]) { request =>
+                    val (secret, salt) = request.toSecret()
+
+                    onSuccess(store.put(owner.copy(password = secret, salt = salt))) { _ =>
+                      log.info(
+                        "Realm [{}]: User [{}] successfully updated credentials for resource owner [{}]",
+                        realm,
+                        user,
+                        ownerUsername
+                      )
+                      complete(StatusCodes.OK)
+                    }
+                  }
+                }
+              },
+              pathEndOrSingleSlash {
+                concat(
+                  get {
+                    log.info(
+                      "Realm [{}]: User [{}] successfully retrieved resource owner [{}]",
+                      realm,
+                      user,
+                      ownerUsername
+                    )
+                    complete(owner)
+                  },
+                  put {
+                    entity(as[UpdateOwner]) { request =>
+                      onSuccess(
+                        store.put(
+                          owner.copy(
+                            allowedScopes = request.allowedScopes,
+                            active = request.active
+                          )
+                        )
+                      ) { _ =>
+                        log.info(
+                          "Realm [{}]: User [{}] successfully updated resource owner [{}]",
+                          realm,
+                          user,
+                          ownerUsername
+                        )
+                        complete(StatusCodes.OK)
+
+                      }
+                    }
+                  },
+                  delete {
+                    onSuccess(store.delete(ownerUsername)) { _ =>
+                      log.info(
+                        "Realm [{}]: User [{}] successfully deleted resource owner [{}]",
+                        realm,
+                        user,
+                        ownerUsername
+                      )
+                      complete(StatusCodes.OK)
+                    }
+                  }
+                )
+              }
+            )
+        }
+      }
+    )
+}

--- a/identity/src/main/scala/stasis/identity/api/manage/Realms.scala
+++ b/identity/src/main/scala/stasis/identity/api/manage/Realms.scala
@@ -1,0 +1,70 @@
+package stasis.identity.api.manage
+
+import akka.actor.ActorSystem
+import akka.event.{Logging, LoggingAdapter}
+import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.server.Directives._
+import akka.http.scaladsl.server._
+import stasis.identity.api.manage.requests.CreateRealm
+import stasis.identity.model.owners.ResourceOwner
+import stasis.identity.model.realms.RealmStore
+
+class Realms(store: RealmStore)(implicit system: ActorSystem) {
+  import de.heikoseeberger.akkahttpplayjson.PlayJsonSupport._
+  import stasis.identity.api.Formats._
+
+  private val log: LoggingAdapter = Logging(system, this.getClass.getName)
+
+  def routes(user: ResourceOwner.Id): Route =
+    concat(
+      pathEndOrSingleSlash {
+        concat(
+          get {
+            onSuccess(store.realms) { realms =>
+              log.info("User [{}] successfully retrieved [{}] realms", user, realms.size)
+              complete(realms.values)
+            }
+          },
+          post {
+            entity(as[CreateRealm]) { request =>
+              val realm = request.toRealm
+              onSuccess(store.put(realm)) { _ =>
+                log.info("User [{}] successfully created realm [{}]", user, realm.id)
+                complete(StatusCodes.OK)
+              }
+            }
+          }
+        )
+      },
+      path(Segment) { realmId =>
+        concat(
+          get {
+            onSuccess(store.get(realmId)) {
+              case Some(realm) =>
+                log.info("User [{}] successfully retrieved realm [{}]", user, realmId)
+                complete(realm)
+
+              case None =>
+                log.warning(
+                  "User [{}] requested realm [{}] but none was found",
+                  user,
+                  realmId
+                )
+                complete(StatusCodes.NotFound)
+            }
+          },
+          delete {
+            onSuccess(store.delete(realmId)) { deleted =>
+              if (deleted) {
+                log.info("User [{}] successfully deleted realm [{}]", user, realmId)
+                complete(StatusCodes.OK)
+              } else {
+                log.warning("User [{}] failed to delete realm [{}]", user, realmId)
+                complete(StatusCodes.NotFound)
+              }
+            }
+          }
+        )
+      }
+    )
+}

--- a/identity/src/main/scala/stasis/identity/api/manage/Tokens.scala
+++ b/identity/src/main/scala/stasis/identity/api/manage/Tokens.scala
@@ -1,0 +1,58 @@
+package stasis.identity.api.manage
+
+import akka.actor.ActorSystem
+import akka.event.{Logging, LoggingAdapter}
+import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.server.Directives._
+import akka.http.scaladsl.server._
+import stasis.identity.model.owners.ResourceOwner
+import stasis.identity.model.tokens.RefreshTokenStore
+
+class Tokens(store: RefreshTokenStore)(implicit system: ActorSystem) {
+  import de.heikoseeberger.akkahttpplayjson.PlayJsonSupport._
+  import stasis.identity.api.Formats._
+
+  private val log: LoggingAdapter = Logging(system, this.getClass.getName)
+
+  def routes(user: ResourceOwner.Id): Route =
+    concat(
+      pathEndOrSingleSlash {
+        get {
+          onSuccess(store.tokens) { tokens =>
+            log.info("User [{}] successfully retrieved [{}] refresh tokens", user, tokens.size)
+            complete(tokens.values)
+          }
+        }
+      },
+      path(JavaUUID) { clientId =>
+        concat(
+          get {
+            onSuccess(store.get(clientId)) {
+              case Some(token) =>
+                log.info("User [{}] successfully retrieved refresh token for client [{}]", user, clientId)
+                complete(token)
+
+              case None =>
+                log.warning(
+                  "User [{}] requested a refresh token for client [{}] but none was found",
+                  user,
+                  clientId
+                )
+                complete(StatusCodes.NotFound)
+            }
+          },
+          delete {
+            onSuccess(store.delete(clientId)) { deleted =>
+              if (deleted) {
+                log.info("User [{}] successfully deleted refresh token for client [{}]", user, clientId)
+                complete(StatusCodes.OK)
+              } else {
+                log.warning("User [{}] failed to delete refresh token for client [{}]", user, clientId)
+                complete(StatusCodes.NotFound)
+              }
+            }
+          }
+        )
+      }
+    )
+}

--- a/identity/src/main/scala/stasis/identity/api/manage/directives/RealmExtraction.scala
+++ b/identity/src/main/scala/stasis/identity/api/manage/directives/RealmExtraction.scala
@@ -1,0 +1,29 @@
+package stasis.identity.api.manage.directives
+
+import akka.event.LoggingAdapter
+import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.server.Directives._
+import akka.http.scaladsl.server.{Directive, Directive1}
+import stasis.identity.api.directives.BaseApiDirective
+import stasis.identity.model.realms.{Realm, RealmStoreView}
+
+trait RealmExtraction extends BaseApiDirective {
+
+  protected def log: LoggingAdapter
+
+  protected def realmStore: RealmStoreView
+
+  def extractRealm(realmId: Realm.Id): Directive1[Realm] =
+    Directive { inner =>
+      onSuccess(realmStore.get(realmId)) {
+        case Some(realm) =>
+          inner(Tuple1(realm))
+
+        case None =>
+          log.warning("Requested realm [{}] was not found", realmId)
+          discardEntity {
+            complete(StatusCodes.NotFound)
+          }
+      }
+    }
+}

--- a/identity/src/main/scala/stasis/identity/api/manage/directives/RealmValidation.scala
+++ b/identity/src/main/scala/stasis/identity/api/manage/directives/RealmValidation.scala
@@ -1,0 +1,55 @@
+package stasis.identity.api.manage.directives
+
+import akka.event.LoggingAdapter
+import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.server.Directives.{complete, onSuccess}
+import akka.http.scaladsl.server.{Directive, Directive1}
+import stasis.identity.api.directives.BaseApiDirective
+import stasis.identity.model.realms.Realm
+
+import scala.concurrent.Future
+
+trait RealmValidation[T] extends BaseApiDirective {
+
+  protected def log: LoggingAdapter
+
+  protected implicit def extractor: RealmValidation.Extractor[T]
+
+  def filterRealm[K](realm: Realm.Id, entitiesFuture: Future[Map[K, T]]): Directive1[Map[K, T]] =
+    Directive { inner =>
+      onSuccess(entitiesFuture) { entities =>
+        inner(Tuple1(entities.filter(entity => extractor.extract(entity._2) == realm)))
+      }
+    }
+
+  def validateRealm(realm: Realm.Id, entityFuture: Future[Option[T]]): Directive1[T] =
+    Directive { inner =>
+      onSuccess(entityFuture) {
+        case Some(entity) =>
+          extractor.extract(entity) match {
+            case `realm` =>
+              inner(Tuple1(entity))
+
+            case unexpectedRealm: Realm.Id =>
+              discardEntity {
+                complete(
+                  StatusCodes.BadRequest,
+                  s"Expected realm [$realm] but [$unexpectedRealm] provided"
+                )
+              }
+          }
+
+        case None =>
+          log.warning("Entity for realm [{}] was not found", realm)
+          discardEntity {
+            complete(StatusCodes.NotFound)
+          }
+      }
+    }
+}
+
+object RealmValidation {
+  trait Extractor[T] {
+    def extract(entity: T): Realm.Id
+  }
+}

--- a/identity/src/main/scala/stasis/identity/api/manage/directives/UserAuthentication.scala
+++ b/identity/src/main/scala/stasis/identity/api/manage/directives/UserAuthentication.scala
@@ -1,0 +1,81 @@
+package stasis.identity.api.manage.directives
+
+import akka.event.LoggingAdapter
+import akka.http.scaladsl.model.headers.{HttpChallenges, OAuth2BearerToken}
+import akka.http.scaladsl.model.{headers, StatusCodes}
+import akka.http.scaladsl.server.Directives._
+import akka.http.scaladsl.server.{Directive, Directive1}
+import stasis.identity.api.directives.BaseApiDirective
+import stasis.identity.authentication.manage.ResourceOwnerAuthenticator
+import stasis.identity.model.owners.ResourceOwner
+import stasis.identity.model.realms.Realm
+
+import scala.util.{Failure, Success}
+
+trait UserAuthentication extends BaseApiDirective {
+
+  protected def log: LoggingAdapter
+
+  protected def authenticator: ResourceOwnerAuthenticator
+
+  def authenticate(realm: Realm.Id): Directive1[ResourceOwner] =
+    Directive { inner =>
+      (extractMethod & extractUri & extractClientIP) { (method, uri, remoteAddress) =>
+        extractCredentials {
+          case Some(token: OAuth2BearerToken) =>
+            onComplete(authenticator.authenticate(token)) {
+              case Success(user) =>
+                inner(Tuple1(user))
+
+              case Failure(e) =>
+                log.warning(
+                  "Realm [{}]: Rejecting [{}] request for [{}] with invalid credentials from [{}]: [{}]",
+                  Array(
+                    realm,
+                    method.value,
+                    uri,
+                    remoteAddress,
+                    e
+                  )
+                )
+
+                discardEntity {
+                  complete(StatusCodes.Unauthorized)
+                }
+            }
+
+          case Some(unsupportedCredentials) =>
+            log.warning(
+              "Realm [{}]: Rejecting [{}] request for [{}] with unsupported credentials [{}] from [{}]",
+              Array(
+                realm,
+                method.value,
+                uri,
+                unsupportedCredentials.scheme(),
+                remoteAddress
+              )
+            )
+
+            discardEntity {
+              complete(StatusCodes.Unauthorized)
+            }
+
+          case None =>
+            log.warning(
+              "Realm [{}]: Rejecting [{}] request for [{}] with no credentials from [{}]",
+              realm,
+              method.value,
+              uri,
+              remoteAddress
+            )
+
+            discardEntity {
+              complete(
+                StatusCodes.Unauthorized,
+                List(headers.`WWW-Authenticate`(HttpChallenges.basic(realm)))
+              )
+            }
+        }
+      }
+    }
+}

--- a/identity/src/main/scala/stasis/identity/api/manage/directives/UserAuthorization.scala
+++ b/identity/src/main/scala/stasis/identity/api/manage/directives/UserAuthorization.scala
@@ -1,0 +1,50 @@
+package stasis.identity.api.manage.directives
+
+import akka.event.LoggingAdapter
+import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.server.Directives.complete
+import akka.http.scaladsl.server.{Directive, Directive0}
+import stasis.identity.api.directives.BaseApiDirective
+import stasis.identity.model.owners.ResourceOwner
+import stasis.identity.model.realms.Realm
+
+trait UserAuthorization extends BaseApiDirective {
+
+  protected def log: LoggingAdapter
+
+  def authorize(user: ResourceOwner, targetRealm: Realm.Id, scope: String): Directive0 =
+    Directive { inner =>
+      user.realm match {
+        case Realm.Master =>
+          log.info("Realm [{}]: Allowed access for user [{}]", targetRealm, user.username)
+          inner(())
+
+        case `targetRealm` =>
+          if (user.allowedScopes.contains(scope)) {
+            inner(())
+          } else {
+            log.warning(
+              "Realm [{}]: User [{}] not allowed to access scope [{}]",
+              targetRealm,
+              user.username,
+              scope
+            )
+
+            discardEntity {
+              complete(StatusCodes.Forbidden)
+            }
+          }
+
+        case _ =>
+          log.warning(
+            "Realm [{}]: User [{}] not allowed to access realm",
+            targetRealm,
+            user.username
+          )
+
+          discardEntity {
+            complete(StatusCodes.Forbidden)
+          }
+      }
+    }
+}

--- a/identity/src/main/scala/stasis/identity/api/manage/requests/CreateApi.scala
+++ b/identity/src/main/scala/stasis/identity/api/manage/requests/CreateApi.scala
@@ -1,0 +1,11 @@
+package stasis.identity.api.manage.requests
+
+import stasis.identity.model.apis.Api
+import stasis.identity.model.realms.Realm
+
+final case class CreateApi(id: Api.Id) {
+  require(id.nonEmpty, "id must not be empty")
+
+  def toApi(realm: Realm.Id): Api =
+    Api(id = id, realm = realm)
+}

--- a/identity/src/main/scala/stasis/identity/api/manage/requests/CreateClient.scala
+++ b/identity/src/main/scala/stasis/identity/api/manage/requests/CreateClient.scala
@@ -1,0 +1,33 @@
+package stasis.identity.api.manage.requests
+
+import stasis.identity.model.Seconds
+import stasis.identity.model.clients.Client
+import stasis.identity.model.realms.Realm
+import stasis.identity.model.secrets.Secret
+
+final case class CreateClient(
+  allowedScopes: Seq[String],
+  redirectUri: String,
+  tokenExpiration: Seconds,
+  rawSecret: String
+) {
+  require(allowedScopes.nonEmpty, "allowed scopes must not be empty")
+  require(redirectUri.nonEmpty, "redirect URI must not be empty")
+  require(tokenExpiration.value > 0, "token expiration must be a positive number")
+  require(rawSecret.nonEmpty, "secret must not be empty")
+
+  def toClient(realm: Realm.Id)(implicit config: Secret.ClientConfig): Client = {
+    val salt = Secret.generateSalt()
+
+    Client(
+      id = Client.generateId(),
+      realm = realm,
+      allowedScopes = allowedScopes,
+      redirectUri = redirectUri,
+      tokenExpiration = tokenExpiration,
+      secret = Secret.derive(rawSecret = rawSecret, salt = salt),
+      salt = salt,
+      active = true
+    )
+  }
+}

--- a/identity/src/main/scala/stasis/identity/api/manage/requests/CreateOwner.scala
+++ b/identity/src/main/scala/stasis/identity/api/manage/requests/CreateOwner.scala
@@ -1,0 +1,28 @@
+package stasis.identity.api.manage.requests
+
+import stasis.identity.model.owners.ResourceOwner
+import stasis.identity.model.realms.Realm
+import stasis.identity.model.secrets.Secret
+
+final case class CreateOwner(
+  username: ResourceOwner.Id,
+  rawPassword: String,
+  allowedScopes: Seq[String]
+) {
+  require(username.nonEmpty, "username must not be empty")
+  require(allowedScopes.nonEmpty, "allowed scopes must not be empty")
+  require(rawPassword.nonEmpty, "password must not be empty")
+
+  def toResourceOwner(realm: Realm.Id)(implicit config: Secret.ResourceOwnerConfig): ResourceOwner = {
+    val salt = Secret.generateSalt()
+
+    ResourceOwner(
+      username = username,
+      password = Secret.derive(rawSecret = rawPassword, salt = salt),
+      salt = salt,
+      realm = realm,
+      allowedScopes = allowedScopes,
+      active = true
+    )
+  }
+}

--- a/identity/src/main/scala/stasis/identity/api/manage/requests/CreateRealm.scala
+++ b/identity/src/main/scala/stasis/identity/api/manage/requests/CreateRealm.scala
@@ -1,0 +1,12 @@
+package stasis.identity.api.manage.requests
+
+import stasis.identity.model.realms.Realm
+
+final case class CreateRealm(
+  id: Realm.Id,
+  refreshTokensAllowed: Boolean
+) {
+  require(id.nonEmpty, "identifier must be empty")
+
+  def toRealm: Realm = Realm(id = id, refreshTokensAllowed = refreshTokensAllowed)
+}

--- a/identity/src/main/scala/stasis/identity/api/manage/requests/UpdateClient.scala
+++ b/identity/src/main/scala/stasis/identity/api/manage/requests/UpdateClient.scala
@@ -1,0 +1,12 @@
+package stasis.identity.api.manage.requests
+
+import stasis.identity.model.Seconds
+
+final case class UpdateClient(
+  allowedScopes: Seq[String],
+  tokenExpiration: Seconds,
+  active: Boolean
+) {
+  require(allowedScopes.nonEmpty, "allowed scopes must not be empty")
+  require(tokenExpiration.value > 0, "token expiration must be a positive number")
+}

--- a/identity/src/main/scala/stasis/identity/api/manage/requests/UpdateClientCredentials.scala
+++ b/identity/src/main/scala/stasis/identity/api/manage/requests/UpdateClientCredentials.scala
@@ -1,0 +1,16 @@
+package stasis.identity.api.manage.requests
+
+import stasis.identity.model.secrets.Secret
+
+final case class UpdateClientCredentials(
+  rawSecret: String
+) {
+  require(rawSecret.nonEmpty, "secret must not be empty")
+
+  def toSecret()(implicit config: Secret.ClientConfig): (Secret, String) = {
+    val salt = Secret.generateSalt()
+    val secret = Secret.derive(rawSecret = rawSecret, salt = salt)
+
+    (secret, salt)
+  }
+}

--- a/identity/src/main/scala/stasis/identity/api/manage/requests/UpdateOwner.scala
+++ b/identity/src/main/scala/stasis/identity/api/manage/requests/UpdateOwner.scala
@@ -1,0 +1,8 @@
+package stasis.identity.api.manage.requests
+
+final case class UpdateOwner(
+  allowedScopes: Seq[String],
+  active: Boolean
+) {
+  require(allowedScopes.nonEmpty, "allowed scopes must not be empty")
+}

--- a/identity/src/main/scala/stasis/identity/api/manage/requests/UpdateOwnerCredentials.scala
+++ b/identity/src/main/scala/stasis/identity/api/manage/requests/UpdateOwnerCredentials.scala
@@ -1,0 +1,16 @@
+package stasis.identity.api.manage.requests
+
+import stasis.identity.model.secrets.Secret
+
+final case class UpdateOwnerCredentials(
+  rawPassword: String
+) {
+  require(rawPassword.nonEmpty, "password must not be empty")
+
+  def toSecret()(implicit config: Secret.ResourceOwnerConfig): (Secret, String) = {
+    val salt = Secret.generateSalt()
+    val secret = Secret.derive(rawSecret = rawPassword, salt = salt)
+
+    (secret, salt)
+  }
+}

--- a/identity/src/main/scala/stasis/identity/api/manage/responses/CreatedClient.scala
+++ b/identity/src/main/scala/stasis/identity/api/manage/responses/CreatedClient.scala
@@ -1,0 +1,5 @@
+package stasis.identity.api.manage.responses
+
+import stasis.identity.model.clients.Client
+
+final case class CreatedClient(client: Client.Id)

--- a/identity/src/main/scala/stasis/identity/api/manage/setup/Config.scala
+++ b/identity/src/main/scala/stasis/identity/api/manage/setup/Config.scala
@@ -1,0 +1,8 @@
+package stasis.identity.api.manage.setup
+
+import stasis.identity.model.secrets.Secret
+
+final case class Config(
+  clientSecrets: Secret.ClientConfig,
+  ownerSecrets: Secret.ResourceOwnerConfig
+)

--- a/identity/src/main/scala/stasis/identity/api/manage/setup/Providers.scala
+++ b/identity/src/main/scala/stasis/identity/api/manage/setup/Providers.scala
@@ -1,0 +1,19 @@
+package stasis.identity.api.manage.setup
+
+import stasis.identity.authentication.manage.ResourceOwnerAuthenticator
+import stasis.identity.model.apis.ApiStore
+import stasis.identity.model.clients.ClientStore
+import stasis.identity.model.codes.AuthorizationCodeStore
+import stasis.identity.model.owners.ResourceOwnerStore
+import stasis.identity.model.realms.RealmStore
+import stasis.identity.model.tokens.RefreshTokenStore
+
+final case class Providers(
+  apiStore: ApiStore,
+  clientStore: ClientStore,
+  codeStore: AuthorizationCodeStore,
+  ownerStore: ResourceOwnerStore,
+  realmStore: RealmStore,
+  tokenStore: RefreshTokenStore,
+  ownerAuthenticator: ResourceOwnerAuthenticator
+)

--- a/identity/src/main/scala/stasis/identity/api/oauth/AuthorizationCodeGrant.scala
+++ b/identity/src/main/scala/stasis/identity/api/oauth/AuthorizationCodeGrant.scala
@@ -1,0 +1,194 @@
+package stasis.identity.api.oauth
+
+import akka.actor.ActorSystem
+import akka.event.{Logging, LoggingAdapter}
+import akka.http.scaladsl.model._
+import akka.http.scaladsl.server.Directives._
+import akka.http.scaladsl.server.Route
+import akka.stream.Materializer
+import play.api.libs.json.{Format, Json}
+import stasis.identity.api.Formats._
+import stasis.identity.api.oauth.directives.AuthDirectives
+import stasis.identity.api.oauth.setup.Providers
+import stasis.identity.model.clients.Client
+import stasis.identity.model.codes.AuthorizationCode
+import stasis.identity.model.errors.TokenError
+import stasis.identity.model.realms.Realm
+import stasis.identity.model.tokens._
+import stasis.identity.model.{GrantType, ResponseType, Seconds}
+
+import scala.concurrent.ExecutionContext
+
+class AuthorizationCodeGrant(
+  override val providers: Providers
+)(implicit system: ActorSystem, override val mat: Materializer)
+    extends AuthDirectives {
+  import AuthorizationCodeGrant._
+  import de.heikoseeberger.akkahttpplayjson.PlayJsonSupport._
+
+  override implicit protected def ec: ExecutionContext = system.dispatcher
+  override protected def log: LoggingAdapter = Logging(system, this.getClass.getName)
+
+  def authorization(realm: Realm): Route =
+    get {
+      parameters(
+        "response_type".as[ResponseType],
+        "client_id".as[Client.Id],
+        "redirect_uri".as[String].?,
+        "scope".as[String].?,
+        "state".as[String]
+      ).as(AuthorizationRequest) { request =>
+        retrieveClient(request.client_id) {
+          case client if request.redirect_uri.forall(_ == client.redirectUri) =>
+            val redirectUri = Uri(request.redirect_uri.getOrElse(client.redirectUri))
+
+            (authenticateResourceOwner(redirectUri, request.state) & extractApiAudience(request.scope)) {
+              (owner, audience) =>
+                val scope = apiAudienceToScope(audience)
+
+                generateAuthorizationCode(client.id, redirectUri, request.state, owner, scope) { code =>
+                  log.debug(
+                    "Realm [{}]: Successfully generated authorization code for client [{}]",
+                    realm.id,
+                    client.id
+                  )
+
+                  redirect(
+                    redirectUri.withQuery(AuthorizationResponse(code, request.state, scope).asQuery),
+                    StatusCodes.Found
+                  )
+                }
+            }
+
+          case client =>
+            log.warning(
+              "Realm [{}]: Redirect URI [{}] for client [{}] did not match URI provided in request: [{}]",
+              realm.id,
+              client.redirectUri,
+              client.id,
+              request.redirect_uri
+            )
+
+            complete(
+              StatusCodes.BadRequest,
+              "The request has missing, invalid or mismatching redirection URI and/or client identifier"
+            )
+        }
+      }
+    }
+
+  def token(realm: Realm): Route =
+    post {
+      parameters(
+        "grant_type".as[GrantType],
+        "code".as[AuthorizationCode],
+        "redirect_uri".as[String].?,
+        "client_id".as[Client.Id]
+      ).as(AccessTokenRequest) { request =>
+        authenticateClient(realm) {
+          case client if client.id == request.client_id && request.redirect_uri.forall(_ == client.redirectUri) =>
+            consumeAuthorizationCode(client.id, request.code) { (owner, scope) =>
+              extractApiAudience(scope) { audience =>
+                val scope = apiAudienceToScope(audience)
+
+                (generateAccessToken(owner, audience) & generateRefreshToken(realm, client.id, owner, scope)) {
+                  (accessToken, refreshToken) =>
+                    log.debug(
+                      "Realm [{}]: Successfully generated {} for client [{}]",
+                      realm.id,
+                      refreshToken match {
+                        case Some(_) => "access and refresh tokens"
+                        case None    => "access token"
+                      },
+                      client.id
+                    )
+
+                    complete(
+                      StatusCodes.OK,
+                      List[HttpHeader](
+                        headers.`Content-Type`(ContentTypes.`application/json`),
+                        headers.`Cache-Control`(headers.CacheDirectives.`no-store`)
+                      ),
+                      AccessTokenResponse(
+                        access_token = accessToken,
+                        token_type = TokenType.Bearer,
+                        expires_in = client.tokenExpiration,
+                        refresh_token = refreshToken
+                      )
+                    )
+                }
+              }
+            }
+
+          case client =>
+            log.warning(
+              "Realm [{}]: Encountered mismatched client identifiers (expected [{}], found [{}]) " +
+                "and/or redirect URIs (expected [{}], found [{}])",
+              Array(
+                realm.id,
+                client.id,
+                request.client_id,
+                client.redirectUri,
+                request.redirect_uri
+              )
+            )
+
+            complete(
+              StatusCodes.BadRequest,
+              TokenError.InvalidRequest
+            )
+        }
+      }
+    }
+}
+
+object AuthorizationCodeGrant {
+  implicit val accessTokenResponseFormat: Format[AccessTokenResponse] = Json.format[AccessTokenResponse]
+
+  final case class AuthorizationRequest(
+    response_type: ResponseType,
+    client_id: Client.Id,
+    redirect_uri: Option[String],
+    scope: Option[String],
+    state: String
+  ) {
+    require(response_type == ResponseType.Code, "response type must be 'code'")
+    require(redirect_uri.forall(_.nonEmpty), "redirect URI must not be empty")
+    require(scope.forall(_.nonEmpty), "scope must not be empty")
+    require(state.nonEmpty, "state must not be empty")
+  }
+
+  final case class AccessTokenRequest(
+    grant_type: GrantType,
+    code: AuthorizationCode,
+    redirect_uri: Option[String],
+    client_id: Client.Id
+  ) {
+    require(grant_type == GrantType.AuthorizationCode, "grant type must be 'authorization_code'")
+    require(code.value.nonEmpty, "code must not be empty")
+    require(redirect_uri.forall(_.nonEmpty), "redirect URI must not be empty")
+  }
+
+  final case class AuthorizationResponse(
+    code: AuthorizationCode,
+    state: String,
+    scope: Option[String]
+  ) {
+    def asQuery: Uri.Query =
+      Uri.Query(
+        scope.foldLeft(
+          Map(
+            "code" -> code.value,
+            "state" -> state
+          )
+        ) { case (baseParams, actualScope) => baseParams + ("scope" -> actualScope) }
+      )
+  }
+
+  final case class AccessTokenResponse(
+    access_token: AccessToken,
+    token_type: TokenType,
+    expires_in: Seconds,
+    refresh_token: Option[RefreshToken]
+  )
+}

--- a/identity/src/main/scala/stasis/identity/api/oauth/ClientCredentialsGrant.scala
+++ b/identity/src/main/scala/stasis/identity/api/oauth/ClientCredentialsGrant.scala
@@ -1,0 +1,82 @@
+package stasis.identity.api.oauth
+
+import akka.actor.ActorSystem
+import akka.event.{Logging, LoggingAdapter}
+import akka.http.scaladsl.model._
+import akka.http.scaladsl.model.headers.CacheDirectives
+import akka.http.scaladsl.server.Directives._
+import akka.http.scaladsl.server.Route
+import akka.stream.Materializer
+import play.api.libs.json.{Format, Json}
+import stasis.identity.api.Formats._
+import stasis.identity.api.oauth.directives.AuthDirectives
+import stasis.identity.api.oauth.setup.Providers
+import stasis.identity.model.realms.Realm
+import stasis.identity.model.tokens.{AccessToken, TokenType}
+import stasis.identity.model.{GrantType, Seconds}
+
+import scala.concurrent.ExecutionContext
+
+class ClientCredentialsGrant(
+  override val providers: Providers
+)(implicit system: ActorSystem, override val mat: Materializer)
+    extends AuthDirectives {
+  import ClientCredentialsGrant._
+  import de.heikoseeberger.akkahttpplayjson.PlayJsonSupport._
+
+  override implicit protected def ec: ExecutionContext = system.dispatcher
+  override protected def log: LoggingAdapter = Logging(system, this.getClass.getName)
+
+  def token(realm: Realm): Route =
+    post {
+      parameters(
+        "grant_type".as[GrantType],
+        "scope".as[String].?
+      ).as(AccessTokenRequest) { request =>
+        (authenticateClient(realm) & extractClientAudience(request.scope)) { (client, audience) =>
+          generateAccessToken(client, audience) { accessToken =>
+            val scope = clientAudienceToScope(audience)
+
+            log.debug(
+              "Realm [{}]: Successfully generated access token for client [{}]",
+              realm.id,
+              client.id
+            )
+
+            complete(
+              StatusCodes.OK,
+              List[HttpHeader](
+                headers.`Content-Type`(ContentTypes.`application/json`),
+                headers.`Cache-Control`(CacheDirectives.`no-store`)
+              ),
+              AccessTokenResponse(
+                access_token = accessToken,
+                token_type = TokenType.Bearer,
+                expires_in = client.tokenExpiration,
+                scope = scope
+              )
+            )
+          }
+        }
+      }
+    }
+}
+
+object ClientCredentialsGrant {
+  implicit val accessTokenResponseFormat: Format[AccessTokenResponse] = Json.format[AccessTokenResponse]
+
+  final case class AccessTokenRequest(
+    grant_type: GrantType,
+    scope: Option[String]
+  ) {
+    require(grant_type == GrantType.ClientCredentials, "grant type must be 'client_credentials'")
+    require(scope.forall(_.nonEmpty), "scope must not be empty")
+  }
+
+  final case class AccessTokenResponse(
+    access_token: AccessToken,
+    token_type: TokenType,
+    expires_in: Seconds,
+    scope: Option[String]
+  )
+}

--- a/identity/src/main/scala/stasis/identity/api/oauth/ImplicitGrant.scala
+++ b/identity/src/main/scala/stasis/identity/api/oauth/ImplicitGrant.scala
@@ -1,0 +1,117 @@
+package stasis.identity.api.oauth
+
+import akka.actor.ActorSystem
+import akka.event.{Logging, LoggingAdapter}
+import akka.http.scaladsl.model.{StatusCodes, Uri}
+import akka.http.scaladsl.server.Directives._
+import akka.http.scaladsl.server.Route
+import akka.stream.Materializer
+import stasis.identity.api.Formats._
+import stasis.identity.api.oauth.directives.AuthDirectives
+import stasis.identity.api.oauth.setup.Providers
+import stasis.identity.model.clients.Client
+import stasis.identity.model.realms.Realm
+import stasis.identity.model.tokens.{AccessToken, TokenType}
+import stasis.identity.model.{ResponseType, Seconds}
+
+import scala.concurrent.ExecutionContext
+
+class ImplicitGrant(
+  override val providers: Providers
+)(implicit system: ActorSystem, override val mat: Materializer)
+    extends AuthDirectives {
+  import ImplicitGrant._
+
+  override implicit protected def ec: ExecutionContext = system.dispatcher
+  override protected def log: LoggingAdapter = Logging(system, this.getClass.getName)
+
+  def authorization(realm: Realm): Route =
+    get {
+      parameters(
+        "response_type".as[ResponseType],
+        "client_id".as[Client.Id],
+        "redirect_uri".as[String].?,
+        "scope".as[String].?,
+        "state".as[String]
+      ).as(AuthorizationRequest) { request =>
+        retrieveClient(request.client_id) {
+          case client if request.redirect_uri.forall(_ == client.redirectUri) =>
+            val redirectUri = Uri(request.redirect_uri.getOrElse(client.redirectUri))
+
+            (authenticateResourceOwner(redirectUri, request.state) & extractApiAudience(request.scope)) {
+              (owner, audience) =>
+                generateAccessToken(owner, audience) { accessToken =>
+                  val scope = apiAudienceToScope(audience)
+
+                  val response = AccessTokenResponse(
+                    access_token = accessToken,
+                    token_type = TokenType.Bearer,
+                    expires_in = client.tokenExpiration,
+                    state = request.state,
+                    scope = scope
+                  )
+
+                  log.debug(
+                    "Realm [{}]: Successfully generated access token for client [{}]",
+                    realm.id,
+                    client.id
+                  )
+
+                  redirect(
+                    redirectUri.withQuery(response.asQuery),
+                    StatusCodes.Found
+                  )
+                }
+            }
+
+          case client =>
+            log.warning(
+              "Realm [{}]: Encountered mismatched redirect URIs (expected [{}], found [{}])",
+              realm.id,
+              client.redirectUri,
+              request.redirect_uri
+            )
+
+            complete(
+              StatusCodes.BadRequest,
+              "The request has missing, invalid or mismatching redirection URI and/or client identifier"
+            )
+        }
+      }
+    }
+}
+
+object ImplicitGrant {
+  final case class AuthorizationRequest(
+    response_type: ResponseType,
+    client_id: Client.Id,
+    redirect_uri: Option[String],
+    scope: Option[String],
+    state: String
+  ) {
+    require(response_type == ResponseType.Token, "response type must be 'token'")
+    require(redirect_uri.forall(_.nonEmpty), "redirect URI must not be empty")
+    require(scope.forall(_.nonEmpty), "scope must not be empty")
+    require(state.nonEmpty, "state must not be empty")
+  }
+
+  final case class AccessTokenResponse(
+    access_token: AccessToken,
+    token_type: TokenType,
+    expires_in: Seconds,
+    state: String,
+    scope: Option[String]
+  ) {
+    def asQuery: Uri.Query =
+      Uri.Query(
+        scope.foldLeft(
+          Map(
+            "access_token" -> access_token.value,
+            "token_type" -> token_type.toString.toLowerCase,
+            "expires_in" -> expires_in.value.toString,
+            "state" -> state
+          )
+        ) { case (baseParams, actualScope) => baseParams + ("scope" -> actualScope) }
+      )
+  }
+}

--- a/identity/src/main/scala/stasis/identity/api/oauth/RefreshTokenGrant.scala
+++ b/identity/src/main/scala/stasis/identity/api/oauth/RefreshTokenGrant.scala
@@ -1,0 +1,95 @@
+package stasis.identity.api.oauth
+
+import akka.actor.ActorSystem
+import akka.event.{Logging, LoggingAdapter}
+import akka.http.scaladsl.model._
+import akka.http.scaladsl.server.Directives._
+import akka.http.scaladsl.server.Route
+import akka.stream.Materializer
+import play.api.libs.json.{Format, Json}
+import stasis.identity.api.Formats._
+import stasis.identity.api.oauth.directives.AuthDirectives
+import stasis.identity.api.oauth.setup.Providers
+import stasis.identity.model.realms.Realm
+import stasis.identity.model.tokens._
+import stasis.identity.model.{GrantType, Seconds}
+
+import scala.concurrent.ExecutionContext
+
+class RefreshTokenGrant(
+  override val providers: Providers
+)(implicit system: ActorSystem, override val mat: Materializer)
+    extends AuthDirectives {
+  import RefreshTokenGrant._
+  import de.heikoseeberger.akkahttpplayjson.PlayJsonSupport._
+
+  override implicit protected def ec: ExecutionContext = system.dispatcher
+  override protected def log: LoggingAdapter = Logging(system, this.getClass.getName)
+
+  def token(realm: Realm): Route =
+    post {
+      parameters(
+        "grant_type".as[GrantType],
+        "refresh_token".as[RefreshToken],
+        "scope".as[String].?
+      ).as(AccessTokenRequest) { request =>
+        authenticateClient(realm) { client =>
+          consumeRefreshToken(client.id, request.scope, request.refresh_token) { owner =>
+            extractApiAudience(request.scope) { audience =>
+              val scope = apiAudienceToScope(audience)
+
+              (generateAccessToken(owner, audience) & generateRefreshToken(realm, client.id, owner, scope)) {
+                (accessToken, refreshToken) =>
+                  log.debug(
+                    "Realm [{}]: Successfully generated {} for client [{}]",
+                    realm.id,
+                    refreshToken match {
+                      case Some(_) => "access and refresh tokens"
+                      case None    => "access token"
+                    },
+                    client.id
+                  )
+
+                  complete(
+                    StatusCodes.OK,
+                    List[HttpHeader](
+                      headers.`Content-Type`(ContentTypes.`application/json`),
+                      headers.`Cache-Control`(headers.CacheDirectives.`no-store`)
+                    ),
+                    AccessTokenResponse(
+                      access_token = accessToken,
+                      token_type = TokenType.Bearer,
+                      expires_in = client.tokenExpiration,
+                      refresh_token = refreshToken,
+                      scope = scope
+                    )
+                  )
+              }
+            }
+          }
+        }
+      }
+    }
+}
+
+object RefreshTokenGrant {
+  implicit val accessTokenResponseFormat: Format[AccessTokenResponse] = Json.format[AccessTokenResponse]
+
+  final case class AccessTokenRequest(
+    grant_type: GrantType,
+    refresh_token: RefreshToken,
+    scope: Option[String]
+  ) {
+    require(grant_type == GrantType.RefreshToken, "grant type must be 'refresh_token'")
+    require(refresh_token.value.nonEmpty, "refresh token must not be empty")
+    require(scope.forall(_.nonEmpty), "scope must not be empty")
+  }
+
+  final case class AccessTokenResponse(
+    access_token: AccessToken,
+    token_type: TokenType,
+    expires_in: Seconds,
+    refresh_token: Option[RefreshToken],
+    scope: Option[String]
+  )
+}

--- a/identity/src/main/scala/stasis/identity/api/oauth/ResourceOwnerPasswordCredentialsGrant.scala
+++ b/identity/src/main/scala/stasis/identity/api/oauth/ResourceOwnerPasswordCredentialsGrant.scala
@@ -1,0 +1,98 @@
+package stasis.identity.api.oauth
+
+import akka.actor.ActorSystem
+import akka.event.{Logging, LoggingAdapter}
+import akka.http.scaladsl.model._
+import akka.http.scaladsl.server.Directives._
+import akka.http.scaladsl.server.Route
+import akka.stream.Materializer
+import play.api.libs.json.{Format, Json}
+import stasis.identity.api.Formats._
+import stasis.identity.api.oauth.directives.AuthDirectives
+import stasis.identity.api.oauth.setup.Providers
+import stasis.identity.model.realms.Realm
+import stasis.identity.model.tokens._
+import stasis.identity.model.{GrantType, Seconds}
+
+import scala.concurrent.ExecutionContext
+
+class ResourceOwnerPasswordCredentialsGrant(
+  override val providers: Providers
+)(implicit system: ActorSystem, override val mat: Materializer)
+    extends AuthDirectives {
+  import ResourceOwnerPasswordCredentialsGrant._
+  import de.heikoseeberger.akkahttpplayjson.PlayJsonSupport._
+
+  override implicit protected def ec: ExecutionContext = system.dispatcher
+  override protected def log: LoggingAdapter = Logging(system, this.getClass.getName)
+
+  def token(realm: Realm): Route =
+    post {
+      parameters(
+        "grant_type".as[GrantType],
+        "username".as[String],
+        "password".as[String],
+        "scope".as[String].?
+      ).as(AccessTokenRequest) { request =>
+        authenticateClient(realm) { client =>
+          authenticateResourceOwner(request.username, request.password) { owner =>
+            extractApiAudience(request.scope) { audience =>
+              val scope = apiAudienceToScope(audience)
+
+              (generateAccessToken(owner, audience) & generateRefreshToken(realm, client.id, owner, scope)) {
+                (accessToken, refreshToken) =>
+                  log.debug(
+                    "Realm [{}]: Successfully generated {} for client [{}]",
+                    realm.id,
+                    refreshToken match {
+                      case Some(_) => "access and refresh tokens"
+                      case None    => "access token"
+                    },
+                    client.id
+                  )
+
+                  complete(
+                    StatusCodes.OK,
+                    List[HttpHeader](
+                      headers.`Content-Type`(ContentTypes.`application/json`),
+                      headers.`Cache-Control`(headers.CacheDirectives.`no-store`)
+                    ),
+                    AccessTokenResponse(
+                      access_token = accessToken,
+                      token_type = TokenType.Bearer,
+                      expires_in = client.tokenExpiration,
+                      refresh_token = refreshToken,
+                      scope = scope
+                    )
+                  )
+              }
+            }
+          }
+        }
+      }
+    }
+}
+
+object ResourceOwnerPasswordCredentialsGrant {
+  implicit val accessTokenResponseFormat: Format[AccessTokenResponse] = Json.format[AccessTokenResponse]
+
+  final case class AccessTokenRequest(
+    grant_type: GrantType,
+    username: String,
+    password: String,
+    scope: Option[String]
+  ) {
+    require(grant_type == GrantType.Password, "grant type must be 'password'")
+    require(username.nonEmpty, "username must not be empty")
+    require(password.nonEmpty, "password must not be empty")
+    require(scope.forall(_.nonEmpty), "scope must not be empty")
+  }
+
+  final case class AccessTokenResponse(
+    access_token: AccessToken,
+    token_type: TokenType,
+    expires_in: Seconds,
+    refresh_token: Option[RefreshToken],
+    scope: Option[String]
+  )
+}

--- a/identity/src/main/scala/stasis/identity/api/oauth/directives/AccessTokenGeneration.scala
+++ b/identity/src/main/scala/stasis/identity/api/oauth/directives/AccessTokenGeneration.scala
@@ -1,0 +1,24 @@
+package stasis.identity.api.oauth.directives
+
+import akka.http.scaladsl.server.{Directive, Directive1}
+import stasis.identity.api.directives.BaseApiDirective
+import stasis.identity.model.apis.Api
+import stasis.identity.model.clients.Client
+import stasis.identity.model.owners.ResourceOwner
+import stasis.identity.model.tokens.AccessToken
+import stasis.identity.model.tokens.generators.AccessTokenGenerator
+
+trait AccessTokenGeneration extends BaseApiDirective {
+
+  protected def accessTokenGenerator: AccessTokenGenerator
+
+  def generateAccessToken(client: Client, audience: Seq[Client]): Directive1[AccessToken] =
+    Directive { inner =>
+      inner(Tuple1(accessTokenGenerator.generate(client, audience)))
+    }
+
+  def generateAccessToken(owner: ResourceOwner, audience: Seq[Api]): Directive1[AccessToken] =
+    Directive { inner =>
+      inner(Tuple1(accessTokenGenerator.generate(owner, audience)))
+    }
+}

--- a/identity/src/main/scala/stasis/identity/api/oauth/directives/AudienceExtraction.scala
+++ b/identity/src/main/scala/stasis/identity/api/oauth/directives/AudienceExtraction.scala
@@ -1,0 +1,160 @@
+package stasis.identity.api.oauth.directives
+
+import akka.event.LoggingAdapter
+import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.server.Directives._
+import akka.http.scaladsl.server.{Directive, Directive1}
+import stasis.identity.api.Formats._
+import stasis.identity.api.directives.BaseApiDirective
+import stasis.identity.model.apis.{Api, ApiStoreView}
+import stasis.identity.model.clients.{Client, ClientStoreView}
+import stasis.identity.model.errors.TokenError
+
+import scala.concurrent.{ExecutionContext, Future}
+import scala.util.matching.Regex
+import scala.util.{Failure, Success, Try}
+
+trait AudienceExtraction extends BaseApiDirective {
+  import de.heikoseeberger.akkahttpplayjson.PlayJsonSupport._
+
+  protected implicit def ec: ExecutionContext
+  protected def log: LoggingAdapter
+
+  protected def clientStore: ClientStoreView
+  protected def apiStore: ApiStoreView
+
+  private val audienceUrn: Regex = s"${AudienceExtraction.UrnPrefix}:(.+)".r
+
+  def extractClientAudience(scopeOpt: Option[String]): Directive1[Seq[Client]] =
+    Directive { inner =>
+      extractAudienceFromScope(scopeOpt) { audience =>
+        Try(audience.map(java.util.UUID.fromString)) match {
+          case Success(clientIds) =>
+            getAudienceFromStore(
+              audience = clientIds,
+              audienceType = "client",
+              get = clientStore.get
+            )(result => inner(Tuple1(result)))
+
+          case Failure(_) =>
+            log.warning(
+              "One or more invalid client identifiers found in provided audience: [{}]",
+              audience
+            )
+
+            discardEntity {
+              complete(
+                StatusCodes.BadRequest,
+                TokenError.InvalidScope
+              )
+            }
+        }
+      }
+    }
+
+  def extractApiAudience(scopeOpt: Option[String]): Directive1[Seq[Api]] =
+    Directive { inner =>
+      extractAudienceFromScope(scopeOpt) { apiIds =>
+        getAudienceFromStore(
+          audience = apiIds,
+          audienceType = "API",
+          get = apiStore.get
+        )(result => inner(Tuple1(result)))
+      }
+    }
+
+  def clientAudienceToScope(audience: Seq[Client]): Option[String] =
+    if (audience.nonEmpty) {
+      Some(audience.map(client => s"${AudienceExtraction.UrnPrefix}:${client.id}").mkString(" "))
+    } else {
+      None
+    }
+
+  def apiAudienceToScope(audience: Seq[Api]): Option[String] =
+    if (audience.nonEmpty) {
+      Some(audience.map(api => s"${AudienceExtraction.UrnPrefix}:${api.id}").mkString(" "))
+    } else {
+      None
+    }
+
+  private def extractAudienceFromScope(scopeOpt: Option[String]): Directive1[Seq[String]] =
+    Directive { inner =>
+      scopeOpt match {
+        case Some(scope) =>
+          audienceFromScope(scope) match {
+            case audience @ _ :: _ =>
+              inner(Tuple1(audience))
+
+            case Nil =>
+              log.warning(
+                "No matching audience found in scope [{}]",
+                scope
+              )
+
+              discardEntity {
+                complete(
+                  StatusCodes.BadRequest,
+                  TokenError.InvalidScope
+                )
+              }
+          }
+
+        case None =>
+          inner(Tuple1(Seq.empty))
+      }
+    }
+
+  private def audienceFromScope(scope: String): List[String] =
+    scope
+      .split(" ")
+      .flatMap {
+        case audienceUrn(audience) => Some(audience)
+        case _                     => None
+      }
+      .toList
+
+  private def getAudienceFromStore[I, A](
+    audience: Seq[I],
+    audienceType: String,
+    get: I => Future[Option[A]]
+  ): Directive1[Seq[A]] =
+    Directive { inner =>
+      onComplete(Future.sequence(audience.map(get(_))).map(_.flatten)) {
+        case Success(result) if result.nonEmpty =>
+          inner(Tuple1(result))
+
+        case Success(_) =>
+          log.warning(
+            "No {} audience found with provided identifiers [{}]",
+            audienceType,
+            audience,
+          )
+
+          discardEntity {
+            complete(
+              StatusCodes.BadRequest,
+              TokenError.InvalidScope
+            )
+          }
+
+        case Failure(e) =>
+          log.error(
+            e,
+            "Failed to retrieve {} audience with provided identifiers [{}]: [{}]",
+            audienceType,
+            audience,
+            e.getMessage
+          )
+
+          discardEntity {
+            complete(
+              StatusCodes.InternalServerError
+            )
+          }
+      }
+    }
+}
+
+object AudienceExtraction {
+  final val UrnPrefix: String = "urn:stasis:identity:audience"
+}

--- a/identity/src/main/scala/stasis/identity/api/oauth/directives/AuthDirectives.scala
+++ b/identity/src/main/scala/stasis/identity/api/oauth/directives/AuthDirectives.scala
@@ -1,0 +1,36 @@
+package stasis.identity.api.oauth.directives
+
+import stasis.identity.api.oauth.setup.Providers
+import stasis.identity.authentication.oauth.{ClientAuthenticator, ResourceOwnerAuthenticator}
+import stasis.identity.model.apis.ApiStoreView
+import stasis.identity.model.clients.ClientStoreView
+import stasis.identity.model.codes.AuthorizationCodeStore
+import stasis.identity.model.codes.generators.AuthorizationCodeGenerator
+import stasis.identity.model.tokens.RefreshTokenStore
+import stasis.identity.model.tokens.generators.{AccessTokenGenerator, RefreshTokenGenerator}
+
+trait AuthDirectives
+    extends AccessTokenGeneration
+    with AudienceExtraction
+    with AuthorizationCodeConsumption
+    with AuthorizationCodeGeneration
+    with ClientAuthentication
+    with ClientRetrieval
+    with RefreshTokenConsumption
+    with RefreshTokenGeneration
+    with ResourceOwnerAuthentication {
+
+  protected def providers: Providers
+
+  override protected def apiStore: ApiStoreView = providers.apiStore
+  override protected def clientStore: ClientStoreView = providers.clientStore
+  override protected def refreshTokenStore: RefreshTokenStore = providers.refreshTokenStore
+  override protected def authorizationCodeStore: AuthorizationCodeStore = providers.authorizationCodeStore
+
+  override protected def accessTokenGenerator: AccessTokenGenerator = providers.accessTokenGenerator
+  override protected def authorizationCodeGenerator: AuthorizationCodeGenerator = providers.authorizationCodeGenerator
+
+  override protected def clientAuthenticator: ClientAuthenticator = providers.clientAuthenticator
+  override protected def refreshTokenGenerator: RefreshTokenGenerator = providers.refreshTokenGenerator
+  override protected def resourceOwnerAuthenticator: ResourceOwnerAuthenticator = providers.resourceOwnerAuthenticator
+}

--- a/identity/src/main/scala/stasis/identity/api/oauth/directives/AuthorizationCodeConsumption.scala
+++ b/identity/src/main/scala/stasis/identity/api/oauth/directives/AuthorizationCodeConsumption.scala
@@ -1,0 +1,84 @@
+package stasis.identity.api.oauth.directives
+
+import akka.event.LoggingAdapter
+import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.server.Directive
+import akka.http.scaladsl.server.Directives._
+import stasis.identity.api.Formats._
+import stasis.identity.api.directives.BaseApiDirective
+import stasis.identity.model.clients.Client
+import stasis.identity.model.codes.{AuthorizationCode, AuthorizationCodeStore, StoredAuthorizationCode}
+import stasis.identity.model.errors.TokenError
+import stasis.identity.model.owners.ResourceOwner
+
+import scala.concurrent.ExecutionContext
+import scala.util.{Failure, Success}
+
+trait AuthorizationCodeConsumption extends BaseApiDirective {
+  import de.heikoseeberger.akkahttpplayjson.PlayJsonSupport._
+
+  protected implicit def ec: ExecutionContext
+  protected def log: LoggingAdapter
+
+  protected def authorizationCodeStore: AuthorizationCodeStore
+
+  def consumeAuthorizationCode(
+    client: Client.Id,
+    providedCode: AuthorizationCode
+  ): Directive[(ResourceOwner, Option[String])] =
+    Directive { inner =>
+      onComplete(
+        for {
+          storedCode <- authorizationCodeStore.get(client)
+          _ <- authorizationCodeStore.delete(client)
+        } yield {
+          storedCode
+        }
+      ) {
+        case Success(Some(StoredAuthorizationCode(`providedCode`, owner, scope))) =>
+          inner(Tuple2(owner, scope))
+
+        case Success(Some(StoredAuthorizationCode(storedCode, owner, _))) =>
+          log.warning(
+            "Authorization code [{}] stored for client [{}] and owner [{}] did not match provided code",
+            storedCode,
+            client,
+            owner.username
+          )
+
+          discardEntity {
+            complete(
+              StatusCodes.BadRequest,
+              TokenError.InvalidGrant
+            )
+          }
+
+        case Success(None) =>
+          log.warning(
+            "No authorization code found for client [{}]",
+            client
+          )
+
+          discardEntity {
+            complete(
+              StatusCodes.BadRequest,
+              TokenError.InvalidGrant
+            )
+          }
+
+        case Failure(e) =>
+          log.error(
+            e,
+            "Failed to consume authorization code for client [{}]: [{}]",
+            client,
+            e.getMessage
+          )
+
+          discardEntity {
+            complete(
+              StatusCodes.InternalServerError
+            )
+          }
+      }
+    }
+}

--- a/identity/src/main/scala/stasis/identity/api/oauth/directives/AuthorizationCodeGeneration.scala
+++ b/identity/src/main/scala/stasis/identity/api/oauth/directives/AuthorizationCodeGeneration.scala
@@ -1,0 +1,53 @@
+package stasis.identity.api.oauth.directives
+
+import akka.event.LoggingAdapter
+import akka.http.scaladsl.model.{StatusCodes, Uri}
+import akka.http.scaladsl.server.Directives._
+import akka.http.scaladsl.server.{Directive, Directive1}
+import stasis.identity.api.directives.BaseApiDirective
+import stasis.identity.model.clients.Client
+import stasis.identity.model.codes.generators.AuthorizationCodeGenerator
+import stasis.identity.model.codes.{AuthorizationCode, AuthorizationCodeStore}
+import stasis.identity.model.errors.AuthorizationError
+import stasis.identity.model.owners.ResourceOwner
+
+import scala.util.{Failure, Success}
+
+trait AuthorizationCodeGeneration extends BaseApiDirective {
+
+  protected def log: LoggingAdapter
+
+  protected def authorizationCodeGenerator: AuthorizationCodeGenerator
+  protected def authorizationCodeStore: AuthorizationCodeStore
+
+  def generateAuthorizationCode(
+    client: Client.Id,
+    redirectUri: Uri,
+    state: String,
+    owner: ResourceOwner,
+    scope: Option[String]
+  ): Directive1[AuthorizationCode] =
+    Directive { inner =>
+      val code = authorizationCodeGenerator.generate()
+
+      onComplete(authorizationCodeStore.put(client, code, owner, scope)) {
+        case Success(_) =>
+          inner(Tuple1(code))
+
+        case Failure(e) =>
+          log.error(
+            e,
+            "Failed to store authorization code for client [{}]: [{}]",
+            client,
+            e.getMessage
+          )
+
+          discardEntity {
+            redirect(
+              redirectUri.withQuery(AuthorizationError.ServerError(state).asQuery),
+              StatusCodes.Found
+            )
+          }
+      }
+    }
+}

--- a/identity/src/main/scala/stasis/identity/api/oauth/directives/ClientAuthentication.scala
+++ b/identity/src/main/scala/stasis/identity/api/oauth/directives/ClientAuthentication.scala
@@ -1,0 +1,80 @@
+package stasis.identity.api.oauth.directives
+
+import akka.event.LoggingAdapter
+import akka.http.scaladsl.model.headers.{BasicHttpCredentials, HttpChallenges}
+import akka.http.scaladsl.model.{headers, StatusCodes}
+import akka.http.scaladsl.server.Directives._
+import akka.http.scaladsl.server.{Directive, Directive1}
+import stasis.identity.api.Formats._
+import stasis.identity.api.directives.BaseApiDirective
+import stasis.identity.authentication.oauth.ClientAuthenticator
+import stasis.identity.model.clients.Client
+import stasis.identity.model.errors.TokenError
+import stasis.identity.model.realms.Realm
+
+import scala.util.{Failure, Success}
+
+trait ClientAuthentication extends BaseApiDirective {
+  import de.heikoseeberger.akkahttpplayjson.PlayJsonSupport._
+
+  protected def log: LoggingAdapter
+
+  protected def clientAuthenticator: ClientAuthenticator
+
+  def authenticateClient(realm: Realm): Directive1[Client] =
+    Directive { inner =>
+      extractClientIP { remoteAddress =>
+        extractCredentials {
+          case Some(clientCredentials: BasicHttpCredentials) =>
+            onComplete(clientAuthenticator.authenticate(clientCredentials)) {
+              case Success(client) =>
+                inner(Tuple1(client))
+
+              case Failure(e) =>
+                log.warning(
+                  "Authentication failed for client [{}]: [{}]",
+                  clientCredentials.username,
+                  e.getMessage
+                )
+
+                discardEntity {
+                  complete(
+                    StatusCodes.Unauthorized,
+                    List(headers.`WWW-Authenticate`(HttpChallenges.basic(realm.id))),
+                    TokenError.InvalidClient
+                  )
+                }
+            }
+
+          case Some(unsupportedCredentials) =>
+            log.warning(
+              "Client with address [{}] provided unsupported credentials: [{}]",
+              remoteAddress,
+              unsupportedCredentials.scheme()
+            )
+
+            discardEntity {
+              complete(
+                StatusCodes.Unauthorized,
+                List(headers.`WWW-Authenticate`(HttpChallenges.basic(realm.id))),
+                TokenError.InvalidClient
+              )
+            }
+
+          case None =>
+            log.warning(
+              "Client with address [{}] provided no credentials",
+              remoteAddress
+            )
+
+            discardEntity {
+              complete(
+                StatusCodes.Unauthorized,
+                List(headers.`WWW-Authenticate`(HttpChallenges.basic(realm.id))),
+                TokenError.InvalidClient
+              )
+            }
+        }
+      }
+    }
+}

--- a/identity/src/main/scala/stasis/identity/api/oauth/directives/ClientRetrieval.scala
+++ b/identity/src/main/scala/stasis/identity/api/oauth/directives/ClientRetrieval.scala
@@ -1,0 +1,62 @@
+package stasis.identity.api.oauth.directives
+
+import akka.event.LoggingAdapter
+import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.server.Directives._
+import akka.http.scaladsl.server.{Directive, Directive1}
+import stasis.identity.api.directives.BaseApiDirective
+import stasis.identity.model.clients.{Client, ClientStoreView}
+
+import scala.util.{Failure, Success}
+
+trait ClientRetrieval extends BaseApiDirective {
+
+  protected def log: LoggingAdapter
+
+  protected def clientStore: ClientStoreView
+
+  def retrieveClient(clientId: Client.Id): Directive1[Client] =
+    Directive { inner =>
+      onComplete(clientStore.get(clientId)) {
+        case Success(Some(client)) if client.active =>
+          inner(Tuple1(client))
+
+        case Success(Some(client)) =>
+          log.warning(
+            "Retrieval of client [{}] failed; client is not active",
+            client.id
+          )
+
+          discardEntity {
+            complete(
+              StatusCodes.BadRequest,
+              "The request was made by an inactive client"
+            )
+          }
+
+        case Success(None) =>
+          log.warning("Client [{}] was not found", clientId)
+
+          discardEntity {
+            complete(
+              StatusCodes.BadRequest,
+              "The request has missing, invalid or mismatching redirection URI and/or client identifier"
+            )
+          }
+
+        case Failure(e) =>
+          log.error(
+            e,
+            "Failed to retrieve client [{}]: [{}]",
+            clientId,
+            e.getMessage
+          )
+
+          discardEntity {
+            complete(
+              StatusCodes.InternalServerError
+            )
+          }
+      }
+    }
+}

--- a/identity/src/main/scala/stasis/identity/api/oauth/directives/RefreshTokenConsumption.scala
+++ b/identity/src/main/scala/stasis/identity/api/oauth/directives/RefreshTokenConsumption.scala
@@ -1,0 +1,110 @@
+package stasis.identity.api.oauth.directives
+
+import akka.event.LoggingAdapter
+import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.server.Directives._
+import akka.http.scaladsl.server.{Directive, Directive1}
+import stasis.identity.api.Formats._
+import stasis.identity.api.directives.BaseApiDirective
+import stasis.identity.model.clients.Client
+import stasis.identity.model.errors.TokenError
+import stasis.identity.model.owners.ResourceOwner
+import stasis.identity.model.tokens.{RefreshToken, RefreshTokenStore, StoredRefreshToken}
+
+import scala.concurrent.ExecutionContext
+import scala.util.{Failure, Success}
+
+trait RefreshTokenConsumption extends BaseApiDirective {
+  import de.heikoseeberger.akkahttpplayjson.PlayJsonSupport._
+
+  protected implicit def ec: ExecutionContext
+  protected def log: LoggingAdapter
+
+  protected def refreshTokenStore: RefreshTokenStore
+
+  def consumeRefreshToken(
+    client: Client.Id,
+    providedScope: Option[String],
+    providedToken: RefreshToken
+  ): Directive1[ResourceOwner] =
+    Directive { inner =>
+      onComplete(
+        for {
+          storedToken <- refreshTokenStore.get(client)
+          _ <- refreshTokenStore.delete(client)
+        } yield {
+          storedToken
+        }
+      ) {
+        case Success(Some(StoredRefreshToken(`providedToken`, owner, storedScope))) =>
+          if (providedScopeAllowed(storedScope, providedScope)) {
+            inner(Tuple1(owner))
+          } else {
+            log.warning(
+              "Client [{}] provided less restrictive scope [{}] than originally requested for refresh token: [{}]",
+              client,
+              providedScope,
+              storedScope
+            )
+
+            discardEntity {
+              complete(
+                StatusCodes.BadRequest,
+                TokenError.InvalidScope
+              )
+            }
+          }
+
+        case Success(Some(StoredRefreshToken(storedToken, owner, _))) =>
+          log.warning(
+            "Refresh token [{}] stored for client [{}] and owner [{}] did not match provided token",
+            storedToken,
+            client,
+            owner.username
+          )
+
+          discardEntity {
+            complete(
+              StatusCodes.BadRequest,
+              TokenError.InvalidGrant
+            )
+          }
+
+        case Success(None) =>
+          log.warning(
+            "No refresh token found for client [{}]",
+            client
+          )
+
+          discardEntity {
+            complete(
+              StatusCodes.BadRequest,
+              TokenError.InvalidGrant
+            )
+          }
+
+        case Failure(e) =>
+          log.error(
+            e,
+            "Failed to consume refresh token for client [{}]: [{}]",
+            client,
+            e.getMessage
+          )
+
+          discardEntity {
+            complete(
+              StatusCodes.InternalServerError
+            )
+          }
+      }
+    }
+
+  def providedScopeAllowed(stored: Option[String], provided: Option[String]): Boolean = {
+    val storedScopes = extractScopes(stored)
+    val providedScopes = extractScopes(provided)
+    providedScopes.nonEmpty && storedScopes.containsSlice(providedScopes)
+  }
+
+  private def extractScopes(scope: Option[String]): Array[String] =
+    scope.map(_.split(" ")).getOrElse(Array.empty).distinct.sorted
+}

--- a/identity/src/main/scala/stasis/identity/api/oauth/directives/RefreshTokenGeneration.scala
+++ b/identity/src/main/scala/stasis/identity/api/oauth/directives/RefreshTokenGeneration.scala
@@ -1,0 +1,55 @@
+package stasis.identity.api.oauth.directives
+
+import akka.event.LoggingAdapter
+import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.server.Directives._
+import akka.http.scaladsl.server.{Directive, Directive1}
+import stasis.identity.api.directives.BaseApiDirective
+import stasis.identity.model.clients.Client
+import stasis.identity.model.owners.ResourceOwner
+import stasis.identity.model.realms.Realm
+import stasis.identity.model.tokens.generators.RefreshTokenGenerator
+import stasis.identity.model.tokens.{RefreshToken, RefreshTokenStore}
+
+import scala.util.{Failure, Success}
+
+trait RefreshTokenGeneration extends BaseApiDirective {
+
+  protected def log: LoggingAdapter
+
+  protected def refreshTokenGenerator: RefreshTokenGenerator
+  protected def refreshTokenStore: RefreshTokenStore
+
+  def generateRefreshToken(
+    realm: Realm,
+    client: Client.Id,
+    owner: ResourceOwner,
+    scope: Option[String]
+  ): Directive1[Option[RefreshToken]] =
+    Directive { inner =>
+      if (realm.refreshTokensAllowed) {
+        val token = refreshTokenGenerator.generate()
+
+        onComplete(refreshTokenStore.put(client, token, owner, scope)) {
+          case Success(_) =>
+            inner(Tuple1(Some(token)))
+
+          case Failure(e) =>
+            log.error(
+              e,
+              "Failed to store refresh token for client [{}]: [{}]",
+              client,
+              e.getMessage
+            )
+
+            discardEntity {
+              complete(
+                StatusCodes.InternalServerError
+              )
+            }
+        }
+      } else {
+        inner(Tuple1(None))
+      }
+    }
+}

--- a/identity/src/main/scala/stasis/identity/api/oauth/directives/ResourceOwnerAuthentication.scala
+++ b/identity/src/main/scala/stasis/identity/api/oauth/directives/ResourceOwnerAuthentication.scala
@@ -1,0 +1,94 @@
+package stasis.identity.api.oauth.directives
+
+import akka.event.LoggingAdapter
+import akka.http.scaladsl.model.headers.BasicHttpCredentials
+import akka.http.scaladsl.model.{StatusCodes, Uri}
+import akka.http.scaladsl.server.Directives._
+import akka.http.scaladsl.server.{Directive, Directive1}
+import stasis.identity.api.Formats._
+import stasis.identity.api.directives.BaseApiDirective
+import stasis.identity.authentication.oauth.ResourceOwnerAuthenticator
+import stasis.identity.model.errors.AuthorizationError
+import stasis.identity.model.owners.ResourceOwner
+
+import scala.util.{Failure, Success}
+
+trait ResourceOwnerAuthentication extends BaseApiDirective {
+
+  protected def log: LoggingAdapter
+
+  protected def resourceOwnerAuthenticator: ResourceOwnerAuthenticator
+
+  def authenticateResourceOwner(username: String, password: String): Directive1[ResourceOwner] =
+    Directive { inner =>
+      onComplete(resourceOwnerAuthenticator.authenticate(BasicHttpCredentials(username, password))) {
+        case Success(owner) =>
+          inner(Tuple1(owner))
+
+        case Failure(e) =>
+          log.warning(
+            "Authentication failed for resource owner [{}]: [{}]",
+            username,
+            e.getMessage
+          )
+
+          discardEntity {
+            complete(StatusCodes.Unauthorized)
+          }
+      }
+    }
+
+  def authenticateResourceOwner(redirectUri: Uri, state: String): Directive1[ResourceOwner] =
+    Directive { inner =>
+      extractClientIP { remoteAddress =>
+        extractCredentials {
+          case Some(resourceOwnerCredentials: BasicHttpCredentials) =>
+            onComplete(resourceOwnerAuthenticator.authenticate(resourceOwnerCredentials)) {
+              case Success(owner) =>
+                inner(Tuple1(owner))
+
+              case Failure(e) =>
+                log.warning(
+                  "Authentication failed for resource owner [{}]: [{}]",
+                  resourceOwnerCredentials.username,
+                  e.getMessage
+                )
+
+                discardEntity {
+                  redirect(
+                    redirectUri.withQuery(AuthorizationError.AccessDenied(state).asQuery),
+                    StatusCodes.Found
+                  )
+                }
+            }
+
+          case Some(unsupportedCredentials) =>
+            log.warning(
+              "Resource owner with address [{}] provided unsupported credentials: [{}]",
+              remoteAddress,
+              unsupportedCredentials.scheme()
+            )
+
+            discardEntity {
+              redirect(
+                redirectUri.withQuery(AuthorizationError.AccessDenied(state).asQuery),
+                StatusCodes.Found
+              )
+            }
+
+          case None =>
+            log.warning(
+              "Resource owner with address [{}] provided no credentials",
+              remoteAddress
+            )
+
+            discardEntity {
+              redirect(
+                redirectUri.withQuery(AuthorizationError.AccessDenied(state).asQuery),
+                StatusCodes.Found
+              )
+            }
+        }
+      }
+    }
+}

--- a/identity/src/main/scala/stasis/identity/api/oauth/setup/Providers.scala
+++ b/identity/src/main/scala/stasis/identity/api/oauth/setup/Providers.scala
@@ -1,0 +1,23 @@
+package stasis.identity.api.oauth.setup
+
+import stasis.identity.authentication.oauth.{ClientAuthenticator, ResourceOwnerAuthenticator}
+import stasis.identity.model.apis.ApiStoreView
+import stasis.identity.model.clients.ClientStoreView
+import stasis.identity.model.codes.AuthorizationCodeStore
+import stasis.identity.model.codes.generators.AuthorizationCodeGenerator
+import stasis.identity.model.realms.RealmStore
+import stasis.identity.model.tokens.RefreshTokenStore
+import stasis.identity.model.tokens.generators.{AccessTokenGenerator, RefreshTokenGenerator}
+
+final case class Providers(
+  apiStore: ApiStoreView,
+  clientStore: ClientStoreView,
+  realmStore: RealmStore,
+  refreshTokenStore: RefreshTokenStore,
+  authorizationCodeStore: AuthorizationCodeStore,
+  accessTokenGenerator: AccessTokenGenerator,
+  authorizationCodeGenerator: AuthorizationCodeGenerator,
+  refreshTokenGenerator: RefreshTokenGenerator,
+  clientAuthenticator: ClientAuthenticator,
+  resourceOwnerAuthenticator: ResourceOwnerAuthenticator
+)

--- a/identity/src/main/scala/stasis/identity/authentication/manage/DefaultResourceOwnerAuthenticator.scala
+++ b/identity/src/main/scala/stasis/identity/authentication/manage/DefaultResourceOwnerAuthenticator.scala
@@ -1,0 +1,37 @@
+package stasis.identity.authentication.manage
+
+import akka.http.scaladsl.model.headers.OAuth2BearerToken
+import org.jose4j.jwt.JwtClaims
+import stasis.core.security.exceptions.AuthenticationFailure
+import stasis.core.security.jwt.JwtAuthenticator
+import stasis.identity.model.owners.{ResourceOwner, ResourceOwnerStoreView}
+
+import scala.concurrent.{ExecutionContext, Future}
+import scala.util.Try
+
+class DefaultResourceOwnerAuthenticator(
+  store: ResourceOwnerStoreView,
+  underlying: JwtAuthenticator
+)(implicit ec: ExecutionContext)
+    extends ResourceOwnerAuthenticator {
+  override def authenticate(credentials: OAuth2BearerToken): Future[ResourceOwner] =
+    for {
+      claims <- underlying.authenticate(credentials.token)
+      owner <- extractOwnerFromClaims(claims)
+    } yield {
+      owner
+    }
+
+  private def extractOwnerFromClaims(claims: JwtClaims): Future[ResourceOwner] =
+    for {
+      subject <- Future.fromTry(Try(claims.getSubject))
+      ownerOpt <- store.get(subject)
+      owner <- ownerOpt match {
+        case Some(owner) if owner.active => Future.successful(owner)
+        case Some(_)                     => Future.failed(AuthenticationFailure(s"Resource owner [$subject] is not active"))
+        case None                        => Future.failed(AuthenticationFailure(s"Resource owner [$subject] not found"))
+      }
+    } yield {
+      owner
+    }
+}

--- a/identity/src/main/scala/stasis/identity/authentication/manage/ResourceOwnerAuthenticator.scala
+++ b/identity/src/main/scala/stasis/identity/authentication/manage/ResourceOwnerAuthenticator.scala
@@ -1,0 +1,10 @@
+package stasis.identity.authentication.manage
+
+import akka.http.scaladsl.model.headers.OAuth2BearerToken
+import stasis.identity.model.owners.ResourceOwner
+
+import scala.concurrent.Future
+
+trait ResourceOwnerAuthenticator {
+  def authenticate(credentials: OAuth2BearerToken): Future[ResourceOwner]
+}

--- a/identity/src/main/scala/stasis/identity/authentication/oauth/ClientAuthenticator.scala
+++ b/identity/src/main/scala/stasis/identity/authentication/oauth/ClientAuthenticator.scala
@@ -1,0 +1,5 @@
+package stasis.identity.authentication.oauth
+
+import stasis.identity.model.clients.Client
+
+trait ClientAuthenticator extends EntityAuthenticator[Client]

--- a/identity/src/main/scala/stasis/identity/authentication/oauth/DefaultClientAuthenticator.scala
+++ b/identity/src/main/scala/stasis/identity/authentication/oauth/DefaultClientAuthenticator.scala
@@ -1,0 +1,41 @@
+package stasis.identity.authentication.oauth
+
+import akka.actor.ActorSystem
+import stasis.core.security.exceptions.AuthenticationFailure
+import stasis.identity.model.clients.{Client, ClientStoreView}
+import stasis.identity.model.secrets.Secret
+
+import scala.concurrent.Future
+import scala.util.{Failure, Success, Try}
+
+class DefaultClientAuthenticator(
+  store: ClientStoreView,
+  secretConfig: Secret.ClientConfig
+)(implicit val system: ActorSystem)
+    extends ClientAuthenticator {
+
+  override implicit protected def config: Secret.Config = secretConfig
+
+  override protected def getEntity(username: String): Future[Client] = getClient(username)
+
+  override protected def extractSecret: Client => Secret = _.secret
+
+  override protected def extractSalt: Client => String = _.salt
+
+  private def getClient(username: String): Future[Client] =
+    Try(java.util.UUID.fromString(username)) match {
+      case Success(clientId) =>
+        store
+          .get(clientId)
+          .flatMap {
+            case Some(client) if client.active => Future.successful(client)
+            case Some(_)                       => Future.failed(AuthenticationFailure(s"Client [$clientId] is not active"))
+            case None                          => Future.failed(AuthenticationFailure(s"Client [$clientId] was not found"))
+          }
+
+      case Failure(_) =>
+        Future.failed(
+          AuthenticationFailure(s"Invalid client identifier provided: [$username]")
+        )
+    }
+}

--- a/identity/src/main/scala/stasis/identity/authentication/oauth/DefaultResourceOwnerAuthenticator.scala
+++ b/identity/src/main/scala/stasis/identity/authentication/oauth/DefaultResourceOwnerAuthenticator.scala
@@ -1,0 +1,32 @@
+package stasis.identity.authentication.oauth
+
+import akka.actor.ActorSystem
+import stasis.core.security.exceptions.AuthenticationFailure
+import stasis.identity.model.owners.{ResourceOwner, ResourceOwnerStoreView}
+import stasis.identity.model.secrets.Secret
+
+import scala.concurrent.Future
+
+class DefaultResourceOwnerAuthenticator(
+  store: ResourceOwnerStoreView,
+  secretConfig: Secret.ResourceOwnerConfig
+)(implicit val system: ActorSystem)
+    extends ResourceOwnerAuthenticator {
+
+  override implicit protected def config: Secret.Config = secretConfig
+
+  override protected def getEntity(username: String): Future[ResourceOwner] = getOwner(username)
+
+  override protected def extractSecret: ResourceOwner => Secret = _.password
+
+  override protected def extractSalt: ResourceOwner => String = _.salt
+
+  private def getOwner(username: String): Future[ResourceOwner] =
+    store
+      .get(username)
+      .flatMap {
+        case Some(client) if client.active => Future.successful(client)
+        case Some(_)                       => Future.failed(AuthenticationFailure(s"Resource owner [$username] is not active"))
+        case None                          => Future.failed(AuthenticationFailure(s"Resource owner [$username] was not found"))
+      }
+}

--- a/identity/src/main/scala/stasis/identity/authentication/oauth/EntityAuthenticator.scala
+++ b/identity/src/main/scala/stasis/identity/authentication/oauth/EntityAuthenticator.scala
@@ -1,0 +1,43 @@
+package stasis.identity.authentication.oauth
+
+import akka.actor.ActorSystem
+import akka.http.scaladsl.model.headers.BasicHttpCredentials
+import stasis.core.security.exceptions.AuthenticationFailure
+import stasis.identity.model.secrets.Secret
+
+import scala.concurrent.{ExecutionContext, Future}
+
+trait EntityAuthenticator[T] {
+
+  protected implicit def system: ActorSystem
+  protected implicit def config: Secret.Config
+
+  protected implicit val ec: ExecutionContext = system.dispatcher
+
+  protected def getEntity(username: String): Future[T]
+  protected def extractSecret: T => Secret
+  protected def extractSalt: T => String
+
+  def authenticate(credentials: BasicHttpCredentials): Future[T] =
+    getEntity(credentials.username).flatMap { entity =>
+      val secret = extractSecret(entity)
+      val salt = extractSalt(entity)
+
+      val result =
+        Future(secret.isSameAs(credentials.password, salt))
+          .flatMap { credentialsMatch =>
+            if (credentialsMatch) {
+              Future.successful(entity)
+            } else {
+              Future.failed(
+                AuthenticationFailure(s"Credentials for entity [${credentials.username}] do not match")
+              )
+            }
+          }
+
+      akka.pattern.after(
+        duration = config.authenticationDelay,
+        using = system.scheduler
+      )(result)
+    }
+}

--- a/identity/src/main/scala/stasis/identity/authentication/oauth/ResourceOwnerAuthenticator.scala
+++ b/identity/src/main/scala/stasis/identity/authentication/oauth/ResourceOwnerAuthenticator.scala
@@ -1,0 +1,5 @@
+package stasis.identity.authentication.oauth
+
+import stasis.identity.model.owners.ResourceOwner
+
+trait ResourceOwnerAuthenticator extends EntityAuthenticator[ResourceOwner]

--- a/identity/src/main/scala/stasis/identity/model/GrantType.scala
+++ b/identity/src/main/scala/stasis/identity/model/GrantType.scala
@@ -1,0 +1,11 @@
+package stasis.identity.model
+
+sealed trait GrantType
+
+object GrantType {
+  case object AuthorizationCode extends GrantType
+  case object ClientCredentials extends GrantType
+  case object Implicit extends GrantType
+  case object RefreshToken extends GrantType
+  case object Password extends GrantType
+}

--- a/identity/src/main/scala/stasis/identity/model/ResponseType.scala
+++ b/identity/src/main/scala/stasis/identity/model/ResponseType.scala
@@ -1,0 +1,8 @@
+package stasis.identity.model
+
+sealed trait ResponseType
+
+object ResponseType {
+  case object Code extends ResponseType
+  case object Token extends ResponseType
+}

--- a/identity/src/main/scala/stasis/identity/model/Seconds.scala
+++ b/identity/src/main/scala/stasis/identity/model/Seconds.scala
@@ -1,0 +1,13 @@
+package stasis.identity.model
+
+import scala.concurrent.duration.FiniteDuration
+
+final case class Seconds(value: Long) extends AnyVal
+
+object Seconds {
+  import scala.language.implicitConversions
+
+  def apply(duration: FiniteDuration): Seconds = Seconds(duration.toSeconds)
+
+  implicit def durationToSeconds(duration: FiniteDuration): Seconds = Seconds(duration)
+}

--- a/identity/src/main/scala/stasis/identity/model/apis/Api.scala
+++ b/identity/src/main/scala/stasis/identity/model/apis/Api.scala
@@ -1,0 +1,12 @@
+package stasis.identity.model.apis
+
+import stasis.identity.model.realms.Realm
+
+final case class Api(
+  id: Api.Id,
+  realm: Realm.Id
+)
+
+object Api {
+  type Id = String
+}

--- a/identity/src/main/scala/stasis/identity/model/apis/ApiStore.scala
+++ b/identity/src/main/scala/stasis/identity/model/apis/ApiStore.scala
@@ -1,0 +1,27 @@
+package stasis.identity.model.apis
+
+import scala.concurrent.Future
+
+import akka.Done
+import stasis.core.persistence.backends.KeyValueBackend
+
+trait ApiStore { store =>
+  def put(api: Api): Future[Done]
+  def delete(api: Api.Id): Future[Boolean]
+  def get(api: Api.Id): Future[Option[Api]]
+  def apis: Future[Map[Api.Id, Api]]
+
+  def view: ApiStoreView = new ApiStoreView {
+    override def get(api: Api.Id): Future[Option[Api]] = store.get(api)
+    override def apis: Future[Map[Api.Id, Api]] = store.apis
+  }
+}
+
+object ApiStore {
+  def apply(backend: KeyValueBackend[Api.Id, Api]): ApiStore = new ApiStore {
+    override def put(api: Api): Future[Done] = backend.put(api.id, api)
+    override def delete(api: Api.Id): Future[Boolean] = backend.delete(api)
+    override def get(api: Api.Id): Future[Option[Api]] = backend.get(api)
+    override def apis: Future[Map[Api.Id, Api]] = backend.entries
+  }
+}

--- a/identity/src/main/scala/stasis/identity/model/apis/ApiStoreView.scala
+++ b/identity/src/main/scala/stasis/identity/model/apis/ApiStoreView.scala
@@ -1,0 +1,8 @@
+package stasis.identity.model.apis
+
+import scala.concurrent.Future
+
+trait ApiStoreView {
+  def get(api: Api.Id): Future[Option[Api]]
+  def apis: Future[Map[Api.Id, Api]]
+}

--- a/identity/src/main/scala/stasis/identity/model/clients/Client.scala
+++ b/identity/src/main/scala/stasis/identity/model/clients/Client.scala
@@ -1,0 +1,22 @@
+package stasis.identity.model.clients
+
+import stasis.identity.model.Seconds
+import stasis.identity.model.realms.Realm
+import stasis.identity.model.secrets.Secret
+
+final case class Client(
+  id: Client.Id,
+  realm: Realm.Id,
+  allowedScopes: Seq[String],
+  redirectUri: String,
+  tokenExpiration: Seconds,
+  secret: Secret,
+  salt: String,
+  active: Boolean
+)
+
+object Client {
+  type Id = java.util.UUID
+
+  def generateId(): Id = java.util.UUID.randomUUID()
+}

--- a/identity/src/main/scala/stasis/identity/model/clients/ClientStore.scala
+++ b/identity/src/main/scala/stasis/identity/model/clients/ClientStore.scala
@@ -1,0 +1,27 @@
+package stasis.identity.model.clients
+
+import scala.concurrent.Future
+
+import akka.Done
+import stasis.core.persistence.backends.KeyValueBackend
+
+trait ClientStore { store =>
+  def put(client: Client): Future[Done]
+  def delete(client: Client.Id): Future[Boolean]
+  def get(client: Client.Id): Future[Option[Client]]
+  def clients: Future[Map[Client.Id, Client]]
+
+  def view: ClientStoreView = new ClientStoreView {
+    override def get(client: Client.Id): Future[Option[Client]] = store.get(client)
+    override def clients: Future[Map[Client.Id, Client]] = store.clients
+  }
+}
+
+object ClientStore {
+  def apply(backend: KeyValueBackend[Client.Id, Client]): ClientStore = new ClientStore {
+    override def put(client: Client): Future[Done] = backend.put(client.id, client)
+    override def delete(client: Client.Id): Future[Boolean] = backend.delete(client)
+    override def get(client: Client.Id): Future[Option[Client]] = backend.get(client)
+    override def clients: Future[Map[Client.Id, Client]] = backend.entries
+  }
+}

--- a/identity/src/main/scala/stasis/identity/model/clients/ClientStoreView.scala
+++ b/identity/src/main/scala/stasis/identity/model/clients/ClientStoreView.scala
@@ -1,0 +1,8 @@
+package stasis.identity.model.clients
+
+import scala.concurrent.Future
+
+trait ClientStoreView {
+  def get(client: Client.Id): Future[Option[Client]]
+  def clients: Future[Map[Client.Id, Client]]
+}

--- a/identity/src/main/scala/stasis/identity/model/codes/AuthorizationCode.scala
+++ b/identity/src/main/scala/stasis/identity/model/codes/AuthorizationCode.scala
@@ -1,0 +1,3 @@
+package stasis.identity.model.codes
+
+final case class AuthorizationCode(value: String) extends AnyVal

--- a/identity/src/main/scala/stasis/identity/model/codes/AuthorizationCodeStore.scala
+++ b/identity/src/main/scala/stasis/identity/model/codes/AuthorizationCodeStore.scala
@@ -1,0 +1,48 @@
+package stasis.identity.model.codes
+
+import scala.concurrent.duration.FiniteDuration
+import scala.concurrent.{ExecutionContext, Future}
+import akka.Done
+import akka.actor.typed.{ActorSystem, SpawnProtocol}
+import stasis.core.persistence.backends.KeyValueBackend
+import stasis.identity.model.clients.Client
+import stasis.identity.model.owners.ResourceOwner
+
+trait AuthorizationCodeStore {
+  def put(client: Client.Id, code: AuthorizationCode, owner: ResourceOwner, scope: Option[String]): Future[Done]
+  def delete(client: Client.Id): Future[Boolean]
+  def get(client: Client.Id): Future[Option[StoredAuthorizationCode]]
+  def codes: Future[Map[Client.Id, StoredAuthorizationCode]]
+}
+
+object AuthorizationCodeStore {
+  def apply(
+    expiration: FiniteDuration,
+    backend: KeyValueBackend[Client.Id, StoredAuthorizationCode]
+  )(implicit system: ActorSystem[SpawnProtocol]): AuthorizationCodeStore =
+    new AuthorizationCodeStore {
+      private implicit val ec: ExecutionContext = system.executionContext
+
+      override def put(
+        client: Client.Id,
+        code: AuthorizationCode,
+        owner: ResourceOwner,
+        scope: Option[String]
+      ): Future[Done] =
+        backend
+          .put(client, StoredAuthorizationCode(code, owner, scope))
+          .map { result =>
+            val _ = akka.pattern.after(expiration, system.scheduler)(backend.delete(client))
+            result
+          }
+
+      override def delete(client: Client.Id): Future[Boolean] =
+        backend.delete(client)
+
+      override def get(client: Client.Id): Future[Option[StoredAuthorizationCode]] =
+        backend.get(client)
+
+      override def codes: Future[Map[Client.Id, StoredAuthorizationCode]] =
+        backend.entries
+    }
+}

--- a/identity/src/main/scala/stasis/identity/model/codes/StoredAuthorizationCode.scala
+++ b/identity/src/main/scala/stasis/identity/model/codes/StoredAuthorizationCode.scala
@@ -1,0 +1,9 @@
+package stasis.identity.model.codes
+
+import stasis.identity.model.owners.ResourceOwner
+
+final case class StoredAuthorizationCode(
+  code: AuthorizationCode,
+  owner: ResourceOwner,
+  scope: Option[String]
+)

--- a/identity/src/main/scala/stasis/identity/model/codes/generators/AuthorizationCodeGenerator.scala
+++ b/identity/src/main/scala/stasis/identity/model/codes/generators/AuthorizationCodeGenerator.scala
@@ -1,0 +1,7 @@
+package stasis.identity.model.codes.generators
+
+import stasis.identity.model.codes.AuthorizationCode
+
+trait AuthorizationCodeGenerator {
+  def generate(): AuthorizationCode
+}

--- a/identity/src/main/scala/stasis/identity/model/codes/generators/DefaultAuthorizationCodeGenerator.scala
+++ b/identity/src/main/scala/stasis/identity/model/codes/generators/DefaultAuthorizationCodeGenerator.scala
@@ -1,0 +1,14 @@
+package stasis.identity.model.codes.generators
+
+import java.security.SecureRandom
+
+import stasis.identity.model.codes.AuthorizationCode
+
+import scala.util.Random
+
+class DefaultAuthorizationCodeGenerator(codeSize: Int) extends AuthorizationCodeGenerator {
+  override def generate(): AuthorizationCode = {
+    val random = Random.javaRandomToRandom(new SecureRandom())
+    AuthorizationCode(random.alphanumeric.take(codeSize).mkString(""))
+  }
+}

--- a/identity/src/main/scala/stasis/identity/model/errors/AuthorizationError.scala
+++ b/identity/src/main/scala/stasis/identity/model/errors/AuthorizationError.scala
@@ -1,0 +1,87 @@
+package stasis.identity.model.errors
+
+import akka.http.scaladsl.model.Uri
+
+sealed abstract class AuthorizationError(
+  val error: String,
+  val error_description: String,
+  val state: String
+) {
+  def asQuery: Uri.Query = Uri.Query(
+    "error" -> error,
+    "state" -> state
+  )
+}
+
+object AuthorizationError {
+  final case class InvalidRequest(withState: String)
+      extends AuthorizationError(
+        error = "invalid_request",
+        error_description = s"""
+             |The request is missing a required parameter, includes an
+             |invalid parameter value, includes a parameter more than
+             |once, or is otherwise malformed.
+           """.stripMargin.replaceAll("\n", " ").trim,
+        state = withState
+      )
+
+  final case class UnauthorizedClient(withState: String)
+      extends AuthorizationError(
+        error = "unauthorized_client",
+        error_description = s"""
+             |The client is not authorized to request an authorization
+             |code using this method.
+           """.stripMargin.replaceAll("\n", " ").trim,
+        state = withState
+      )
+
+  final case class AccessDenied(withState: String)
+      extends AuthorizationError(
+        error = "access_denied",
+        error_description = s"""
+             |The resource owner or authorization server denied the
+             |request.
+           """.stripMargin.replaceAll("\n", " ").trim,
+        state = withState
+      )
+
+  final case class UnsupportedResponseType(withState: String)
+      extends AuthorizationError(
+        error = "unsupported_response_type",
+        error_description = s"""
+             |The authorization server does not support obtaining an
+             |authorization code using this method.
+           """.stripMargin.replaceAll("\n", " ").trim,
+        state = withState
+      )
+
+  final case class InvalidScope(withState: String)
+      extends AuthorizationError(
+        error = "invalid_scope",
+        error_description = s"""
+             |The requested scope is invalid, unknown, or malformed.
+           """.stripMargin.replaceAll("\n", " ").trim,
+        state = withState
+      )
+
+  final case class ServerError(withState: String)
+      extends AuthorizationError(
+        error = "server_error",
+        error_description = s"""
+             |The authorization server encountered an unexpected
+             |condition that prevented it from fulfilling the request.
+           """.stripMargin.replaceAll("\n", " ").trim,
+        state = withState
+      )
+
+  final case class TemporarilyUnavailable(withState: String)
+      extends AuthorizationError(
+        error = "temporarily_unavailable",
+        error_description = s"""
+             |The authorization server is currently unable to handle
+             |the request due to a temporary overloading or maintenance
+             |of the server
+           """.stripMargin.replaceAll("\n", " ").trim,
+        state = withState
+      )
+}

--- a/identity/src/main/scala/stasis/identity/model/errors/TokenError.scala
+++ b/identity/src/main/scala/stasis/identity/model/errors/TokenError.scala
@@ -1,0 +1,76 @@
+package stasis.identity.model.errors
+
+sealed abstract class TokenError(
+  val error: String,
+  val error_description: String
+)
+
+object TokenError {
+  final case object InvalidRequest
+      extends TokenError(
+        error = "invalid_request",
+        error_description = s"""
+           |The request is missing a required parameter, includes an
+           |unsupported parameter value (other than grant type),
+           |repeats a parameter, includes multiple credentials,
+           |utilizes more than one mechanism for authenticating the
+           |client, or is otherwise malformed.
+           """.stripMargin.replaceAll("\n", " ").trim
+      )
+
+  final case object InvalidClient
+      extends TokenError(
+        error = "invalid_client",
+        error_description = s"""
+           |Client authentication failed (e.g., unknown client, no
+           |client authentication included, or unsupported
+           |authentication method).  The authorization server MAY
+           |return an HTTP 401 (Unauthorized) status code to indicate
+           |which HTTP authentication schemes are supported.  If the
+           |client attempted to authenticate via the "Authorization"
+           |request header field, the authorization server MUST
+           |respond with an HTTP 401 (Unauthorized) status code and
+           |include the "WWW-Authenticate" response header field
+           |matching the authentication scheme used by the client.
+           """.stripMargin.replaceAll("\n", " ").trim
+      )
+
+  final case object InvalidGrant
+      extends TokenError(
+        error = "invalid_grant",
+        error_description = s"""
+           |The provided authorization grant (e.g., authorization
+           |code, resource owner credentials) or refresh token is
+           |invalid, expired, revoked, does not match the redirection
+           |URI used in the authorization request, or was issued to
+           |another client.
+           """.stripMargin.replaceAll("\n", " ").trim
+      )
+
+  final case object UnauthorizedClient
+      extends TokenError(
+        error = "unauthorized_client",
+        error_description = s"""
+           |The authenticated client is not authorized to use this
+           |authorization grant type.
+           """.stripMargin.replaceAll("\n", " ").trim
+      )
+
+  final case object UnsupportedGrantType
+      extends TokenError(
+        error = "unsupported_grant_type",
+        error_description = s"""
+           |The authorization grant type is not supported by the
+           |authorization server.
+           """.stripMargin.replaceAll("\n", " ").trim
+      )
+
+  final case object InvalidScope
+      extends TokenError(
+        error = "invalid_scope",
+        error_description = s"""
+           |The requested scope is invalid, unknown, malformed, or
+           |exceeds the scope granted by the resource owner.
+           """.stripMargin.replaceAll("\n", " ").trim
+      )
+}

--- a/identity/src/main/scala/stasis/identity/model/owners/ResourceOwner.scala
+++ b/identity/src/main/scala/stasis/identity/model/owners/ResourceOwner.scala
@@ -1,0 +1,17 @@
+package stasis.identity.model.owners
+
+import stasis.identity.model.realms.Realm
+import stasis.identity.model.secrets.Secret
+
+final case class ResourceOwner(
+  username: ResourceOwner.Id,
+  password: Secret,
+  salt: String,
+  realm: Realm.Id,
+  allowedScopes: Seq[String],
+  active: Boolean
+)
+
+object ResourceOwner {
+  type Id = String
+}

--- a/identity/src/main/scala/stasis/identity/model/owners/ResourceOwnerStore.scala
+++ b/identity/src/main/scala/stasis/identity/model/owners/ResourceOwnerStore.scala
@@ -1,0 +1,27 @@
+package stasis.identity.model.owners
+
+import scala.concurrent.Future
+
+import akka.Done
+import stasis.core.persistence.backends.KeyValueBackend
+
+trait ResourceOwnerStore { store =>
+  def put(owner: ResourceOwner): Future[Done]
+  def delete(owner: ResourceOwner.Id): Future[Boolean]
+  def get(owner: ResourceOwner.Id): Future[Option[ResourceOwner]]
+  def owners: Future[Map[ResourceOwner.Id, ResourceOwner]]
+
+  def view: ResourceOwnerStoreView = new ResourceOwnerStoreView {
+    override def get(owner: ResourceOwner.Id): Future[Option[ResourceOwner]] = store.get(owner)
+    override def owners: Future[Map[ResourceOwner.Id, ResourceOwner]] = store.owners
+  }
+}
+
+object ResourceOwnerStore {
+  def apply(backend: KeyValueBackend[ResourceOwner.Id, ResourceOwner]): ResourceOwnerStore = new ResourceOwnerStore {
+    override def put(owner: ResourceOwner): Future[Done] = backend.put(owner.username, owner)
+    override def delete(owner: ResourceOwner.Id): Future[Boolean] = backend.delete(owner)
+    override def get(owner: ResourceOwner.Id): Future[Option[ResourceOwner]] = backend.get(owner)
+    override def owners: Future[Map[ResourceOwner.Id, ResourceOwner]] = backend.entries
+  }
+}

--- a/identity/src/main/scala/stasis/identity/model/owners/ResourceOwnerStoreView.scala
+++ b/identity/src/main/scala/stasis/identity/model/owners/ResourceOwnerStoreView.scala
@@ -1,0 +1,8 @@
+package stasis.identity.model.owners
+
+import scala.concurrent.Future
+
+trait ResourceOwnerStoreView {
+  def get(owner: ResourceOwner.Id): Future[Option[ResourceOwner]]
+  def owners: Future[Map[ResourceOwner.Id, ResourceOwner]]
+}

--- a/identity/src/main/scala/stasis/identity/model/realms/Realm.scala
+++ b/identity/src/main/scala/stasis/identity/model/realms/Realm.scala
@@ -1,0 +1,12 @@
+package stasis.identity.model.realms
+
+final case class Realm(
+  id: Realm.Id,
+  refreshTokensAllowed: Boolean
+)
+
+object Realm {
+  type Id = String
+
+  final val Master: Id = "master"
+}

--- a/identity/src/main/scala/stasis/identity/model/realms/RealmStore.scala
+++ b/identity/src/main/scala/stasis/identity/model/realms/RealmStore.scala
@@ -1,0 +1,28 @@
+package stasis.identity.model.realms
+
+import scala.concurrent.Future
+
+import akka.Done
+import stasis.core.persistence.backends.KeyValueBackend
+import stasis.identity.model.realms.Realm.Id
+
+trait RealmStore { store =>
+  def put(realm: Realm): Future[Done]
+  def delete(realm: Realm.Id): Future[Boolean]
+  def get(realm: Realm.Id): Future[Option[Realm]]
+  def realms: Future[Map[Realm.Id, Realm]]
+
+  def view: RealmStoreView = new RealmStoreView {
+    override def get(realm: Id): Future[Option[Realm]] = store.get(realm)
+    override def realms: Future[Map[Id, Realm]] = store.realms
+  }
+}
+
+object RealmStore {
+  def apply(backend: KeyValueBackend[Realm.Id, Realm]): RealmStore = new RealmStore {
+    override def put(realm: Realm): Future[Done] = backend.put(realm.id, realm)
+    override def delete(realm: Id): Future[Boolean] = backend.delete(realm)
+    override def get(realm: Id): Future[Option[Realm]] = backend.get(realm)
+    override def realms: Future[Map[Id, Realm]] = backend.entries
+  }
+}

--- a/identity/src/main/scala/stasis/identity/model/realms/RealmStoreView.scala
+++ b/identity/src/main/scala/stasis/identity/model/realms/RealmStoreView.scala
@@ -1,0 +1,8 @@
+package stasis.identity.model.realms
+
+import scala.concurrent.Future
+
+trait RealmStoreView {
+  def get(realm: Realm.Id): Future[Option[Realm]]
+  def realms: Future[Map[Realm.Id, Realm]]
+}

--- a/identity/src/main/scala/stasis/identity/model/secrets/Secret.scala
+++ b/identity/src/main/scala/stasis/identity/model/secrets/Secret.scala
@@ -1,0 +1,73 @@
+package stasis.identity.model.secrets
+
+import java.nio.charset.StandardCharsets
+import java.security.SecureRandom
+
+import akka.util.ByteString
+import javax.crypto.SecretKeyFactory
+import javax.crypto.spec.PBEKeySpec
+
+import scala.concurrent.duration.FiniteDuration
+import scala.util.Random
+
+final case class Secret(value: ByteString) {
+  override def toString: String = "Secret"
+
+  def isSameAs(rawSecret: String, salt: String)(implicit config: Secret.Config): Boolean = {
+    val hashedSecret = Secret.derive(rawSecret, salt)
+
+    value == hashedSecret.value
+  }
+}
+
+object Secret {
+  sealed trait Config {
+    def algorithm: String
+    def iterations: Int
+    def derivedKeySize: Int
+    def saltSize: Int
+    def authenticationDelay: FiniteDuration
+  }
+
+  final case class ClientConfig(
+    override val algorithm: String,
+    override val iterations: Int,
+    override val derivedKeySize: Int,
+    override val saltSize: Int,
+    override val authenticationDelay: FiniteDuration
+  ) extends Config
+
+  final case class ResourceOwnerConfig(
+    override val algorithm: String,
+    override val iterations: Int,
+    override val derivedKeySize: Int,
+    override val saltSize: Int,
+    override val authenticationDelay: FiniteDuration
+  ) extends Config
+
+  def apply(value: ByteString): Secret = new Secret(value)
+
+  def derive(
+    rawSecret: String,
+    salt: String
+  )(implicit config: Config): Secret = {
+    val spec = new PBEKeySpec(
+      rawSecret.toCharArray,
+      salt.getBytes(StandardCharsets.UTF_8),
+      config.iterations,
+      config.derivedKeySize * 8
+    )
+
+    val derivedSecret = SecretKeyFactory
+      .getInstance(config.algorithm)
+      .generateSecret(spec)
+      .getEncoded
+
+    Secret(ByteString(derivedSecret))
+  }
+
+  def generateSalt()(implicit config: Config): String = {
+    val random = Random.javaRandomToRandom(new SecureRandom())
+    random.alphanumeric.take(config.saltSize).mkString("")
+  }
+}

--- a/identity/src/main/scala/stasis/identity/model/tokens/AccessToken.scala
+++ b/identity/src/main/scala/stasis/identity/model/tokens/AccessToken.scala
@@ -1,0 +1,3 @@
+package stasis.identity.model.tokens
+
+final case class AccessToken(value: String) extends AnyVal

--- a/identity/src/main/scala/stasis/identity/model/tokens/RefreshToken.scala
+++ b/identity/src/main/scala/stasis/identity/model/tokens/RefreshToken.scala
@@ -1,0 +1,3 @@
+package stasis.identity.model.tokens
+
+final case class RefreshToken(value: String) extends AnyVal

--- a/identity/src/main/scala/stasis/identity/model/tokens/RefreshTokenStore.scala
+++ b/identity/src/main/scala/stasis/identity/model/tokens/RefreshTokenStore.scala
@@ -1,0 +1,49 @@
+package stasis.identity.model.tokens
+
+import akka.Done
+import akka.actor.typed.{ActorSystem, SpawnProtocol}
+import stasis.core.persistence.backends.KeyValueBackend
+import stasis.identity.model.clients.Client
+import stasis.identity.model.owners.ResourceOwner
+
+import scala.concurrent.duration.FiniteDuration
+import scala.concurrent.{ExecutionContext, Future}
+
+trait RefreshTokenStore { store =>
+  def put(client: Client.Id, token: RefreshToken, owner: ResourceOwner, scope: Option[String]): Future[Done]
+  def delete(client: Client.Id): Future[Boolean]
+  def get(client: Client.Id): Future[Option[StoredRefreshToken]]
+  def tokens: Future[Map[Client.Id, StoredRefreshToken]]
+}
+
+object RefreshTokenStore {
+  def apply(
+    expiration: FiniteDuration,
+    backend: KeyValueBackend[Client.Id, StoredRefreshToken]
+  )(implicit system: ActorSystem[SpawnProtocol]): RefreshTokenStore =
+    new RefreshTokenStore {
+      private implicit val ec: ExecutionContext = system.executionContext
+
+      override def put(
+        client: Client.Id,
+        token: RefreshToken,
+        owner: ResourceOwner,
+        scope: Option[String]
+      ): Future[Done] =
+        backend
+          .put(client, StoredRefreshToken(token, owner, scope))
+          .map { result =>
+            val _ = akka.pattern.after(expiration, system.scheduler)(backend.delete(client))
+            result
+          }
+
+      override def delete(client: Client.Id): Future[Boolean] =
+        backend.delete(client)
+
+      override def get(client: Client.Id): Future[Option[StoredRefreshToken]] =
+        backend.get(client)
+
+      override def tokens: Future[Map[Client.Id, StoredRefreshToken]] =
+        backend.entries
+    }
+}

--- a/identity/src/main/scala/stasis/identity/model/tokens/StoredRefreshToken.scala
+++ b/identity/src/main/scala/stasis/identity/model/tokens/StoredRefreshToken.scala
@@ -1,0 +1,9 @@
+package stasis.identity.model.tokens
+
+import stasis.identity.model.owners.ResourceOwner
+
+final case class StoredRefreshToken(
+  token: RefreshToken,
+  owner: ResourceOwner,
+  scope: Option[String]
+)

--- a/identity/src/main/scala/stasis/identity/model/tokens/TokenType.scala
+++ b/identity/src/main/scala/stasis/identity/model/tokens/TokenType.scala
@@ -1,0 +1,7 @@
+package stasis.identity.model.tokens
+
+sealed trait TokenType
+
+object TokenType {
+  case object Bearer extends TokenType
+}

--- a/identity/src/main/scala/stasis/identity/model/tokens/generators/AccessTokenGenerator.scala
+++ b/identity/src/main/scala/stasis/identity/model/tokens/generators/AccessTokenGenerator.scala
@@ -1,0 +1,11 @@
+package stasis.identity.model.tokens.generators
+
+import stasis.identity.model.apis.Api
+import stasis.identity.model.clients.Client
+import stasis.identity.model.owners.ResourceOwner
+import stasis.identity.model.tokens.AccessToken
+
+trait AccessTokenGenerator {
+  def generate(client: Client, audience: Seq[Client]): AccessToken
+  def generate(owner: ResourceOwner, audience: Seq[Api]): AccessToken
+}

--- a/identity/src/main/scala/stasis/identity/model/tokens/generators/JwtBearerAccessTokenGenerator.scala
+++ b/identity/src/main/scala/stasis/identity/model/tokens/generators/JwtBearerAccessTokenGenerator.scala
@@ -1,0 +1,58 @@
+package stasis.identity.model.tokens.generators
+
+import org.jose4j.jwk._
+import org.jose4j.jws.JsonWebSignature
+import org.jose4j.jwt.JwtClaims
+import stasis.identity.model.apis.Api
+import stasis.identity.model.clients.Client
+import stasis.identity.model.owners.ResourceOwner
+import stasis.identity.model.tokens.AccessToken
+
+import scala.concurrent.duration.FiniteDuration
+
+class JwtBearerAccessTokenGenerator(
+  issuer: String,
+  jwk: JsonWebKey,
+  jwtExpiration: FiniteDuration
+) extends AccessTokenGenerator {
+
+  override def generate(client: Client, audience: Seq[Client]): AccessToken =
+    generateToken(
+      subject = client.id.toString,
+      audience = audience.map(_.id.toString)
+    )
+
+  override def generate(owner: ResourceOwner, audience: Seq[Api]): AccessToken =
+    generateToken(
+      subject = owner.username,
+      audience = audience.map(_.id.toString)
+    )
+
+  private def generateToken(subject: String, audience: Seq[String]): AccessToken = {
+    val claims = new JwtClaims()
+
+    claims.setGeneratedJwtId()
+
+    claims.setIssuer(issuer)
+    claims.setSubject(subject)
+    claims.setAudience(audience: _*)
+
+    claims.setExpirationTimeMinutesInTheFuture(jwtExpiration.toMinutes)
+    claims.setIssuedAtToNow()
+
+    val jws = new JsonWebSignature
+    jws.setPayload(claims.toJson)
+    jws.setKeyIdHeaderValue(jwk.getKeyId)
+    jws.setAlgorithmHeaderValue(jwk.getAlgorithm)
+
+    jwk match {
+      case key: RsaJsonWebKey           => jws.setKey(key.getPrivateKey)
+      case key: EllipticCurveJsonWebKey => jws.setKey(key.getPrivateKey)
+      case key: OctetSequenceJsonWebKey => jws.setKey(key.getKey)
+    }
+
+    val jwt = jws.getCompactSerialization
+
+    AccessToken(value = jwt)
+  }
+}

--- a/identity/src/main/scala/stasis/identity/model/tokens/generators/RandomRefreshTokenGenerator.scala
+++ b/identity/src/main/scala/stasis/identity/model/tokens/generators/RandomRefreshTokenGenerator.scala
@@ -1,0 +1,14 @@
+package stasis.identity.model.tokens.generators
+
+import java.security.SecureRandom
+
+import stasis.identity.model.tokens.RefreshToken
+
+import scala.util.Random
+
+class RandomRefreshTokenGenerator(tokenSize: Int) extends RefreshTokenGenerator {
+  override def generate(): RefreshToken = {
+    val random = Random.javaRandomToRandom(new SecureRandom())
+    RefreshToken(random.alphanumeric.take(tokenSize).mkString(""))
+  }
+}

--- a/identity/src/main/scala/stasis/identity/model/tokens/generators/RefreshTokenGenerator.scala
+++ b/identity/src/main/scala/stasis/identity/model/tokens/generators/RefreshTokenGenerator.scala
@@ -1,0 +1,7 @@
+package stasis.identity.model.tokens.generators
+
+import stasis.identity.model.tokens.RefreshToken
+
+trait RefreshTokenGenerator {
+  def generate(): RefreshToken
+}

--- a/identity/src/test/resources/application.conf
+++ b/identity/src/test/resources/application.conf
@@ -1,0 +1,3 @@
+akka {
+  loglevel = "DEBUG"
+}

--- a/identity/src/test/scala/stasis/test/specs/unit/identity/EncodingHelpers.scala
+++ b/identity/src/test/scala/stasis/test/specs/unit/identity/EncodingHelpers.scala
@@ -1,0 +1,14 @@
+package stasis.test.specs.unit.identity
+
+import akka.parboiled2.util.Base64
+import akka.util.ByteString
+
+trait EncodingHelpers {
+  implicit class ByteStringToBase64(raw: ByteString) {
+    def encodeAsBase64: String = Base64.rfc2045().encodeToString(raw.toArray, false)
+  }
+
+  implicit class Base64StringToByteString(raw: String) {
+    def decodeFromBase64: ByteString = ByteString.fromArray(Base64.rfc2045().decodeFast(raw))
+  }
+}

--- a/identity/src/test/scala/stasis/test/specs/unit/identity/RouteTest.scala
+++ b/identity/src/test/scala/stasis/test/specs/unit/identity/RouteTest.scala
@@ -1,0 +1,209 @@
+package stasis.test.specs.unit.identity
+
+import akka.Done
+import akka.actor.typed.scaladsl.Behaviors
+import akka.actor.typed.{ActorSystem, Behavior, SpawnProtocol}
+import akka.event.{Logging, LoggingAdapter}
+import akka.http.scaladsl.marshalling.{Marshal, Marshaller}
+import akka.http.scaladsl.model.RequestEntity
+import akka.http.scaladsl.testkit.ScalatestRouteTest
+import akka.util.Timeout
+import stasis.core.persistence.backends.KeyValueBackend
+import stasis.core.persistence.backends.memory.MemoryBackend
+import stasis.identity.model.apis.{Api, ApiStore}
+import stasis.identity.model.clients.{Client, ClientStore}
+import stasis.identity.model.codes.{AuthorizationCodeStore, StoredAuthorizationCode}
+import stasis.identity.model.owners.{ResourceOwner, ResourceOwnerStore}
+import stasis.identity.model.realms.{Realm, RealmStore}
+import stasis.identity.model.tokens.{RefreshTokenStore, StoredRefreshToken}
+import stasis.test.specs.unit.AsyncUnitSpec
+import stasis.test.specs.unit.identity.RouteTest.FailingMemoryBackend
+
+import scala.concurrent.Future
+import scala.concurrent.duration._
+
+trait RouteTest extends AsyncUnitSpec with ScalatestRouteTest {
+  import scala.language.implicitConversions
+
+  implicit val typedSystem: ActorSystem[SpawnProtocol] = ActorSystem(
+    Behaviors.setup(_ => SpawnProtocol.behavior): Behavior[SpawnProtocol],
+    name = this.getClass.getSimpleName + "_typed"
+  )
+
+  implicit def requestToEntity[T](request: T)(implicit m: Marshaller[T, RequestEntity]): RequestEntity =
+    Marshal(request).to[RequestEntity].await
+
+  def createLogger(): LoggingAdapter = Logging(system, this.getClass.getName)
+
+  def createApiStore(): ApiStore = ApiStore(
+    MemoryBackend[Api.Id, Api](name = s"api-store-${java.util.UUID.randomUUID()}")
+  )
+
+  def createClientStore(): ClientStore = ClientStore(
+    MemoryBackend[Client.Id, Client](name = s"client-store-${java.util.UUID.randomUUID()}")
+  )
+
+  def createCodeStore(expiration: FiniteDuration = 3.seconds): AuthorizationCodeStore = AuthorizationCodeStore(
+    expiration = expiration,
+    MemoryBackend[Client.Id, StoredAuthorizationCode](name = s"code-store-${java.util.UUID.randomUUID()}")
+  )
+
+  def createOwnerStore(): ResourceOwnerStore = ResourceOwnerStore(
+    MemoryBackend[ResourceOwner.Id, ResourceOwner](name = s"owner-store-${java.util.UUID.randomUUID()}")
+  )
+
+  def createRealmStore(): RealmStore = RealmStore(
+    MemoryBackend[Realm.Id, Realm](name = s"realm-store-${java.util.UUID.randomUUID()}")
+  )
+
+  def createTokenStore(expiration: FiniteDuration = 3.seconds): RefreshTokenStore = RefreshTokenStore(
+    expiration = expiration,
+    MemoryBackend[Client.Id, StoredRefreshToken](name = s"token-store-${java.util.UUID.randomUUID()}")
+  )
+
+  def createFailingApiStore(
+    failingPut: Boolean = false,
+    failingDelete: Boolean = false,
+    failingGet: Boolean = false,
+    failingEntries: Boolean = false,
+    failingContains: Boolean = false
+  ): ApiStore = ApiStore(
+    new FailingMemoryBackend[Api.Id, Api] {
+      override def system: ActorSystem[SpawnProtocol] = typedSystem
+      override def storeName: String = s"api-store-${java.util.UUID.randomUUID()}"
+      override def putFails: Boolean = failingPut
+      override def deleteFails: Boolean = failingDelete
+      override def getFails: Boolean = failingGet
+      override def entriesFails: Boolean = failingEntries
+      override def containsFails: Boolean = failingContains
+    }
+  )
+
+  def createFailingClientStore(
+    failingPut: Boolean = false,
+    failingDelete: Boolean = false,
+    failingGet: Boolean = false,
+    failingEntries: Boolean = false,
+    failingContains: Boolean = false
+  ): ClientStore = ClientStore(
+    new FailingMemoryBackend[Client.Id, Client] {
+      override def system: ActorSystem[SpawnProtocol] = typedSystem
+      override def storeName: String = s"client-store-${java.util.UUID.randomUUID()}"
+      override def putFails: Boolean = failingPut
+      override def deleteFails: Boolean = failingDelete
+      override def getFails: Boolean = failingGet
+      override def entriesFails: Boolean = failingEntries
+      override def containsFails: Boolean = failingContains
+    }
+  )
+
+  def createFailingCodeStore(
+    expiration: FiniteDuration = 3.second,
+    failingPut: Boolean = false,
+    failingDelete: Boolean = false,
+    failingGet: Boolean = false,
+    failingEntries: Boolean = false,
+    failingContains: Boolean = false
+  ): AuthorizationCodeStore = AuthorizationCodeStore(
+    expiration = expiration,
+    new FailingMemoryBackend[Client.Id, StoredAuthorizationCode] {
+      override def system: ActorSystem[SpawnProtocol] = typedSystem
+      override def storeName: String = s"code-store-${java.util.UUID.randomUUID()}"
+      override def putFails: Boolean = failingPut
+      override def deleteFails: Boolean = failingDelete
+      override def getFails: Boolean = failingGet
+      override def entriesFails: Boolean = failingEntries
+      override def containsFails: Boolean = failingContains
+    }
+  )
+
+  def createFailingOwnerStore(
+    failingPut: Boolean = false,
+    failingDelete: Boolean = false,
+    failingGet: Boolean = false,
+    failingEntries: Boolean = false,
+    failingContains: Boolean = false
+  ): ResourceOwnerStore = ResourceOwnerStore(
+    new FailingMemoryBackend[ResourceOwner.Id, ResourceOwner] {
+      override def system: ActorSystem[SpawnProtocol] = typedSystem
+      override def storeName: String = s"owner-store-${java.util.UUID.randomUUID()}"
+      override def putFails: Boolean = failingPut
+      override def deleteFails: Boolean = failingDelete
+      override def getFails: Boolean = failingGet
+      override def entriesFails: Boolean = failingEntries
+      override def containsFails: Boolean = failingContains
+    }
+  )
+
+  def createFailingRealmStore(
+    failingPut: Boolean = false,
+    failingDelete: Boolean = false,
+    failingGet: Boolean = false,
+    failingEntries: Boolean = false,
+    failingContains: Boolean = false
+  ): RealmStore = RealmStore(
+    new FailingMemoryBackend[Realm.Id, Realm] {
+      override def system: ActorSystem[SpawnProtocol] = typedSystem
+      override def storeName: String = s"realm-store-${java.util.UUID.randomUUID()}"
+      override def putFails: Boolean = failingPut
+      override def deleteFails: Boolean = failingDelete
+      override def getFails: Boolean = failingGet
+      override def entriesFails: Boolean = failingEntries
+      override def containsFails: Boolean = failingContains
+    }
+  )
+
+  def createFailingTokenStore(
+    expiration: FiniteDuration = 3.seconds,
+    failingPut: Boolean = false,
+    failingDelete: Boolean = false,
+    failingGet: Boolean = false,
+    failingEntries: Boolean = false,
+    failingContains: Boolean = false
+  ): RefreshTokenStore = RefreshTokenStore(
+    expiration = expiration,
+    new FailingMemoryBackend[Client.Id, StoredRefreshToken] {
+      override def system: ActorSystem[SpawnProtocol] = typedSystem
+      override def storeName: String = s"token-store-${java.util.UUID.randomUUID()}"
+      override def putFails: Boolean = failingPut
+      override def deleteFails: Boolean = failingDelete
+      override def getFails: Boolean = failingGet
+      override def entriesFails: Boolean = failingEntries
+      override def containsFails: Boolean = failingContains
+    }
+  )
+}
+
+object RouteTest {
+  trait FailingMemoryBackend[K, V] extends KeyValueBackend[K, V] {
+    private val underlying = MemoryBackend[K, V](storeName)
+
+    implicit def system: ActorSystem[SpawnProtocol]
+    implicit def timeout: Timeout = 3.seconds
+
+    def storeName: String
+    def putFails: Boolean
+    def deleteFails: Boolean
+    def getFails: Boolean
+    def entriesFails: Boolean
+    def containsFails: Boolean
+
+    override def init(): Future[Done] = Future.successful(Done)
+    override def drop(): Future[Done] = Future.successful(Done)
+
+    override def put(key: K, value: V): Future[Done] =
+      if (putFails) Future.failed(new RuntimeException("Operation failure enabled")) else underlying.put(key, value)
+
+    override def delete(key: K): Future[Boolean] =
+      if (deleteFails) Future.failed(new RuntimeException("Operation failure enabled")) else underlying.delete(key)
+
+    override def get(key: K): Future[Option[V]] =
+      if (getFails) Future.failed(new RuntimeException("Operation failure enabled")) else underlying.get(key)
+
+    override def entries: Future[Map[K, V]] =
+      if (entriesFails) Future.failed(new RuntimeException("Operation failure enabled")) else underlying.entries
+
+    override def contains(key: K): Future[Boolean] =
+      if (containsFails) Future.failed(new RuntimeException("Operation failure enabled")) else underlying.contains(key)
+  }
+}

--- a/identity/src/test/scala/stasis/test/specs/unit/identity/api/FormatsSpec.scala
+++ b/identity/src/test/scala/stasis/test/specs/unit/identity/api/FormatsSpec.scala
@@ -1,0 +1,180 @@
+package stasis.test.specs.unit.identity.api
+
+import play.api.libs.json._
+import stasis.identity.api.Formats._
+import stasis.identity.model.codes.StoredAuthorizationCode
+import stasis.identity.model.errors.{AuthorizationError, TokenError}
+import stasis.identity.model.tokens.{AccessToken, RefreshToken, StoredRefreshToken, TokenType}
+import stasis.identity.model.{GrantType, ResponseType, Seconds}
+import stasis.test.specs.unit.UnitSpec
+import stasis.test.specs.unit.identity.model.Generators
+
+class FormatsSpec extends UnitSpec {
+  "Formats" should "convert authorization errors to JSON" in {
+    val error = AuthorizationError.InvalidScope(withState = Generators.generateString(withSize = 16))
+    val json = authorizationErrorFormat.writes(error).toString
+    val parsedFields = Json.parse(json).as[JsObject].fields
+
+    parsedFields should contain("error" -> JsString(error.error))
+    parsedFields should contain("error_description" -> JsString(error.error_description))
+    parsedFields should contain("state" -> JsString(error.state))
+  }
+
+  they should "convert token errors to JSON" in {
+    val error = TokenError.InvalidScope
+    val json = tokenErrorFormat.writes(error).toString
+    val parsedFields = Json.parse(json).as[JsObject].fields
+
+    parsedFields should contain("error" -> JsString(error.error))
+    parsedFields should contain("error_description" -> JsString(error.error_description))
+  }
+
+  they should "convert token types to/from JSON" in {
+    val json = "\"bearer\""
+    tokenTypeFormat.writes(TokenType.Bearer).toString should be(json)
+    tokenTypeFormat.reads(Json.parse(json).as[JsString]).asOpt should be(Some(TokenType.Bearer))
+  }
+
+  they should "convert grant types to/from JSON" in {
+    val grants = Map(
+      GrantType.AuthorizationCode -> "\"authorization_code\"",
+      GrantType.ClientCredentials -> "\"client_credentials\"",
+      GrantType.Implicit -> "\"implicit\"",
+      GrantType.RefreshToken -> "\"refresh_token\"",
+      GrantType.Password -> "\"password\""
+    )
+
+    grants.foreach {
+      case (grant, json) =>
+        grantTypeFormat.writes(grant).toString should be(json)
+        grantTypeFormat.reads(Json.parse(json).as[JsString]).asOpt should be(Some(grant))
+    }
+  }
+
+  they should "convert response types to/from JSON" in {
+    val responses = Map(
+      ResponseType.Code -> "\"code\"",
+      ResponseType.Token -> "\"token\""
+    )
+
+    responses.foreach {
+      case (response, json) =>
+        responseTypeFormat.writes(response).toString should be(json)
+        responseTypeFormat.reads(Json.parse(json).as[JsString]).asOpt should be(Some(response))
+    }
+  }
+
+  they should "convert access tokens to/from JSON" in {
+    val token = AccessToken(value = Generators.generateString(withSize = 16))
+    val json = s"""\"${token.value}\""""
+
+    accessTokenFormat.writes(token).toString should be(json)
+    accessTokenFormat.reads(Json.parse(json).as[JsString]).asOpt should be(Some(token))
+  }
+
+  they should "convert refresh tokens to/from JSON" in {
+    val token = RefreshToken(value = Generators.generateString(withSize = 16))
+    val json = s"""\"${token.value}\""""
+
+    refreshTokenFormat.writes(token).toString should be(json)
+    refreshTokenFormat.reads(Json.parse(json).as[JsString]).asOpt should be(Some(token))
+  }
+
+  they should "convert authorization codes to/from JSON" in {
+    val code = Generators.generateAuthorizationCode
+    val json = s"""\"${code.value}\""""
+
+    authorizationCodeFormat.writes(code).toString should be(json)
+    authorizationCodeFormat.reads(Json.parse(json).as[JsString]).asOpt should be(Some(code))
+  }
+
+  they should "convert seconds to/from JSON" in {
+    val seconds = Seconds(42)
+    val json = seconds.value.toString
+
+    secondsFormat.writes(seconds).toString should be(json)
+    secondsFormat.reads(Json.parse(json).as[JsNumber]).asOpt should be(Some(seconds))
+  }
+
+  they should "convert APIs to/from JSON" in {
+    val api = Generators.generateApi
+    val json = apiFormat.writes(api).toString
+    val parsedFields = Json.parse(json).as[JsObject].fields
+
+    parsedFields should contain("id" -> JsString(api.id))
+    parsedFields should contain("realm" -> JsString(api.realm))
+
+    apiFormat.reads(Json.parse(json).as[JsObject]).asOpt should be(Some(api))
+  }
+
+  they should "convert clients to JSON" in {
+    val client = Generators.generateClient
+    val json = clientFormat.writes(client).toString
+    val parsedFields = Json.parse(json).as[JsObject].fields
+    val parsedKeys = parsedFields.map(_._1)
+
+    parsedFields should contain("id" -> JsString(client.id.toString))
+    parsedFields should contain("realm" -> JsString(client.realm))
+    parsedFields should contain("allowedScopes" -> JsArray(client.allowedScopes.map(JsString)))
+    parsedFields should contain("redirectUri" -> JsString(client.redirectUri))
+    parsedFields should contain("tokenExpiration" -> JsNumber(client.tokenExpiration.value))
+    parsedFields should contain("active" -> JsBoolean(client.active))
+    parsedKeys should not contain "secret"
+    parsedKeys should not contain "salt"
+  }
+
+  they should "convert stored authorization codes to JSON" in {
+    val code = StoredAuthorizationCode(
+      code = Generators.generateAuthorizationCode,
+      owner = Generators.generateResourceOwner,
+      scope = Some(Generators.generateString(withSize = 16))
+    )
+    val json = storedAuthorizationCodeFormat.writes(code).toString
+    val parsedFields = Json.parse(json).as[JsObject].fields
+    val parsedKeys = parsedFields.map(_._1)
+
+    parsedFields should contain("code" -> JsString(code.code.value))
+    parsedFields should contain("scope" -> JsString(code.scope.getOrElse("invalid-scope")))
+    parsedKeys should contain("owner")
+  }
+
+  they should "convert resource owners to JSON" in {
+    val owner = Generators.generateResourceOwner
+    val json = resourceOwnerFormat.writes(owner).toString
+    val parsedFields = Json.parse(json).as[JsObject].fields
+    val parsedKeys = parsedFields.map(_._1)
+
+    parsedFields should contain("username" -> JsString(owner.username))
+    parsedFields should contain("realm" -> JsString(owner.realm))
+    parsedFields should contain("allowedScopes" -> JsArray(owner.allowedScopes.map(JsString)))
+    parsedFields should contain("active" -> JsBoolean(owner.active))
+    parsedKeys should not contain "secret"
+    parsedKeys should not contain "salt"
+  }
+
+  they should "convert realms to/from JSON" in {
+    val realm = Generators.generateRealm
+    val json = realmFormat.writes(realm).toString
+    val parsedFields = Json.parse(json).as[JsObject].fields
+
+    parsedFields should contain("id" -> JsString(realm.id))
+    parsedFields should contain("refreshTokensAllowed" -> JsBoolean(realm.refreshTokensAllowed))
+
+    realmFormat.reads(Json.parse(json).as[JsObject]).asOpt should be(Some(realm))
+  }
+
+  they should "convert stored refresh tokens to JSON" in {
+    val token = StoredRefreshToken(
+      token = Generators.generateRefreshToken,
+      owner = Generators.generateResourceOwner,
+      scope = Some(Generators.generateString(withSize = 16))
+    )
+    val json = storedRefreshTokenFormat.writes(token).toString
+    val parsedFields = Json.parse(json).as[JsObject].fields
+    val parsedKeys = parsedFields.map(_._1)
+
+    parsedFields should contain("token" -> JsString(token.token.value))
+    parsedFields should contain("scope" -> JsString(token.scope.getOrElse("invalid-scope")))
+    parsedKeys should contain("owner")
+  }
+}

--- a/identity/src/test/scala/stasis/test/specs/unit/identity/api/IdentityEndpointSpec.scala
+++ b/identity/src/test/scala/stasis/test/specs/unit/identity/api/IdentityEndpointSpec.scala
@@ -1,0 +1,204 @@
+package stasis.test.specs.unit.identity.api
+
+import akka.http.scaladsl.Http
+import akka.http.scaladsl.model.headers.OAuth2BearerToken
+import akka.http.scaladsl.model.{HttpMethods, HttpRequest, StatusCodes}
+import akka.http.scaladsl.unmarshalling.Unmarshal
+import play.api.libs.json._
+import stasis.identity.api.IdentityEndpoint
+import stasis.identity.api.manage.setup.Config
+import stasis.identity.model.realms.Realm
+import stasis.identity.model.secrets.Secret
+import stasis.test.specs.unit.core.security.jwt.mocks.MockJwksGenerators
+import stasis.test.specs.unit.identity.RouteTest
+import stasis.test.specs.unit.identity.api.manage.ManageFixtures
+import stasis.test.specs.unit.identity.api.oauth.OAuthFixtures
+import stasis.test.specs.unit.identity.model.Generators
+
+import scala.collection.mutable
+import scala.concurrent.duration._
+
+class IdentityEndpointSpec extends RouteTest with OAuthFixtures with ManageFixtures {
+  private val ports: mutable.Queue[Int] = (24000 to 24100).to[mutable.Queue]
+
+  "An IdentityEndpoint" should "provide OAuth routes" in {
+    val (stores, _, oauthProviders) = createOAuthFixtures()
+    val manageProviders = createManageProviders()
+
+    val realm = Generators.generateRealm
+
+    val endpoint = new IdentityEndpoint(
+      keys = Seq(
+        MockJwksGenerators.generateRandomRsaKey(
+          keyId = Some(Generators.generateString(withSize = 16))
+        )
+      ),
+      oauthProviders = oauthProviders,
+      manageProviders = manageProviders,
+      manageConfig = manageConfig
+    )
+
+    val responseType = "some-response"
+
+    stores.realms.put(realm).await
+    Get(s"/oauth/${realm.id}/authorization?response_type=$responseType") ~> endpoint.routes ~> check {
+      status should be(StatusCodes.BadRequest)
+      responseAs[String] should be(
+        s"Realm [${realm.id}]: The request includes an invalid response type: [$responseType]"
+      )
+    }
+  }
+
+  it should "provide JWKs routes" in {
+    import de.heikoseeberger.akkahttpplayjson.PlayJsonSupport._
+
+    val (_, _, oauthProviders) = createOAuthFixtures()
+    val manageProviders = createManageProviders()
+
+    val keys = Seq(
+      MockJwksGenerators.generateRandomRsaKey(
+        keyId = Some(Generators.generateString(withSize = 16))
+      )
+    )
+
+    val endpoint = new IdentityEndpoint(
+      keys = keys,
+      oauthProviders = oauthProviders,
+      manageProviders = manageProviders,
+      manageConfig = manageConfig
+    )
+
+    Get("/jwks/jwks.json") ~> endpoint.routes ~> check {
+      status should be(StatusCodes.OK)
+      responseAs[JsObject].fields should contain(
+        "keys" -> JsArray(keys.map(jwk => JsString(jwk.toJson)))
+      )
+    }
+  }
+
+  it should "provide management routes" in {
+    import de.heikoseeberger.akkahttpplayjson.PlayJsonSupport._
+    import stasis.identity.api.Formats._
+
+    val (_, _, oauthProviders) = createOAuthFixtures()
+    val manageProviders = createManageProviders()
+
+    val realm = Generators.generateRealm
+
+    val endpoint = new IdentityEndpoint(
+      keys = Seq(
+        MockJwksGenerators.generateRandomRsaKey(
+          keyId = Some(Generators.generateString(withSize = 16))
+        )
+      ),
+      oauthProviders = oauthProviders,
+      manageProviders = manageProviders,
+      manageConfig = manageConfig
+    )
+
+    val credentials = OAuth2BearerToken("some-token")
+
+    manageProviders.realmStore.put(realm).await
+    Get(s"/manage/master/realms/${realm.id}").addCredentials(credentials) ~> endpoint.routes ~> check {
+      status should be(StatusCodes.OK)
+      responseAs[Realm] should be(realm)
+    }
+  }
+
+  it should "handle parameter rejections reported by routes" in {
+    val endpointPort = ports.dequeue()
+
+    val (stores, _, oauthProviders) = createOAuthFixtures()
+    val manageProviders = createManageProviders()
+
+    val realm = Generators.generateRealm
+
+    val endpoint = new IdentityEndpoint(
+      keys = Seq(
+        MockJwksGenerators.generateRandomRsaKey(
+          keyId = Some(Generators.generateString(withSize = 16))
+        )
+      ),
+      oauthProviders = oauthProviders,
+      manageProviders = manageProviders,
+      manageConfig = manageConfig
+    )
+
+    stores.realms.put(realm).await
+
+    endpoint.start(
+      hostname = "localhost",
+      port = endpointPort
+    )
+
+    Http()
+      .singleRequest(
+        request = HttpRequest(
+          method = HttpMethods.GET,
+          uri = s"http://localhost:$endpointPort/oauth/${realm.id}/authorization?response_type=code"
+        )
+      )
+      .map { response =>
+        response.status should be(StatusCodes.BadRequest)
+        Unmarshal(response.entity).to[String].await should be(
+          "Parameter [client_id] is missing, invalid or malformed"
+        )
+      }
+  }
+
+  it should "handle generic failures reported by routes" in {
+    val endpointPort = ports.dequeue()
+
+    val (_, _, oauthProviders) = createOAuthFixtures()
+    val manageProviders = createManageProviders()
+
+    val endpoint = new IdentityEndpoint(
+      keys = Seq(
+        MockJwksGenerators.generateRandomRsaKey(
+          keyId = Some(Generators.generateString(withSize = 16))
+        )
+      ),
+      oauthProviders = oauthProviders,
+      manageProviders = manageProviders.copy(realmStore = createFailingRealmStore(failingGet = true)),
+      manageConfig = manageConfig
+    )
+
+    endpoint.start(
+      hostname = "localhost",
+      port = endpointPort
+    )
+
+    val credentials = OAuth2BearerToken("some-token")
+
+    Http()
+      .singleRequest(
+        request = HttpRequest(
+          method = HttpMethods.GET,
+          uri = s"http://localhost:$endpointPort/manage/master/realms/some-realm"
+        ).addCredentials(credentials)
+      )
+      .map { response =>
+        response.status should be(StatusCodes.InternalServerError)
+        Unmarshal(response.entity).to[String].await should startWith(
+          "Failed to process request; failure reference is"
+        )
+      }
+  }
+
+  private val manageConfig = Config(
+    clientSecrets = Secret.ClientConfig(
+      algorithm = "PBKDF2WithHmacSHA512",
+      iterations = 10000,
+      derivedKeySize = 32,
+      saltSize = 16,
+      authenticationDelay = 20.millis
+    ),
+    ownerSecrets = Secret.ResourceOwnerConfig(
+      algorithm = "PBKDF2WithHmacSHA512",
+      iterations = 10000,
+      derivedKeySize = 32,
+      saltSize = 16,
+      authenticationDelay = 20.millis
+    )
+  )
+}

--- a/identity/src/test/scala/stasis/test/specs/unit/identity/api/JwksSpec.scala
+++ b/identity/src/test/scala/stasis/test/specs/unit/identity/api/JwksSpec.scala
@@ -1,0 +1,32 @@
+package stasis.test.specs.unit.identity.api
+
+import akka.http.scaladsl.model.StatusCodes
+import play.api.libs.json.{JsArray, JsObject, JsString}
+import stasis.identity.api.Jwks
+import stasis.test.specs.unit.core.security.jwt.mocks.MockJwksGenerators
+import stasis.test.specs.unit.identity.RouteTest
+import stasis.test.specs.unit.identity.model.Generators
+
+class JwksSpec extends RouteTest {
+  import de.heikoseeberger.akkahttpplayjson.PlayJsonSupport._
+
+  "JWKs routes" should "provide a list of available JSON web keys" in {
+    val expectedKeys =
+      Generators.generateSeq(
+        min = 1,
+        max = 3,
+        g = MockJwksGenerators.generateRandomRsaKey(
+          keyId = Some(Generators.generateString(withSize = 16))
+        )
+      )
+
+    val jwks = new Jwks(keys = expectedKeys)
+
+    Get("/jwks.json") ~> jwks.routes ~> check {
+      status should be(StatusCodes.OK)
+      responseAs[JsObject].fields should contain(
+        "keys" -> JsArray(expectedKeys.map(jwk => JsString(jwk.toJson)))
+      )
+    }
+  }
+}

--- a/identity/src/test/scala/stasis/test/specs/unit/identity/api/ManageSpec.scala
+++ b/identity/src/test/scala/stasis/test/specs/unit/identity/api/ManageSpec.scala
@@ -1,0 +1,128 @@
+package stasis.test.specs.unit.identity.api
+
+import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.model.headers.OAuth2BearerToken
+import play.api.libs.json._
+import stasis.identity.api.Formats._
+import stasis.identity.api.Manage
+import stasis.identity.api.manage.setup.Config
+import stasis.identity.model.apis.Api
+import stasis.identity.model.clients.Client
+import stasis.identity.model.realms.Realm
+import stasis.identity.model.secrets.Secret
+import stasis.test.specs.unit.identity.RouteTest
+import stasis.test.specs.unit.identity.api.manage.ManageFixtures
+import stasis.test.specs.unit.identity.model.Generators
+
+import scala.concurrent.duration._
+
+class ManageSpec extends RouteTest with ManageFixtures {
+  import de.heikoseeberger.akkahttpplayjson.PlayJsonSupport._
+
+  "Manage routes" should "handle realm management requests" in {
+    val providers = createManageProviders()
+    val manage = new Manage(providers, config)
+
+    val expectedRealm = Generators.generateRealm
+
+    providers.realmStore.put(expectedRealm).await
+    Get(s"/master/realms/${expectedRealm.id}").addCredentials(credentials) ~> manage.routes ~> check {
+      status should be(StatusCodes.OK)
+      responseAs[Realm] should be(expectedRealm)
+    }
+  }
+
+  they should "handle authorization code management requests" in {
+    val providers = createManageProviders()
+    val manage = new Manage(providers, config)
+
+    val client = Client.generateId()
+    val code = Generators.generateAuthorizationCode
+    val owner = Generators.generateResourceOwner
+
+    providers.codeStore.put(client, code, owner, scope = None).await
+    Get(s"/master/codes/$client").addCredentials(credentials) ~> manage.routes ~> check {
+      status should be(StatusCodes.OK)
+      responseAs[JsObject].fields should contain("code" -> JsString(code.value))
+    }
+  }
+
+  they should "handle refresh token management requests" in {
+    val providers = createManageProviders()
+    val manage = new Manage(providers, config)
+
+    val client = Client.generateId()
+    val token = Generators.generateRefreshToken
+    val owner = Generators.generateResourceOwner
+
+    providers.tokenStore.put(client, token, owner, scope = None).await
+    Get(s"/master/tokens/$client").addCredentials(credentials) ~> manage.routes ~> check {
+      status should be(StatusCodes.OK)
+      responseAs[JsObject].fields should contain("token" -> JsString(token.value))
+    }
+  }
+
+  they should "handle API management requests" in {
+    val providers = createManageProviders()
+    val manage = new Manage(providers, config)
+
+    val realm = Generators.generateRealm
+    val expectedApi = Generators.generateApi.copy(realm = realm.id)
+
+    providers.realmStore.put(realm).await
+    providers.apiStore.put(expectedApi).await
+    Get(s"/${realm.id}/apis/${expectedApi.id}").addCredentials(credentials) ~> manage.routes ~> check {
+      status should be(StatusCodes.OK)
+      responseAs[Api] should be(expectedApi)
+    }
+  }
+
+  they should "handle client management requests" in {
+    val providers = createManageProviders()
+    val manage = new Manage(providers, config)
+
+    val realm = Generators.generateRealm
+    val expectedClient = Generators.generateClient.copy(realm = realm.id)
+
+    providers.realmStore.put(realm).await
+    providers.clientStore.put(expectedClient).await
+    Get(s"/${realm.id}/clients/${expectedClient.id}").addCredentials(credentials) ~> manage.routes ~> check {
+      status should be(StatusCodes.OK)
+      responseAs[JsObject].fields should contain("id" -> JsString(expectedClient.id.toString))
+    }
+  }
+
+  they should "handle resource owner management requests" in {
+    val providers = createManageProviders()
+    val manage = new Manage(providers, config)
+
+    val realm = Generators.generateRealm
+    val expectedOwner = Generators.generateResourceOwner.copy(realm = realm.id)
+
+    providers.realmStore.put(realm).await
+    providers.ownerStore.put(expectedOwner).await
+    Get(s"/${realm.id}/owners/${expectedOwner.username}").addCredentials(credentials) ~> manage.routes ~> check {
+      status should be(StatusCodes.OK)
+      responseAs[JsObject].fields should contain("username" -> JsString(expectedOwner.username))
+    }
+  }
+
+  private val config = Config(
+    clientSecrets = Secret.ClientConfig(
+      algorithm = "PBKDF2WithHmacSHA512",
+      iterations = 10000,
+      derivedKeySize = 32,
+      saltSize = 16,
+      authenticationDelay = 20.millis
+    ),
+    ownerSecrets = Secret.ResourceOwnerConfig(
+      algorithm = "PBKDF2WithHmacSHA512",
+      iterations = 10000,
+      derivedKeySize = 32,
+      saltSize = 16,
+      authenticationDelay = 20.millis
+    )
+  )
+
+  private val credentials = OAuth2BearerToken("some-token")
+}

--- a/identity/src/test/scala/stasis/test/specs/unit/identity/api/OAuthSpec.scala
+++ b/identity/src/test/scala/stasis/test/specs/unit/identity/api/OAuthSpec.scala
@@ -1,0 +1,310 @@
+package stasis.test.specs.unit.identity.api
+
+import akka.http.scaladsl.model
+import akka.http.scaladsl.model.headers.{BasicHttpCredentials, CacheDirectives}
+import akka.http.scaladsl.model.{ContentTypes, StatusCodes, Uri}
+import stasis.identity.api.OAuth
+import stasis.identity.api.oauth.directives.AudienceExtraction
+import stasis.identity.model.secrets.Secret
+import stasis.test.specs.unit.identity.RouteTest
+import stasis.test.specs.unit.identity.api.oauth.OAuthFixtures
+import stasis.test.specs.unit.identity.model.Generators
+
+class OAuthSpec extends RouteTest with OAuthFixtures {
+  "OAuth routes" should "handle code authorization requests" in {
+    val (stores, secrets, providers) = createOAuthFixtures()
+    val oauth = new OAuth(providers)
+
+    val realm = Generators.generateRealm
+    val client = Generators.generateClient.copy(realm = realm.id)
+    val api = Generators.generateApi
+
+    val rawPassword = "some-password"
+    val salt = Generators.generateString(withSize = secrets.owner.saltSize)
+    val owner = Generators.generateResourceOwner.copy(
+      realm = realm.id,
+      password = Secret.derive(rawPassword, salt)(secrets.owner),
+      salt = salt
+    )
+    val credentials = BasicHttpCredentials(owner.username, rawPassword)
+
+    val state = Generators.generateString(withSize = 16)
+    val scope = s"${AudienceExtraction.UrnPrefix}:${api.id}"
+
+    stores.realms.put(realm).await
+    stores.clients.put(client).await
+    stores.owners.put(owner).await
+    stores.apis.put(api).await
+    Get(
+      s"/${realm.id}/authorization?response_type=code&client_id=${client.id}&scope=$scope&state=$state"
+    ).addCredentials(credentials) ~> oauth.routes ~> check {
+      status should be(StatusCodes.Found)
+      stores.codes.get(client.id).await match {
+        case Some(storedCode) =>
+          headers should contain(
+            model.headers.Location(
+              Uri(
+                s"${client.redirectUri}" +
+                  s"?code=${storedCode.code.value}" +
+                  s"&state=$state" +
+                  s"&scope=$scope"
+              )
+            )
+          )
+
+        case None =>
+          fail("Unexpected response received; no authorization code found")
+      }
+    }
+  }
+
+  they should "handle token authorization requests" in {
+    val (stores, secrets, providers) = createOAuthFixtures()
+    val oauth = new OAuth(providers)
+
+    val realm = Generators.generateRealm
+    val client = Generators.generateClient.copy(realm = realm.id)
+    val api = Generators.generateApi
+
+    val rawPassword = "some-password"
+    val salt = Generators.generateString(withSize = secrets.owner.saltSize)
+    val owner = Generators.generateResourceOwner.copy(
+      realm = realm.id,
+      password = Secret.derive(rawPassword, salt)(secrets.owner),
+      salt = salt
+    )
+    val credentials = BasicHttpCredentials(owner.username, rawPassword)
+
+    val scope = s"${AudienceExtraction.UrnPrefix}:${api.id}"
+    val state = Generators.generateString(withSize = 16)
+
+    stores.realms.put(realm).await
+    stores.clients.put(client).await
+    stores.owners.put(owner).await
+    stores.apis.put(api).await
+    Get(
+      s"/${realm.id}/authorization?response_type=token&client_id=${client.id}&scope=$scope&state=$state"
+    ).addCredentials(credentials) ~> oauth.routes ~> check {
+      status should be(StatusCodes.Found)
+
+      headers.find(_.is("location")) match {
+        case Some(header) =>
+          val headerValue = header.value()
+          headerValue.contains("access_token") should be(true)
+          headerValue.contains("token_type=bearer") should be(true)
+          headerValue.contains(s"expires_in=${client.tokenExpiration.value}") should be(true)
+          headerValue.contains(s"state=$state") should be(true)
+          headerValue.contains(s"scope=$scope") should be(true)
+
+        case None =>
+          fail(s"Unexpected response received; no location found in headers [$headers]")
+      }
+    }
+  }
+
+  they should "reject authorization requests with invalid response types" in {
+    val (stores, _, providers) = createOAuthFixtures()
+    val oauth = new OAuth(providers)
+
+    val realm = Generators.generateRealm
+    val responseType = "some-response"
+
+    stores.realms.put(realm).await
+    Get(
+      s"/${realm.id}/authorization?response_type=$responseType"
+    ) ~> oauth.routes ~> check {
+      status should be(StatusCodes.BadRequest)
+      responseAs[String] should be(
+        s"Realm [${realm.id}]: The request includes an invalid response type: [$responseType]"
+      )
+    }
+  }
+
+  they should "handle authorization code token grants" in {
+    val (stores, secrets, providers) = createOAuthFixtures()
+    val oauth = new OAuth(providers)
+
+    val realm = Generators.generateRealm
+    val owner = Generators.generateResourceOwner
+    val code = Generators.generateAuthorizationCode
+    val api = Generators.generateApi
+
+    val rawPassword = "some-password"
+    val salt = Generators.generateString(withSize = secrets.client.saltSize)
+    val client = Generators.generateClient.copy(
+      realm = realm.id,
+      secret = Secret.derive(rawPassword, salt)(secrets.client),
+      salt = salt
+    )
+    val credentials = BasicHttpCredentials(client.id.toString, rawPassword)
+
+    stores.realms.put(realm).await
+    stores.clients.put(client).await
+    stores.owners.put(owner).await
+    stores.apis.put(api).await
+    stores.codes.put(client.id, code, owner, scope = Some(s"${AudienceExtraction.UrnPrefix}:${api.id}")).await
+    Post(
+      s"/${realm.id}/token?grant_type=authorization_code&code=${code.value}&client_id=${client.id}"
+    ).addCredentials(credentials) ~> oauth.routes ~> check {
+      status should be(StatusCodes.OK)
+      headers should contain(model.headers.`Content-Type`(ContentTypes.`application/json`))
+      headers should contain(model.headers.`Cache-Control`(CacheDirectives.`no-store`))
+
+      val actualResponse = responseAs[String]
+      actualResponse.contains("access_token") should be(true)
+      actualResponse.contains("token_type") should be(true)
+      actualResponse.contains("expires_in") should be(true)
+      actualResponse.contains("refresh_token") should be(true)
+
+      val refreshTokenGenerated = stores.tokens.get(client.id).await.nonEmpty
+      refreshTokenGenerated should be(true)
+    }
+  }
+
+  they should "handle client credentials token grants" in {
+    val (stores, secrets, providers) = createOAuthFixtures()
+    val oauth = new OAuth(providers)
+
+    val realm = Generators.generateRealm
+
+    val rawPassword = "some-password"
+    val salt = Generators.generateString(withSize = secrets.client.saltSize)
+    val client = Generators.generateClient.copy(
+      realm = realm.id,
+      secret = Secret.derive(rawPassword, salt)(secrets.client),
+      salt = salt
+    )
+    val credentials = BasicHttpCredentials(client.id.toString, rawPassword)
+
+    val scope = s"${AudienceExtraction.UrnPrefix}:${client.id}"
+
+    stores.realms.put(realm).await
+    stores.clients.put(client).await
+    Post(
+      s"/${realm.id}/token?grant_type=client_credentials&scope=$scope"
+    ).addCredentials(credentials) ~> oauth.routes ~> check {
+      status should be(StatusCodes.OK)
+
+      headers should contain(model.headers.`Content-Type`(ContentTypes.`application/json`))
+      headers should contain(model.headers.`Cache-Control`(CacheDirectives.`no-store`))
+
+      val actualResponse = responseAs[String]
+      actualResponse.contains("access_token") should be(true)
+      actualResponse.contains("token_type") should be(true)
+      actualResponse.contains("expires_in") should be(true)
+      actualResponse.contains("scope") should be(true)
+    }
+  }
+
+  they should "handle refresh token grants" in {
+    val (stores, secrets, providers) = createOAuthFixtures()
+    val oauth = new OAuth(providers)
+
+    val realm = Generators.generateRealm
+    val owner = Generators.generateResourceOwner.copy(realm = realm.id)
+    val api = Generators.generateApi
+
+    val rawPassword = "some-password"
+    val salt = Generators.generateString(withSize = secrets.client.saltSize)
+    val client = Generators.generateClient.copy(
+      realm = realm.id,
+      secret = Secret.derive(rawPassword, salt)(secrets.client),
+      salt = salt
+    )
+    val credentials = BasicHttpCredentials(client.id.toString, rawPassword)
+
+    val token = Generators.generateRefreshToken
+    val scope = s"${AudienceExtraction.UrnPrefix}:${api.id}"
+
+    stores.realms.put(realm).await
+    stores.owners.put(owner).await
+    stores.apis.put(api).await
+    stores.clients.put(client).await
+    stores.tokens.put(client.id, token, owner, Some(scope)).await
+    Post(
+      s"/${realm.id}/token?grant_type=refresh_token&refresh_token=${token.value}&scope=$scope"
+    ).addCredentials(credentials) ~> oauth.routes ~> check {
+      status should be(StatusCodes.OK)
+
+      headers should contain(model.headers.`Content-Type`(ContentTypes.`application/json`))
+      headers should contain(model.headers.`Cache-Control`(CacheDirectives.`no-store`))
+
+      val actualResponse = responseAs[String]
+      actualResponse.contains("access_token") should be(true)
+      actualResponse.contains("token_type") should be(true)
+      actualResponse.contains("expires_in") should be(true)
+      actualResponse.contains("refresh_token") should be(true)
+      actualResponse.contains("scope") should be(true)
+
+      val newTokenGenerated = stores.tokens.get(client.id).await.exists(_.token != token)
+      newTokenGenerated should be(true)
+    }
+  }
+
+  they should "handle password token grants" in {
+    val (stores, secrets, providers) = createOAuthFixtures()
+    val oauth = new OAuth(providers)
+
+    val realm = Generators.generateRealm
+    val api = Generators.generateApi
+
+    val clientRawPassword = "some-password"
+    val clientSalt = Generators.generateString(withSize = secrets.client.saltSize)
+    val client = Generators.generateClient.copy(
+      realm = realm.id,
+      secret = Secret.derive(clientRawPassword, clientSalt)(secrets.client),
+      salt = clientSalt
+    )
+    val credentials = BasicHttpCredentials(client.id.toString, clientRawPassword)
+
+    val ownerRawPassword = "some-password"
+    val ownerSalt = Generators.generateString(withSize = secrets.owner.saltSize)
+    val owner = Generators.generateResourceOwner.copy(
+      realm = realm.id,
+      password = Secret.derive(ownerRawPassword, ownerSalt)(secrets.owner),
+      salt = ownerSalt
+    )
+    val scope = s"${AudienceExtraction.UrnPrefix}:${api.id}"
+
+    stores.realms.put(realm).await
+    stores.apis.put(api).await
+    stores.clients.put(client).await
+    stores.owners.put(owner).await
+    Post(
+      s"/${realm.id}/token?grant_type=password&username=${owner.username}&password=$ownerRawPassword&scope=$scope"
+    ).addCredentials(credentials) ~> oauth.routes ~> check {
+      status should be(StatusCodes.OK)
+
+      headers should contain(model.headers.`Content-Type`(ContentTypes.`application/json`))
+      headers should contain(model.headers.`Cache-Control`(CacheDirectives.`no-store`))
+
+      val actualResponse = responseAs[String]
+      actualResponse.contains("access_token") should be(true)
+      actualResponse.contains("token_type") should be(true)
+      actualResponse.contains("expires_in") should be(true)
+      actualResponse.contains("refresh_token") should be(true)
+      actualResponse.contains("scope") should be(true)
+
+      val refreshTokenGenerated = stores.tokens.get(client.id).await.nonEmpty
+      refreshTokenGenerated should be(true)
+    }
+  }
+
+  they should "reject token grants with invalid grant type" in {
+    val (stores, _, providers) = createOAuthFixtures()
+    val oauth = new OAuth(providers)
+
+    val realm = Generators.generateRealm
+    val grantType = "some-grant"
+
+    stores.realms.put(realm).await
+    Post(
+      s"/${realm.id}/token?grant_type=$grantType"
+    ) ~> oauth.routes ~> check {
+      status should be(StatusCodes.BadRequest)
+      responseAs[String] should be(
+        s"Realm [${realm.id}]: The request includes an invalid grant type: [$grantType]"
+      )
+    }
+  }
+}

--- a/identity/src/test/scala/stasis/test/specs/unit/identity/api/directives/BaseApiDirectiveSpec.scala
+++ b/identity/src/test/scala/stasis/test/specs/unit/identity/api/directives/BaseApiDirectiveSpec.scala
@@ -1,0 +1,60 @@
+package stasis.test.specs.unit.identity.api.directives
+
+import java.util.concurrent.atomic.AtomicInteger
+
+import akka.http.scaladsl.model.{ContentTypes, HttpEntity, StatusCodes}
+import akka.http.scaladsl.server.Directives
+import akka.stream.scaladsl.Source
+import akka.stream.{ActorMaterializer, Materializer}
+import akka.util.ByteString
+import stasis.identity.api.Formats._
+import stasis.identity.api.directives.BaseApiDirective
+import stasis.test.specs.unit.identity.RouteTest
+
+class BaseApiDirectiveSpec extends RouteTest {
+  "A BaseApiDirective" should "discard entities" in {
+    val directive = new BaseApiDirective {
+      override implicit protected def mat: Materializer = ActorMaterializer()
+    }
+
+    val route = directive.discardEntity {
+      Directives.complete(StatusCodes.OK)
+    }
+
+    val counter = new AtomicInteger(0)
+
+    val content = Source.single(ByteString("some-content")).map { bytes =>
+      counter.incrementAndGet()
+      bytes
+    }
+    val entity = HttpEntity(ContentTypes.`application/octet-stream`, content)
+
+    Post().withEntity(entity) ~> route ~> check {
+      status should be(StatusCodes.OK)
+      counter.get should be(0)
+    }
+  }
+
+  it should "consume entities" in {
+    val directive = new BaseApiDirective {
+      override implicit protected def mat: Materializer = ActorMaterializer()
+    }
+
+    val route = directive.consumeEntity {
+      Directives.complete(StatusCodes.OK)
+    }
+
+    val counter = new AtomicInteger(0)
+
+    val content = Source.single(ByteString("some-content")).map { bytes =>
+      counter.incrementAndGet()
+      bytes
+    }
+    val entity = HttpEntity(ContentTypes.`application/octet-stream`, content)
+
+    Post().withEntity(entity) ~> route ~> check {
+      status should be(StatusCodes.OK)
+      counter.get should be(1)
+    }
+  }
+}

--- a/identity/src/test/scala/stasis/test/specs/unit/identity/api/manage/ApisSpec.scala
+++ b/identity/src/test/scala/stasis/test/specs/unit/identity/api/manage/ApisSpec.scala
@@ -1,0 +1,84 @@
+package stasis.test.specs.unit.identity.api.manage
+
+import akka.http.scaladsl.model.StatusCodes
+import stasis.identity.api.Formats._
+import stasis.identity.api.manage.Apis
+import stasis.identity.api.manage.requests.CreateApi
+import stasis.identity.model.apis.Api
+import stasis.test.specs.unit.identity.RouteTest
+import stasis.test.specs.unit.identity.model.Generators
+
+import scala.concurrent.Future
+
+class ApisSpec extends RouteTest {
+  import de.heikoseeberger.akkahttpplayjson.PlayJsonSupport._
+
+  "Apis routes" should "respond with all APIs" in {
+    val store = createApiStore()
+    val realm = Generators.generateRealmId
+    val apis = new Apis(store)
+
+    val expectedApis = Generators
+      .generateSeq(min = 2, g = Generators.generateApi)
+      .map(_.copy(realm = realm))
+
+    Future.sequence(expectedApis.map(store.put)).await
+    Get() ~> apis.routes(user, realm) ~> check {
+      status should be(StatusCodes.OK)
+      responseAs[Seq[Api]].sortBy(_.id) should be(expectedApis.sortBy(_.id))
+    }
+  }
+
+  they should "create new APIs" in {
+    val store = createApiStore()
+    val realm = Generators.generateRealmId
+    val apis = new Apis(store)
+
+    val request = CreateApi(id = "some-api")
+
+    Post().withEntity(request) ~> apis.routes(user, realm) ~> check {
+      status should be(StatusCodes.OK)
+      store.get(request.id).await should be(Some(request.toApi(realm)))
+    }
+  }
+
+  they should "respond with existing APIs" in {
+    val store = createApiStore()
+    val realm = Generators.generateRealmId
+    val apis = new Apis(store)
+
+    val expectedApi = Generators.generateApi.copy(realm = realm)
+
+    store.put(expectedApi).await
+    Get(s"/${expectedApi.id}") ~> apis.routes(user, realm) ~> check {
+      status should be(StatusCodes.OK)
+      responseAs[Api] should be(expectedApi)
+    }
+  }
+
+  they should "delete existing APIs" in {
+    val store = createApiStore()
+    val realm = Generators.generateRealmId
+    val apis = new Apis(store)
+
+    val api = Generators.generateApi.copy(realm = realm)
+
+    store.put(api).await
+    Delete(s"/${api.id}") ~> apis.routes(user, realm) ~> check {
+      status should be(StatusCodes.OK)
+      store.apis.await should be(Map.empty)
+    }
+  }
+
+  they should "not delete missing APIs" in {
+    val store = createApiStore()
+    val realm = Generators.generateRealmId
+    val apis = new Apis(store)
+
+    Delete("/some-api") ~> apis.routes(user, realm) ~> check {
+      status should be(StatusCodes.NotFound)
+    }
+  }
+
+  private val user = "some-user"
+}

--- a/identity/src/test/scala/stasis/test/specs/unit/identity/api/manage/ClientsSpec.scala
+++ b/identity/src/test/scala/stasis/test/specs/unit/identity/api/manage/ClientsSpec.scala
@@ -1,0 +1,192 @@
+package stasis.test.specs.unit.identity.api.manage
+
+import akka.http.scaladsl.model.StatusCodes
+import akka.util.ByteString
+import stasis.identity.api.Formats._
+import stasis.identity.api.manage.Clients
+import stasis.identity.api.manage.requests.{CreateClient, UpdateClient, UpdateClientCredentials}
+import stasis.identity.api.manage.responses.CreatedClient
+import stasis.identity.model.Seconds
+import stasis.identity.model.clients.Client
+import stasis.identity.model.realms.Realm
+import stasis.identity.model.secrets.Secret
+import stasis.test.specs.unit.identity.RouteTest
+import stasis.test.specs.unit.identity.api.manage.ClientsSpec.PartialClient
+import stasis.test.specs.unit.identity.model.Generators
+
+import scala.concurrent.Future
+import scala.concurrent.duration._
+
+class ClientsSpec extends RouteTest {
+  import de.heikoseeberger.akkahttpplayjson.PlayJsonSupport._
+
+  "Clients routes" should "respond with all clients" in {
+    val store = createClientStore()
+    val realm = Generators.generateRealmId
+    val clients = new Clients(store, secretConfig)
+
+    val secret = Secret(ByteString("some-secret"))
+    val salt = "some-salt"
+
+    val expectedClients = Generators
+      .generateSeq(min = 2, g = Generators.generateClient)
+      .map(_.copy(realm = realm, secret = secret, salt = salt))
+
+    Future.sequence(expectedClients.map(store.put)).await
+    Get() ~> clients.routes(user, realm) ~> check {
+      status should be(StatusCodes.OK)
+      responseAs[Seq[PartialClient]].map(_.toClient(secret, salt)).sortBy(_.id) should be(expectedClients.sortBy(_.id))
+    }
+  }
+
+  they should "create new clients" in {
+    val store = createClientStore()
+    val realm = Generators.generateRealmId
+    val clients = new Clients(store, secretConfig)
+
+    val request = CreateClient(
+      allowedScopes = Seq("some-scope"),
+      redirectUri = "some-uri",
+      tokenExpiration = 3.seconds,
+      rawSecret = "some-secret"
+    )
+
+    Post().withEntity(request) ~> clients.routes(user, realm) ~> check {
+      status should be(StatusCodes.OK)
+      val expectedClient = store.clients.await.values.toList match {
+        case client :: Nil => client
+        case other         => fail(s"Unexpected response received: [$other]")
+      }
+
+      responseAs[CreatedClient] should be(CreatedClient(client = expectedClient.id))
+    }
+  }
+
+  they should "update existing client credentials" in {
+    val store = createClientStore()
+    val realm = Generators.generateRealmId
+    val clients = new Clients(store, secretConfig)
+
+    val client = Generators.generateClient.copy(realm = realm)
+    val request = UpdateClientCredentials(rawSecret = "some-secret")
+
+    store.put(client).await
+    Put(s"/${client.id}/credentials").withEntity(request) ~> clients.routes(user, realm) ~> check {
+      status should be(StatusCodes.OK)
+      store.get(client.id).await match {
+        case Some(updatedClient) =>
+          updatedClient.secret.isSameAs(request.rawSecret, updatedClient.salt)(secretConfig) should be(true)
+
+        case None =>
+          fail("Unexpected response received; no client found")
+      }
+    }
+  }
+
+  they should "respond with existing clients" in {
+    val store = createClientStore()
+    val realm = Generators.generateRealmId
+    val clients = new Clients(store, secretConfig)
+
+    val secret = Secret(ByteString("some-secret"))
+    val salt = "some-salt"
+
+    val expectedClient = Generators.generateClient.copy(realm = realm, secret = secret, salt = salt)
+
+    store.put(expectedClient).await
+    Get(s"/${expectedClient.id}") ~> clients.routes(user, realm) ~> check {
+      status should be(StatusCodes.OK)
+      responseAs[PartialClient].toClient(secret, salt) should be(expectedClient)
+    }
+  }
+
+  they should "update existing clients" in {
+    val store = createClientStore()
+    val realm = Generators.generateRealmId
+    val clients = new Clients(store, secretConfig)
+
+    val client = Generators.generateClient.copy(realm = realm)
+    val request = UpdateClient(
+      allowedScopes = Seq("some-scope"),
+      tokenExpiration = 3.seconds,
+      active = false
+    )
+
+    store.put(client).await
+    Put(s"/${client.id}").withEntity(request) ~> clients.routes(user, realm) ~> check {
+      status should be(StatusCodes.OK)
+      store.get(client.id).await should be(
+        Some(
+          client.copy(
+            allowedScopes = request.allowedScopes,
+            tokenExpiration = request.tokenExpiration,
+            active = request.active
+          )
+        )
+      )
+    }
+  }
+
+  they should "delete existing clients" in {
+    val store = createClientStore()
+    val realm = Generators.generateRealmId
+    val clients = new Clients(store, secretConfig)
+
+    val secret = Secret(ByteString("some-secret"))
+    val salt = "some-salt"
+
+    val client = Generators.generateClient.copy(realm = realm, secret = secret, salt = salt)
+
+    store.put(client).await
+    Delete(s"/${client.id}") ~> clients.routes(user, realm) ~> check {
+      status should be(StatusCodes.OK)
+      store.clients.await should be(Map.empty)
+    }
+  }
+
+  they should "not delete missing clients" in {
+    val store = createClientStore()
+    val realm = Generators.generateRealmId
+    val clients = new Clients(store, secretConfig)
+
+    Delete(s"/${Client.generateId()}") ~> clients.routes(user, realm) ~> check {
+      status should be(StatusCodes.NotFound)
+    }
+  }
+
+  private val user = "some-user"
+
+  private val secretConfig = Secret.ClientConfig(
+    algorithm = "PBKDF2WithHmacSHA512",
+    iterations = 10000,
+    derivedKeySize = 32,
+    saltSize = 16,
+    authenticationDelay = 20.millis
+  )
+}
+
+object ClientsSpec {
+  import play.api.libs.json._
+
+  implicit val partialClientReads: Reads[PartialClient] = Json.reads[PartialClient]
+
+  final case class PartialClient(
+    id: Client.Id,
+    realm: Realm.Id,
+    allowedScopes: Seq[String],
+    redirectUri: String,
+    tokenExpiration: Seconds,
+    active: Boolean
+  ) {
+    def toClient(secret: Secret, salt: String): Client = Client(
+      id = id,
+      realm = realm,
+      allowedScopes = allowedScopes,
+      redirectUri = redirectUri,
+      tokenExpiration = tokenExpiration,
+      secret = secret,
+      salt = salt,
+      active = active
+    )
+  }
+}

--- a/identity/src/test/scala/stasis/test/specs/unit/identity/api/manage/CodesSpec.scala
+++ b/identity/src/test/scala/stasis/test/specs/unit/identity/api/manage/CodesSpec.scala
@@ -1,0 +1,102 @@
+package stasis.test.specs.unit.identity.api.manage
+
+import akka.http.scaladsl.model.StatusCodes
+import stasis.identity.api.Formats._
+import stasis.identity.api.manage.Codes
+import stasis.identity.model.clients.Client
+import stasis.test.specs.unit.identity.RouteTest
+import stasis.test.specs.unit.identity.api.manage.CodesSpec.PartialStoredAuthorizationCode
+import stasis.test.specs.unit.identity.model.Generators
+
+import scala.concurrent.Future
+
+class CodesSpec extends RouteTest {
+  import de.heikoseeberger.akkahttpplayjson.PlayJsonSupport._
+
+  "Codes routes" should "respond with all codes" in {
+    val store = createCodeStore()
+    val codes = new Codes(store)
+
+    val owner = Generators.generateResourceOwner
+    val expectedCodes = Generators.generateSeq(min = 2, g = Generators.generateAuthorizationCode)
+
+    Future.sequence(expectedCodes.map(code => store.put(Client.generateId(), code, owner, scope = None))).await
+    Get() ~> codes.routes(user) ~> check {
+      status should be(StatusCodes.OK)
+      responseAs[Seq[PartialStoredAuthorizationCode]].sortBy(_.code) should be(
+        expectedCodes
+          .map(code => PartialStoredAuthorizationCode(code.value, owner.username, scope = None))
+          .sortBy(_.code)
+      )
+    }
+  }
+
+  they should "respond with existing authorization codes for clients" in {
+    val store = createCodeStore()
+    val codes = new Codes(store)
+
+    val client = Client.generateId()
+    val owner = Generators.generateResourceOwner
+    val code = Generators.generateAuthorizationCode
+
+    store.put(client, code, owner, scope = None).await
+    Get(s"/$client") ~> codes.routes(user) ~> check {
+      status should be(StatusCodes.OK)
+      responseAs[PartialStoredAuthorizationCode] should be(
+        PartialStoredAuthorizationCode(code.value, owner.username, scope = None)
+      )
+    }
+  }
+
+  they should "fail if no authorization codes are available for a client" in {
+    val store = createCodeStore()
+    val codes = new Codes(store)
+
+    val owner = Generators.generateResourceOwner
+    val code = Generators.generateAuthorizationCode
+
+    store.put(Client.generateId(), code, owner, scope = None).await
+    Get(s"/${Client.generateId()}") ~> codes.routes(user) ~> check {
+      status should be(StatusCodes.NotFound)
+    }
+  }
+
+  they should "delete existing authorization codes" in {
+    val store = createCodeStore()
+    val codes = new Codes(store)
+
+    val client = Client.generateId()
+    val owner = Generators.generateResourceOwner
+    val code = Generators.generateAuthorizationCode
+
+    store.put(client, code, owner, scope = None).await
+    Delete(s"/$client") ~> codes.routes(user) ~> check {
+      status should be(StatusCodes.OK)
+      store.codes.await should be(Map.empty)
+    }
+  }
+
+  they should "not delete missing authorization codes" in {
+    val store = createCodeStore()
+    val codes = new Codes(store)
+
+    Delete(s"/${Client.generateId()}") ~> codes.routes(user) ~> check {
+      status should be(StatusCodes.NotFound)
+    }
+  }
+
+  private val user = "some-user"
+}
+
+object CodesSpec {
+  import play.api.libs.json._
+
+  implicit val partialStoredAuthorizationCodeReads: Reads[PartialStoredAuthorizationCode] =
+    Json.reads[PartialStoredAuthorizationCode]
+
+  final case class PartialStoredAuthorizationCode(
+    code: String,
+    owner: String,
+    scope: Option[String]
+  )
+}

--- a/identity/src/test/scala/stasis/test/specs/unit/identity/api/manage/ManageFixtures.scala
+++ b/identity/src/test/scala/stasis/test/specs/unit/identity/api/manage/ManageFixtures.scala
@@ -1,0 +1,43 @@
+package stasis.test.specs.unit.identity.api.manage
+
+import akka.http.scaladsl.model.headers.OAuth2BearerToken
+import stasis.core.persistence.backends.memory.MemoryBackend
+import stasis.identity.api.manage.setup.Providers
+import stasis.identity.model.apis.{Api, ApiStore}
+import stasis.identity.model.clients.{Client, ClientStore}
+import stasis.identity.model.codes.{AuthorizationCodeStore, StoredAuthorizationCode}
+import stasis.identity.model.owners.{ResourceOwner, ResourceOwnerStore}
+import stasis.identity.model.realms.{Realm, RealmStore}
+import stasis.identity.model.tokens.{RefreshTokenStore, StoredRefreshToken}
+import stasis.test.specs.unit.identity.RouteTest
+import stasis.test.specs.unit.identity.model.Generators
+
+import scala.concurrent.Future
+import scala.concurrent.duration._
+
+trait ManageFixtures { _: RouteTest =>
+  def createManageProviders(expiration: FiniteDuration = 3.seconds) = Providers(
+    apiStore = ApiStore(
+      MemoryBackend[Api.Id, Api](name = s"api-store-${java.util.UUID.randomUUID()}")
+    ),
+    clientStore = ClientStore(
+      MemoryBackend[Client.Id, Client](name = s"client-store-${java.util.UUID.randomUUID()}")
+    ),
+    codeStore = AuthorizationCodeStore(
+      expiration = expiration,
+      MemoryBackend[Client.Id, StoredAuthorizationCode](name = s"code-store-${java.util.UUID.randomUUID()}")
+    ),
+    ownerStore = ResourceOwnerStore(
+      MemoryBackend[ResourceOwner.Id, ResourceOwner](name = s"owner-store-${java.util.UUID.randomUUID()}")
+    ),
+    realmStore = RealmStore(
+      MemoryBackend[Realm.Id, Realm](name = s"realm-store-${java.util.UUID.randomUUID()}")
+    ),
+    tokenStore = RefreshTokenStore(
+      expiration = expiration,
+      MemoryBackend[Client.Id, StoredRefreshToken](name = s"token-store-${java.util.UUID.randomUUID()}")
+    ),
+    ownerAuthenticator =
+      (_: OAuth2BearerToken) => Future.successful(Generators.generateResourceOwner.copy(realm = Realm.Master))
+  )
+}

--- a/identity/src/test/scala/stasis/test/specs/unit/identity/api/manage/OwnersSpec.scala
+++ b/identity/src/test/scala/stasis/test/specs/unit/identity/api/manage/OwnersSpec.scala
@@ -1,0 +1,181 @@
+package stasis.test.specs.unit.identity.api.manage
+
+import akka.http.scaladsl.model.StatusCodes
+import akka.util.ByteString
+import stasis.identity.api.Formats._
+import stasis.identity.api.manage.Owners
+import stasis.identity.api.manage.requests.{CreateOwner, UpdateOwner, UpdateOwnerCredentials}
+import stasis.identity.model.owners.ResourceOwner
+import stasis.identity.model.realms.Realm
+import stasis.identity.model.secrets.Secret
+import stasis.test.specs.unit.identity.RouteTest
+import stasis.test.specs.unit.identity.api.manage.OwnersSpec.PartialResourceOwner
+import stasis.test.specs.unit.identity.model.Generators
+
+import scala.concurrent.Future
+import scala.concurrent.duration._
+
+class OwnersSpec extends RouteTest {
+  import de.heikoseeberger.akkahttpplayjson.PlayJsonSupport._
+
+  "Owners routes" should "respond with all resource owners" in {
+    val store = createOwnerStore()
+    val realm = Generators.generateRealmId
+    val owners = new Owners(store, secretConfig)
+
+    val secret = Secret(ByteString("some-secret"))
+    val salt = "some-salt"
+
+    val expectedOwners = Generators
+      .generateSeq(min = 2, g = Generators.generateResourceOwner)
+      .map(_.copy(realm = realm, password = secret, salt = salt))
+
+    Future.sequence(expectedOwners.map(store.put)).await
+    Get() ~> owners.routes(user, realm) ~> check {
+      status should be(StatusCodes.OK)
+      responseAs[Seq[PartialResourceOwner]].map(_.toOwner(secret, salt)).sortBy(_.username) should be(
+        expectedOwners.sortBy(_.username))
+    }
+  }
+
+  they should "create new resource owners" in {
+    val store = createOwnerStore()
+    val realm = Generators.generateRealmId
+    val owners = new Owners(store, secretConfig)
+
+    val request = CreateOwner(
+      username = "some-user",
+      rawPassword = "some-password",
+      allowedScopes = Seq("some-scope")
+    )
+
+    Post().withEntity(request) ~> owners.routes(user, realm) ~> check {
+      status should be(StatusCodes.OK)
+      val createdOwner = store.owners.await.values.toList match {
+        case owner :: Nil => owner
+        case other        => fail(s"Unexpected response recieved; [$other]")
+      }
+
+      createdOwner.username should be(request.username)
+    }
+  }
+
+  they should "update existing resource owner credentials" in {
+    val store = createOwnerStore()
+    val realm = Generators.generateRealmId
+    val owners = new Owners(store, secretConfig)
+
+    val owner = Generators.generateResourceOwner.copy(realm = realm)
+    val request = UpdateOwnerCredentials(rawPassword = "some-password")
+
+    store.put(owner).await
+    Put(s"/${owner.username}/credentials").withEntity(request) ~> owners.routes(user, realm) ~> check {
+      status should be(StatusCodes.OK)
+      store.get(owner.username).await match {
+        case Some(updatedOwner) =>
+          updatedOwner.password.isSameAs(request.rawPassword, updatedOwner.salt)(secretConfig) should be(true)
+
+        case None =>
+          fail("Unexpected response received; no resource owner found")
+      }
+    }
+  }
+
+  they should "respond with existing resource owners" in {
+    val store = createOwnerStore()
+    val realm = Generators.generateRealmId
+    val owners = new Owners(store, secretConfig)
+
+    val secret = Secret(ByteString("some-secret"))
+    val salt = "some-salt"
+    val expectedOwner = Generators.generateResourceOwner.copy(realm = realm, password = secret, salt = salt)
+
+    store.put(expectedOwner).await
+    Get(s"/${expectedOwner.username}") ~> owners.routes(user, realm) ~> check {
+      status should be(StatusCodes.OK)
+      responseAs[PartialResourceOwner].toOwner(secret, salt) should be(expectedOwner)
+    }
+  }
+
+  they should "update existing resource owners" in {
+    val store = createOwnerStore()
+    val realm = Generators.generateRealmId
+    val owners = new Owners(store, secretConfig)
+
+    val owner = Generators.generateResourceOwner.copy(realm = realm)
+    val request = UpdateOwner(
+      allowedScopes = Seq("some-scope"),
+      active = false
+    )
+
+    store.put(owner).await
+    Put(s"/${owner.username}").withEntity(request) ~> owners.routes(user, realm) ~> check {
+      status should be(StatusCodes.OK)
+      store.get(owner.username).await should be(
+        Some(
+          owner.copy(
+            allowedScopes = request.allowedScopes,
+            active = request.active
+          )
+        )
+      )
+    }
+  }
+
+  they should "delete existing resource owners" in {
+    val store = createOwnerStore()
+    val realm = Generators.generateRealmId
+    val owners = new Owners(store, secretConfig)
+
+    val owner = Generators.generateResourceOwner.copy(realm = realm)
+
+    store.put(owner).await
+    Delete(s"/${owner.username}") ~> owners.routes(user, realm) ~> check {
+      status should be(StatusCodes.OK)
+      store.owners.await should be(Map.empty)
+    }
+  }
+
+  they should "not delete missing resource owners" in {
+    val store = createOwnerStore()
+    val realm = Generators.generateRealmId
+    val owners = new Owners(store, secretConfig)
+
+    Delete("/some-user") ~> owners.routes(user, realm) ~> check {
+      status should be(StatusCodes.NotFound)
+    }
+  }
+
+  private val user = "some-user"
+
+  private val secretConfig = Secret.ResourceOwnerConfig(
+    algorithm = "PBKDF2WithHmacSHA512",
+    iterations = 10000,
+    derivedKeySize = 32,
+    saltSize = 16,
+    authenticationDelay = 20.millis
+  )
+}
+
+object OwnersSpec {
+  import play.api.libs.json._
+
+  implicit val partialResourceOwnerReads: Reads[PartialResourceOwner] = Json.reads[PartialResourceOwner]
+
+  final case class PartialResourceOwner(
+    username: ResourceOwner.Id,
+    realm: Realm.Id,
+    allowedScopes: Seq[String],
+    active: Boolean
+  ) {
+    def toOwner(secret: Secret, salt: String): ResourceOwner =
+      ResourceOwner(
+        username = username,
+        password = secret,
+        salt = salt,
+        realm = realm,
+        allowedScopes = allowedScopes,
+        active = active
+      )
+  }
+}

--- a/identity/src/test/scala/stasis/test/specs/unit/identity/api/manage/RealmsSpec.scala
+++ b/identity/src/test/scala/stasis/test/specs/unit/identity/api/manage/RealmsSpec.scala
@@ -1,0 +1,88 @@
+package stasis.test.specs.unit.identity.api.manage
+
+import akka.http.scaladsl.model.StatusCodes
+import stasis.identity.api.Formats._
+import stasis.identity.api.manage.Realms
+import stasis.identity.api.manage.requests.CreateRealm
+import stasis.identity.model.realms.Realm
+import stasis.test.specs.unit.identity.RouteTest
+import stasis.test.specs.unit.identity.model.Generators
+
+import scala.concurrent.Future
+
+class RealmsSpec extends RouteTest {
+  import de.heikoseeberger.akkahttpplayjson.PlayJsonSupport._
+
+  "Realms routes" should "respond with all realms" in {
+    val store = createRealmStore()
+    val realms = new Realms(store)
+
+    val expectedRealms = Generators.generateSeq(min = 2, g = Generators.generateRealm)
+
+    Future.sequence(expectedRealms.map(store.put)).await
+    Get() ~> realms.routes(user) ~> check {
+      status should be(StatusCodes.OK)
+      responseAs[Seq[Realm]].sortBy(_.id) should be(expectedRealms.sortBy(_.id))
+    }
+  }
+
+  they should "create new realms" in {
+    val store = createRealmStore()
+    val realms = new Realms(store)
+
+    val request = CreateRealm(id = "some-realm", refreshTokensAllowed = true)
+
+    Post().withEntity(request) ~> realms.routes(user) ~> check {
+      status should be(StatusCodes.OK)
+      store.get(request.id).await should be(
+        Some(Realm(id = request.id, refreshTokensAllowed = request.refreshTokensAllowed))
+      )
+    }
+  }
+
+  they should "respond with existing realms" in {
+    val store = createRealmStore()
+    val realms = new Realms(store)
+
+    val expectedRealm = Generators.generateRealm
+
+    store.put(expectedRealm).await
+    Get(s"/${expectedRealm.id}") ~> realms.routes(user) ~> check {
+      status should be(StatusCodes.OK)
+      responseAs[Realm] should be(expectedRealm)
+    }
+  }
+
+  they should "fail if a realm is missing" in {
+    val store = createRealmStore()
+    val realms = new Realms(store)
+
+    Get(s"/some-realm") ~> realms.routes(user) ~> check {
+      status should be(StatusCodes.NotFound)
+    }
+  }
+
+  they should "delete existing realms" in {
+    val store = createRealmStore()
+    val realms = new Realms(store)
+
+    val realm = Generators.generateRealm
+
+    store.put(realm).await
+    Delete(s"/${realm.id}") ~> realms.routes(user) ~> check {
+      status should be(StatusCodes.OK)
+      store.realms.await should be(Map.empty)
+    }
+  }
+
+  they should "not delete missing realms" in {
+    val store = createRealmStore()
+    val realms = new Realms(store)
+
+    Delete("/some-realm") ~> realms.routes(user) ~> check {
+      status should be(StatusCodes.NotFound)
+    }
+  }
+
+  private val user = "some-user"
+}

--- a/identity/src/test/scala/stasis/test/specs/unit/identity/api/manage/TokensSpec.scala
+++ b/identity/src/test/scala/stasis/test/specs/unit/identity/api/manage/TokensSpec.scala
@@ -1,0 +1,101 @@
+package stasis.test.specs.unit.identity.api.manage
+
+import akka.http.scaladsl.model.StatusCodes
+import stasis.identity.api.Formats._
+import stasis.identity.api.manage.Tokens
+import stasis.identity.model.clients.Client
+import stasis.test.specs.unit.identity.RouteTest
+import stasis.test.specs.unit.identity.api.manage.TokensSpec.PartialStoredRefreshToken
+import stasis.test.specs.unit.identity.model.Generators
+
+import scala.concurrent.Future
+
+class TokensSpec extends RouteTest {
+  import de.heikoseeberger.akkahttpplayjson.PlayJsonSupport._
+
+  "Tokens routes" should "respond with all refresh tokens" in {
+    val store = createTokenStore()
+    val tokens = new Tokens(store)
+
+    val owner = Generators.generateResourceOwner
+    val expectedTokens = Generators.generateSeq(min = 2, g = Generators.generateRefreshToken)
+
+    Future.sequence(expectedTokens.map(token => store.put(Client.generateId(), token, owner, scope = None))).await
+    Get() ~> tokens.routes(user) ~> check {
+      status should be(StatusCodes.OK)
+      responseAs[Seq[PartialStoredRefreshToken]].sortBy(_.token) should be(
+        expectedTokens
+          .map(token => PartialStoredRefreshToken(token.value, owner.username, scope = None))
+          .sortBy(_.token))
+    }
+  }
+
+  they should "respond with existing refresh tokens for clients" in {
+    val store = createTokenStore()
+    val tokens = new Tokens(store)
+
+    val client = Client.generateId()
+    val owner = Generators.generateResourceOwner
+    val token = Generators.generateRefreshToken
+
+    store.put(client, token, owner, scope = None).await
+    Get(s"/$client") ~> tokens.routes(user) ~> check {
+      status should be(StatusCodes.OK)
+      responseAs[PartialStoredRefreshToken] should be(
+        PartialStoredRefreshToken(token.value, owner.username, scope = None)
+      )
+    }
+  }
+
+  they should "fail if no refresh tokens are available for a client" in {
+    val store = createTokenStore()
+    val tokens = new Tokens(store)
+
+    val owner = Generators.generateResourceOwner
+    val token = Generators.generateRefreshToken
+
+    store.put(Client.generateId(), token, owner, scope = None).await
+    Get(s"/${Client.generateId()}") ~> tokens.routes(user) ~> check {
+      status should be(StatusCodes.NotFound)
+    }
+  }
+
+  they should "delete existing refresh tokens" in {
+    val store = createTokenStore()
+    val tokens = new Tokens(store)
+
+    val client = Client.generateId()
+    val owner = Generators.generateResourceOwner
+    val token = Generators.generateRefreshToken
+
+    store.put(client, token, owner, scope = None).await
+    Delete(s"/$client") ~> tokens.routes(user) ~> check {
+      status should be(StatusCodes.OK)
+      store.tokens.await should be(Map.empty)
+    }
+  }
+
+  they should "not delete missing refresh tokens" in {
+    val store = createTokenStore()
+    val tokens = new Tokens(store)
+
+    Delete(s"/${Client.generateId()}") ~> tokens.routes(user) ~> check {
+      status should be(StatusCodes.NotFound)
+    }
+  }
+
+  private val user = "some-user"
+}
+
+object TokensSpec {
+  import play.api.libs.json._
+
+  implicit val partialStoredRefreshTokenReads: Reads[PartialStoredRefreshToken] =
+    Json.reads[PartialStoredRefreshToken]
+
+  final case class PartialStoredRefreshToken(
+    token: String,
+    owner: String,
+    scope: Option[String]
+  )
+}

--- a/identity/src/test/scala/stasis/test/specs/unit/identity/api/manage/directives/RealmExtractionSpec.scala
+++ b/identity/src/test/scala/stasis/test/specs/unit/identity/api/manage/directives/RealmExtractionSpec.scala
@@ -1,0 +1,51 @@
+package stasis.test.specs.unit.identity.api.manage.directives
+
+import akka.event.LoggingAdapter
+import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.server.Directives
+import akka.stream.{ActorMaterializer, Materializer}
+import stasis.identity.api.Formats._
+import stasis.identity.api.manage.directives.RealmExtraction
+import stasis.identity.model.realms.{Realm, RealmStore, RealmStoreView}
+import stasis.test.specs.unit.identity.RouteTest
+import stasis.test.specs.unit.identity.model.Generators
+
+class RealmExtractionSpec extends RouteTest {
+  import de.heikoseeberger.akkahttpplayjson.PlayJsonSupport._
+
+  "A RealmExtraction directive" should "extract existing realms" in {
+    val store = createRealmStore()
+    val directive = createDirective(store)
+    val realm = Generators.generateRealm
+
+    val routes = directive.extractRealm(realmId = realm.id) { extractedRealm =>
+      Directives.complete(StatusCodes.OK, extractedRealm)
+    }
+
+    store.put(realm).await
+    Get() ~> routes ~> check {
+      status should be(StatusCodes.OK)
+      responseAs[Realm] should be(realm)
+    }
+  }
+
+  it should "fail to extract missing realms" in {
+    val store = createRealmStore()
+    val directive = createDirective(store)
+    val realm = Generators.generateRealm
+
+    val routes = directive.extractRealm(realmId = realm.id) { extractedRealm =>
+      Directives.complete(StatusCodes.OK, extractedRealm.toString)
+    }
+
+    Get() ~> routes ~> check {
+      status should be(StatusCodes.NotFound)
+    }
+  }
+
+  private def createDirective(store: RealmStore) = new RealmExtraction {
+    override implicit protected def mat: Materializer = ActorMaterializer()
+    override protected def log: LoggingAdapter = createLogger()
+    override protected def realmStore: RealmStoreView = store.view
+  }
+}

--- a/identity/src/test/scala/stasis/test/specs/unit/identity/api/manage/directives/RealmValidationSpec.scala
+++ b/identity/src/test/scala/stasis/test/specs/unit/identity/api/manage/directives/RealmValidationSpec.scala
@@ -1,0 +1,83 @@
+package stasis.test.specs.unit.identity.api.manage.directives
+
+import akka.event.LoggingAdapter
+import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.server.Directives
+import akka.stream.{ActorMaterializer, Materializer}
+import stasis.identity.api.Formats._
+import stasis.identity.api.manage.directives.RealmValidation
+import stasis.identity.model.apis.Api
+import stasis.test.specs.unit.identity.RouteTest
+import stasis.test.specs.unit.identity.model.Generators
+
+import scala.concurrent.Future
+
+class RealmValidationSpec extends RouteTest {
+  import de.heikoseeberger.akkahttpplayjson.PlayJsonSupport._
+
+  "A RealmValidation directive" should "filter entities by realm" in {
+    val directive = createDirective()
+    val realm = Generators.generateRealm
+    val entities = Map(
+      "1" -> Api(id = "some-api-1", realm = realm.id),
+      "2" -> Api(id = "some-api-2", realm = Generators.generateRealmId),
+      "3" -> Api(id = "some-api-3", realm = realm.id)
+    )
+
+    val routes = directive.filterRealm(realm.id, Future.successful(entities)) { filteredEntities =>
+      Directives.complete(StatusCodes.OK, filteredEntities)
+    }
+
+    Get() ~> routes ~> check {
+      status should be(StatusCodes.OK)
+      responseAs[Map[String, Api]] should be(entities.filter(_._2.realm == realm.id))
+    }
+  }
+
+  it should "validate an existing entity's realm" in {
+    val directive = createDirective()
+    val realm = Generators.generateRealm
+    val entity = Api(id = "some-api", realm = realm.id)
+
+    val routes = directive.validateRealm(realm.id, Future.successful(Some(entity))) { _ =>
+      Directives.complete(StatusCodes.OK)
+    }
+
+    Get() ~> routes ~> check {
+      status should be(StatusCodes.OK)
+    }
+  }
+
+  it should "fail to validate an existing entity in an invalid realm" in {
+    val directive = createDirective()
+    val realm = Generators.generateRealm
+    val entity = Api(id = "some-api", realm = Generators.generateRealmId)
+
+    val routes = directive.validateRealm(realm.id, Future.successful(Some(entity))) { _ =>
+      Directives.complete(StatusCodes.OK)
+    }
+
+    Get() ~> routes ~> check {
+      status should be(StatusCodes.BadRequest)
+    }
+  }
+
+  it should "fail to validate a missing entity's realm" in {
+    val directive = createDirective()
+    val realm = Generators.generateRealm
+
+    val routes = directive.validateRealm(realm.id, Future.successful(None)) { _ =>
+      Directives.complete(StatusCodes.OK)
+    }
+
+    Get() ~> routes ~> check {
+      status should be(StatusCodes.NotFound)
+    }
+  }
+
+  private def createDirective() = new RealmValidation[Api] {
+    override implicit protected def mat: Materializer = ActorMaterializer()
+    override protected def log: LoggingAdapter = createLogger()
+    override implicit protected def extractor: RealmValidation.Extractor[Api] = api => api.realm
+  }
+}

--- a/identity/src/test/scala/stasis/test/specs/unit/identity/api/manage/directives/UserAuthenticationSpec.scala
+++ b/identity/src/test/scala/stasis/test/specs/unit/identity/api/manage/directives/UserAuthenticationSpec.scala
@@ -1,0 +1,90 @@
+package stasis.test.specs.unit.identity.api.manage.directives
+
+import akka.event.LoggingAdapter
+import akka.http.scaladsl.model
+import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.model.headers.{BasicHttpCredentials, HttpChallenges, OAuth2BearerToken}
+import akka.http.scaladsl.server.Directives
+import akka.stream.{ActorMaterializer, Materializer}
+import stasis.identity.api.manage.directives.UserAuthentication
+import stasis.identity.authentication.manage.ResourceOwnerAuthenticator
+import stasis.identity.model.owners.ResourceOwner
+import stasis.test.specs.unit.identity.RouteTest
+import stasis.test.specs.unit.identity.model.Generators
+
+import scala.concurrent.Future
+
+class UserAuthenticationSpec extends RouteTest {
+  "A UserAuthentication directive" should "authenticate users with valid bearer tokens" in {
+    val owner = Generators.generateResourceOwner
+
+    val directive = createDirective(
+      auth = (_: OAuth2BearerToken) => Future.successful(owner)
+    )
+
+    val routes = directive.authenticate(owner.realm) { authenticatedOwner =>
+      Directives.complete(StatusCodes.OK, authenticatedOwner.username)
+    }
+
+    Get().addCredentials(OAuth2BearerToken("some-token")) ~> routes ~> check {
+      status should be(StatusCodes.OK)
+      responseAs[String] should be(owner.username)
+    }
+  }
+
+  it should "fail to authenticate users with invalid bearer tokens" in {
+    val owner = Generators.generateResourceOwner
+
+    val directive = createDirective(
+      auth = (_: OAuth2BearerToken) => Future.failed(new RuntimeException("Test authentication failure"))
+    )
+
+    val routes = directive.authenticate(owner.realm) { authenticatedOwner =>
+      Directives.complete(StatusCodes.OK, authenticatedOwner.username)
+    }
+
+    Get().addCredentials(OAuth2BearerToken("some-token")) ~> routes ~> check {
+      status should be(StatusCodes.Unauthorized)
+    }
+  }
+
+  it should "fail to authenticate users with unsupported credentials" in {
+    val owner = Generators.generateResourceOwner
+
+    val directive = createDirective(
+      auth = (_: OAuth2BearerToken) => Future.successful(owner)
+    )
+
+    val routes = directive.authenticate(owner.realm) { authenticatedOwner =>
+      Directives.complete(StatusCodes.OK, authenticatedOwner.username)
+    }
+
+    Get().addCredentials(BasicHttpCredentials("username", "password")) ~> routes ~> check {
+      status should be(StatusCodes.Unauthorized)
+    }
+  }
+
+  it should "fail to authenticate users with no credentials" in {
+    val owner = Generators.generateResourceOwner
+
+    val directive = createDirective(
+      auth = (_: OAuth2BearerToken) => Future.successful(owner)
+    )
+
+    val routes = directive.authenticate(owner.realm) { authenticatedOwner =>
+      Directives.complete(StatusCodes.OK, authenticatedOwner.username)
+    }
+
+    Get() ~> routes ~> check {
+      status should be(StatusCodes.Unauthorized)
+      headers should be(List(model.headers.`WWW-Authenticate`(HttpChallenges.basic(owner.realm))))
+    }
+  }
+
+  private def createDirective(auth: OAuth2BearerToken => Future[ResourceOwner]) = new UserAuthentication {
+    override implicit protected def mat: Materializer = ActorMaterializer()
+    override protected def log: LoggingAdapter = createLogger()
+    override protected def authenticator: ResourceOwnerAuthenticator =
+      (credentials: OAuth2BearerToken) => auth(credentials)
+  }
+}

--- a/identity/src/test/scala/stasis/test/specs/unit/identity/api/manage/directives/UserAuthorizationSpec.scala
+++ b/identity/src/test/scala/stasis/test/specs/unit/identity/api/manage/directives/UserAuthorizationSpec.scala
@@ -1,0 +1,88 @@
+package stasis.test.specs.unit.identity.api.manage.directives
+
+import akka.event.LoggingAdapter
+import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.server.Directives
+import akka.stream.{ActorMaterializer, Materializer}
+import stasis.identity.api.manage.directives.UserAuthorization
+import stasis.identity.model.realms.Realm
+import stasis.test.specs.unit.identity.RouteTest
+import stasis.test.specs.unit.identity.model.Generators
+
+class UserAuthorizationSpec extends RouteTest {
+  "A UserAuthorization directive" should "authorize users in the master realm" in {
+    val directive = createDirective()
+    val owner = Generators.generateResourceOwner.copy(realm = Realm.Master)
+
+    val routes = directive.authorize(
+      user = owner,
+      targetRealm = Realm.Master,
+      scope = "some-scope"
+    ) {
+      Directives.complete(StatusCodes.OK)
+    }
+
+    Get() ~> routes ~> check {
+      status should be(StatusCodes.OK)
+    }
+  }
+
+  it should "authorize users in the target realm with appropriate scopes" in {
+    val directive = createDirective()
+    val realm = Generators.generateRealm
+    val owner = Generators.generateResourceOwner.copy(realm = realm.id)
+
+    val routes = directive.authorize(
+      user = owner,
+      targetRealm = realm.id,
+      scope = owner.allowedScopes.headOption.getOrElse("missing-scope")
+    ) {
+      Directives.complete(StatusCodes.OK)
+    }
+
+    Get() ~> routes ~> check {
+      status should be(StatusCodes.OK)
+    }
+  }
+
+  it should "fail to authorize users in the target realm without appropriate scopes" in {
+    val directive = createDirective()
+    val realm = Generators.generateRealm
+    val owner = Generators.generateResourceOwner.copy(realm = realm.id)
+
+    val routes = directive.authorize(
+      user = owner,
+      targetRealm = realm.id,
+      scope = "missing-scope"
+    ) {
+      Directives.complete(StatusCodes.OK)
+    }
+
+    Get() ~> routes ~> check {
+      status should be(StatusCodes.Forbidden)
+    }
+  }
+
+  it should "fail to authorize users not in the target realm" in {
+    val directive = createDirective()
+    val realm = Generators.generateRealm
+    val owner = Generators.generateResourceOwner
+
+    val routes = directive.authorize(
+      user = owner,
+      targetRealm = realm.id,
+      scope = owner.allowedScopes.headOption.getOrElse("missing-scope")
+    ) {
+      Directives.complete(StatusCodes.OK)
+    }
+
+    Get() ~> routes ~> check {
+      status should be(StatusCodes.Forbidden)
+    }
+  }
+
+  private def createDirective() = new UserAuthorization {
+    override implicit protected def mat: Materializer = ActorMaterializer()
+    override protected def log: LoggingAdapter = createLogger()
+  }
+}

--- a/identity/src/test/scala/stasis/test/specs/unit/identity/api/manage/requests/CreateApiSpec.scala
+++ b/identity/src/test/scala/stasis/test/specs/unit/identity/api/manage/requests/CreateApiSpec.scala
@@ -1,0 +1,20 @@
+package stasis.test.specs.unit.identity.api.manage.requests
+
+import stasis.identity.api.manage.requests.CreateApi
+import stasis.identity.model.apis.Api
+import stasis.test.specs.unit.UnitSpec
+
+class CreateApiSpec extends UnitSpec {
+  private val request = CreateApi(id = "some-api")
+
+  "A CreateApi request" should "validate its content" in {
+    an[IllegalArgumentException] should be thrownBy request.copy(id = "")
+  }
+
+  it should "be convertible to Api" in {
+    val expectedApi = Api(id = request.id, realm = "some-realm")
+    val actualApi = request.toApi(realm = expectedApi.realm)
+
+    actualApi should be(expectedApi)
+  }
+}

--- a/identity/src/test/scala/stasis/test/specs/unit/identity/api/manage/requests/CreateClientSpec.scala
+++ b/identity/src/test/scala/stasis/test/specs/unit/identity/api/manage/requests/CreateClientSpec.scala
@@ -1,0 +1,46 @@
+package stasis.test.specs.unit.identity.api.manage.requests
+
+import stasis.identity.api.manage.requests.CreateClient
+import stasis.identity.model.secrets.Secret
+import stasis.test.specs.unit.UnitSpec
+import stasis.test.specs.unit.identity.model.Generators
+
+import scala.concurrent.duration._
+
+class CreateClientSpec extends UnitSpec {
+  private val request = CreateClient(
+    allowedScopes = Seq("some-scope"),
+    redirectUri = "some-uri",
+    tokenExpiration = 5.seconds,
+    rawSecret = "some-secret"
+  )
+
+  "A CreateClient request" should "validate its content" in {
+    an[IllegalArgumentException] should be thrownBy request.copy(allowedScopes = Seq.empty)
+    an[IllegalArgumentException] should be thrownBy request.copy(redirectUri = "")
+    an[IllegalArgumentException] should be thrownBy request.copy(tokenExpiration = 0.seconds)
+    an[IllegalArgumentException] should be thrownBy request.copy(rawSecret = "")
+  }
+
+  it should "be convertible to Client" in {
+    implicit val config: Secret.ClientConfig = Secret.ClientConfig(
+      algorithm = "PBKDF2WithHmacSHA512",
+      iterations = 10000,
+      derivedKeySize = 32,
+      saltSize = 16,
+      authenticationDelay = 3.seconds
+    )
+
+    val expectedClient = Generators.generateClient.copy(
+      allowedScopes = request.allowedScopes,
+      redirectUri = request.redirectUri,
+      tokenExpiration = request.tokenExpiration
+    )
+
+    val actualClient = request.toClient(realm = expectedClient.realm)
+
+    actualClient should be(
+      expectedClient.copy(id = actualClient.id, secret = actualClient.secret, salt = actualClient.salt)
+    )
+  }
+}

--- a/identity/src/test/scala/stasis/test/specs/unit/identity/api/manage/requests/CreateOwnerSpec.scala
+++ b/identity/src/test/scala/stasis/test/specs/unit/identity/api/manage/requests/CreateOwnerSpec.scala
@@ -1,0 +1,41 @@
+package stasis.test.specs.unit.identity.api.manage.requests
+
+import stasis.identity.api.manage.requests.CreateOwner
+import stasis.identity.model.secrets.Secret
+import stasis.test.specs.unit.UnitSpec
+import stasis.test.specs.unit.identity.model.Generators
+
+import scala.concurrent.duration._
+
+class CreateOwnerSpec extends UnitSpec {
+  private val request = CreateOwner(
+    username = "some-username",
+    rawPassword = "some-password",
+    allowedScopes = Seq("some-scope")
+  )
+
+  "A CreateOwner request" should "validate its content" in {
+    an[IllegalArgumentException] should be thrownBy request.copy(username = "")
+    an[IllegalArgumentException] should be thrownBy request.copy(allowedScopes = Seq.empty)
+    an[IllegalArgumentException] should be thrownBy request.copy(rawPassword = "")
+  }
+
+  it should "be convertible to ResourceOwner" in {
+    implicit val config: Secret.ResourceOwnerConfig = Secret.ResourceOwnerConfig(
+      algorithm = "PBKDF2WithHmacSHA512",
+      iterations = 10000,
+      derivedKeySize = 32,
+      saltSize = 16,
+      authenticationDelay = 3.seconds
+    )
+
+    val expectedOwner = Generators.generateResourceOwner.copy(
+      username = request.username,
+      allowedScopes = request.allowedScopes
+    )
+
+    val actualOwner = request.toResourceOwner(realm = expectedOwner.realm)
+
+    actualOwner should be(expectedOwner.copy(password = actualOwner.password, salt = actualOwner.salt))
+  }
+}

--- a/identity/src/test/scala/stasis/test/specs/unit/identity/api/manage/requests/CreateRealmSpec.scala
+++ b/identity/src/test/scala/stasis/test/specs/unit/identity/api/manage/requests/CreateRealmSpec.scala
@@ -1,0 +1,23 @@
+package stasis.test.specs.unit.identity.api.manage.requests
+
+import stasis.identity.api.manage.requests.CreateRealm
+import stasis.identity.model.realms.Realm
+import stasis.test.specs.unit.UnitSpec
+
+class CreateRealmSpec extends UnitSpec {
+  private val request = CreateRealm(
+    id = "some-realm",
+    refreshTokensAllowed = true
+  )
+
+  "A CreateRealm request" should "validate its content" in {
+    an[IllegalArgumentException] should be thrownBy request.copy(id = "")
+  }
+
+  it should "be convertible to Realm" in {
+    val expectedRealm = Realm(id = request.id, refreshTokensAllowed = request.refreshTokensAllowed)
+    val actualRealm = request.toRealm
+
+    actualRealm should be(expectedRealm)
+  }
+}

--- a/identity/src/test/scala/stasis/test/specs/unit/identity/api/manage/requests/UpdateClientCredentialsSpec.scala
+++ b/identity/src/test/scala/stasis/test/specs/unit/identity/api/manage/requests/UpdateClientCredentialsSpec.scala
@@ -1,0 +1,32 @@
+package stasis.test.specs.unit.identity.api.manage.requests
+
+import stasis.identity.api.manage.requests.UpdateClientCredentials
+import stasis.identity.model.secrets.Secret
+import stasis.test.specs.unit.UnitSpec
+
+import scala.concurrent.duration._
+
+class UpdateClientCredentialsSpec extends UnitSpec {
+  private val request = UpdateClientCredentials(
+    rawSecret = "some-secret"
+  )
+
+  "An UpdateClientCredentials request" should "validate its content" in {
+    an[IllegalArgumentException] should be thrownBy request.copy(rawSecret = "")
+  }
+
+  it should "be convertible to a Secret" in {
+    implicit val config: Secret.ClientConfig = Secret.ClientConfig(
+      algorithm = "PBKDF2WithHmacSHA512",
+      iterations = 10000,
+      derivedKeySize = 32,
+      saltSize = 16,
+      authenticationDelay = 3.seconds
+    )
+
+    val (actualSecret, salt) = request.toSecret()
+    val expectedSecret = Secret.derive(request.rawSecret, salt)
+
+    actualSecret should be(expectedSecret)
+  }
+}

--- a/identity/src/test/scala/stasis/test/specs/unit/identity/api/manage/requests/UpdateClientSpec.scala
+++ b/identity/src/test/scala/stasis/test/specs/unit/identity/api/manage/requests/UpdateClientSpec.scala
@@ -1,0 +1,19 @@
+package stasis.test.specs.unit.identity.api.manage.requests
+
+import stasis.identity.api.manage.requests.UpdateClient
+import stasis.test.specs.unit.UnitSpec
+
+import scala.concurrent.duration._
+
+class UpdateClientSpec extends UnitSpec {
+  private val request = UpdateClient(
+    allowedScopes = Seq("some-scope"),
+    tokenExpiration = 1.second,
+    active = true
+  )
+
+  "An UpdateClient request" should "validate its content" in {
+    an[IllegalArgumentException] should be thrownBy request.copy(allowedScopes = Seq.empty)
+    an[IllegalArgumentException] should be thrownBy request.copy(tokenExpiration = 0.seconds)
+  }
+}

--- a/identity/src/test/scala/stasis/test/specs/unit/identity/api/manage/requests/UpdateOwnerCredentialsSpec.scala
+++ b/identity/src/test/scala/stasis/test/specs/unit/identity/api/manage/requests/UpdateOwnerCredentialsSpec.scala
@@ -1,0 +1,32 @@
+package stasis.test.specs.unit.identity.api.manage.requests
+
+import stasis.identity.api.manage.requests.UpdateOwnerCredentials
+import stasis.identity.model.secrets.Secret
+import stasis.test.specs.unit.UnitSpec
+
+import scala.concurrent.duration._
+
+class UpdateOwnerCredentialsSpec extends UnitSpec {
+  private val request = UpdateOwnerCredentials(
+    rawPassword = "some-password"
+  )
+
+  "An UpdateOwnerCredentials request" should "validate its content" in {
+    an[IllegalArgumentException] should be thrownBy request.copy(rawPassword = "")
+  }
+
+  it should "be convertible to a Secret" in {
+    implicit val config: Secret.ResourceOwnerConfig = Secret.ResourceOwnerConfig(
+      algorithm = "PBKDF2WithHmacSHA512",
+      iterations = 10000,
+      derivedKeySize = 32,
+      saltSize = 16,
+      authenticationDelay = 3.seconds
+    )
+
+    val (actualSecret, salt) = request.toSecret()
+    val expectedSecret = Secret.derive(request.rawPassword, salt)
+
+    actualSecret should be(expectedSecret)
+  }
+}

--- a/identity/src/test/scala/stasis/test/specs/unit/identity/api/manage/requests/UpdateOwnerSpec.scala
+++ b/identity/src/test/scala/stasis/test/specs/unit/identity/api/manage/requests/UpdateOwnerSpec.scala
@@ -1,0 +1,15 @@
+package stasis.test.specs.unit.identity.api.manage.requests
+
+import stasis.identity.api.manage.requests.UpdateOwner
+import stasis.test.specs.unit.UnitSpec
+
+class UpdateOwnerSpec extends UnitSpec {
+  private val request = UpdateOwner(
+    allowedScopes = Seq("some-scope"),
+    active = true
+  )
+
+  "An UpdateOwner request" should "validate its content" in {
+    an[IllegalArgumentException] should be thrownBy request.copy(allowedScopes = Seq.empty)
+  }
+}

--- a/identity/src/test/scala/stasis/test/specs/unit/identity/api/oauth/AuthorizationCodeGrantSpec.scala
+++ b/identity/src/test/scala/stasis/test/specs/unit/identity/api/oauth/AuthorizationCodeGrantSpec.scala
@@ -1,0 +1,296 @@
+package stasis.test.specs.unit.identity.api.oauth
+
+import akka.http.scaladsl.model
+import akka.http.scaladsl.model.headers.{BasicHttpCredentials, CacheDirectives}
+import akka.http.scaladsl.model.{ContentTypes, StatusCodes, Uri}
+import play.api.libs.json._
+import stasis.identity.api.oauth.AuthorizationCodeGrant
+import stasis.identity.api.oauth.AuthorizationCodeGrant._
+import stasis.identity.model.clients.Client
+import stasis.identity.model.codes.AuthorizationCode
+import stasis.identity.model.secrets.Secret
+import stasis.identity.model.tokens.TokenType
+import stasis.identity.model.{GrantType, ResponseType}
+import stasis.test.specs.unit.identity.RouteTest
+import stasis.test.specs.unit.identity.model.Generators
+
+class AuthorizationCodeGrantSpec extends RouteTest with OAuthFixtures {
+  import de.heikoseeberger.akkahttpplayjson.PlayJsonSupport._
+
+  "AuthorizationCodeGrant routes" should "validate authorization requests content" in {
+    val request = AuthorizationRequest(
+      response_type = ResponseType.Code,
+      client_id = Client.generateId(),
+      redirect_uri = Some("some-uri"),
+      scope = Some("some-scope"),
+      state = "some-state"
+    )
+
+    an[IllegalArgumentException] should be thrownBy request.copy(response_type = ResponseType.Token)
+    an[IllegalArgumentException] should be thrownBy request.copy(redirect_uri = Some(""))
+    an[IllegalArgumentException] should be thrownBy request.copy(scope = Some(""))
+    an[IllegalArgumentException] should be thrownBy request.copy(state = "")
+  }
+
+  they should "validate access token requests content" in {
+    val request = AccessTokenRequest(
+      grant_type = GrantType.AuthorizationCode,
+      code = AuthorizationCode("some-code"),
+      redirect_uri = Some("some-uri"),
+      client_id = Client.generateId()
+    )
+
+    an[IllegalArgumentException] should be thrownBy request.copy(grant_type = GrantType.Implicit)
+    an[IllegalArgumentException] should be thrownBy request.copy(code = AuthorizationCode(""))
+    an[IllegalArgumentException] should be thrownBy request.copy(redirect_uri = Some(""))
+  }
+
+  they should "represent authorization responses as URI query values" in {
+    val response = AuthorizationResponse(
+      code = AuthorizationCode("some-code"),
+      state = "some-state",
+      scope = Some("some-scope")
+    )
+
+    val expectedQuery = Uri.Query(
+      Map(
+        "code" -> "some-code",
+        "state" -> "some-state",
+        "scope" -> "some-scope"
+      )
+    )
+
+    val actualQuery = response.asQuery
+
+    actualQuery should be(expectedQuery)
+  }
+
+  they should "generate authorization codes for valid requests" in {
+    val (stores, secrets, providers) = createOAuthFixtures()
+    val grant = new AuthorizationCodeGrant(providers)
+
+    val realm = Generators.generateRealm
+    val client = Generators.generateClient.copy(realm = realm.id)
+    val api = Generators.generateApi
+
+    val rawPassword = "some-password"
+    val salt = Generators.generateString(withSize = secrets.owner.saltSize)
+    val owner = Generators.generateResourceOwner.copy(
+      realm = realm.id,
+      password = Secret.derive(rawPassword, salt)(secrets.owner),
+      salt = salt
+    )
+    val credentials = BasicHttpCredentials(owner.username, rawPassword)
+
+    val request = AuthorizationRequest(
+      response_type = ResponseType.Code,
+      client_id = client.id,
+      redirect_uri = Some(client.redirectUri),
+      scope = grant.apiAudienceToScope(Seq(api)),
+      state = Generators.generateString(withSize = 16)
+    )
+
+    stores.clients.put(client).await
+    stores.owners.put(owner).await
+    stores.apis.put(api).await
+    Get(request).addCredentials(credentials) ~> grant.authorization(realm) ~> check {
+      status should be(StatusCodes.Found)
+      stores.codes.get(client.id).await match {
+        case Some(storedCode) =>
+          headers should contain(
+            model.headers.Location(
+              Uri(
+                s"${client.redirectUri}" +
+                  s"?code=${storedCode.code.value}" +
+                  s"&state=${request.state}" +
+                  s"&scope=${request.scope.getOrElse("invalid")}"
+              )
+            )
+          )
+
+        case None =>
+          fail("Unexpected response received; no authorization code found")
+      }
+    }
+  }
+
+  they should "not generate authorization codes when invalid redirect URIs are provided" in {
+    val (stores, secrets, providers) = createOAuthFixtures()
+    val grant = new AuthorizationCodeGrant(providers)
+
+    val realm = Generators.generateRealm
+    val client = Generators.generateClient.copy(realm = realm.id)
+    val api = Generators.generateApi
+
+    val rawPassword = "some-password"
+    val salt = Generators.generateString(withSize = secrets.owner.saltSize)
+    val owner = Generators.generateResourceOwner.copy(
+      realm = realm.id,
+      password = Secret.derive(rawPassword, salt)(secrets.owner),
+      salt = salt
+    )
+    val credentials = BasicHttpCredentials(owner.username, rawPassword)
+
+    val request = AuthorizationRequest(
+      response_type = ResponseType.Code,
+      client_id = client.id,
+      redirect_uri = Some("some-uri"),
+      scope = grant.apiAudienceToScope(Seq(api)),
+      state = Generators.generateString(withSize = 16)
+    )
+
+    stores.clients.put(client).await
+    stores.owners.put(owner).await
+    stores.apis.put(api).await
+    Get(request).addCredentials(credentials) ~> grant.authorization(realm) ~> check {
+      status should be(StatusCodes.BadRequest)
+      responseAs[String] should be(
+        "The request has missing, invalid or mismatching redirection URI and/or client identifier"
+      )
+      stores.codes.codes.await should be(Map.empty)
+    }
+  }
+
+  they should "generate access and refresh tokens for valid authorization codes" in {
+    val (stores, secrets, providers) = createOAuthFixtures()
+    val grant = new AuthorizationCodeGrant(providers)
+
+    val realm = Generators.generateRealm
+    val owner = Generators.generateResourceOwner
+    val code = Generators.generateAuthorizationCode
+    val api = Generators.generateApi
+
+    val rawPassword = "some-password"
+    val salt = Generators.generateString(withSize = secrets.client.saltSize)
+    val client = Generators.generateClient.copy(
+      realm = realm.id,
+      secret = Secret.derive(rawPassword, salt)(secrets.client),
+      salt = salt
+    )
+    val credentials = BasicHttpCredentials(client.id.toString, rawPassword)
+
+    val request = AccessTokenRequest(
+      grant_type = GrantType.AuthorizationCode,
+      code = code,
+      redirect_uri = Some(client.redirectUri),
+      client_id = client.id
+    )
+
+    stores.clients.put(client).await
+    stores.owners.put(owner).await
+    stores.apis.put(api).await
+    stores.codes.put(client.id, code, owner, scope = grant.apiAudienceToScope(Seq(api))).await
+    Post(request).addCredentials(credentials) ~> grant.token(realm) ~> check {
+      status should be(StatusCodes.OK)
+      headers should contain(model.headers.`Content-Type`(ContentTypes.`application/json`))
+      headers should contain(model.headers.`Cache-Control`(CacheDirectives.`no-store`))
+
+      val actualResponse = responseAs[AccessTokenResponse]
+      actualResponse.access_token.value.nonEmpty should be(true)
+      actualResponse.token_type should be(TokenType.Bearer)
+      actualResponse.expires_in.value should be > 0L
+      actualResponse.refresh_token.exists(_.value.nonEmpty) should be(true)
+
+      val refreshTokenGenerated = stores.tokens.get(client.id).await.nonEmpty
+      refreshTokenGenerated should be(true)
+    }
+  }
+
+  they should "generate only access tokens when refresh tokens are not allowed" in {
+    val (stores, secrets, providers) = createOAuthFixtures()
+    val grant = new AuthorizationCodeGrant(providers)
+
+    val realm = Generators.generateRealm.copy(refreshTokensAllowed = false)
+    val owner = Generators.generateResourceOwner
+    val code = Generators.generateAuthorizationCode
+    val api = Generators.generateApi
+
+    val rawPassword = "some-password"
+    val salt = Generators.generateString(withSize = secrets.client.saltSize)
+    val client = Generators.generateClient.copy(
+      realm = realm.id,
+      secret = Secret.derive(rawPassword, salt)(secrets.client),
+      salt = salt
+    )
+    val credentials = BasicHttpCredentials(client.id.toString, rawPassword)
+
+    val request = AccessTokenRequest(
+      grant_type = GrantType.AuthorizationCode,
+      code = code,
+      redirect_uri = Some(client.redirectUri),
+      client_id = client.id
+    )
+
+    stores.clients.put(client).await
+    stores.owners.put(owner).await
+    stores.apis.put(api).await
+    stores.codes.put(client.id, code, owner, scope = grant.apiAudienceToScope(Seq(api))).await
+    Post(request).addCredentials(credentials) ~> grant.token(realm) ~> check {
+      status should be(StatusCodes.OK)
+      headers should contain(model.headers.`Content-Type`(ContentTypes.`application/json`))
+      headers should contain(model.headers.`Cache-Control`(CacheDirectives.`no-store`))
+
+      val actualResponse = responseAs[AccessTokenResponse]
+      actualResponse.access_token.value.nonEmpty should be(true)
+      actualResponse.token_type should be(TokenType.Bearer)
+      actualResponse.expires_in.value should be > 0L
+      actualResponse.refresh_token should be(None)
+    }
+  }
+
+  they should "not generate access or refresh tokens when invalid redirect URIs are provided" in {
+    val (stores, secrets, providers) = createOAuthFixtures()
+    val grant = new AuthorizationCodeGrant(providers)
+
+    val realm = Generators.generateRealm
+    val owner = Generators.generateResourceOwner
+    val code = Generators.generateAuthorizationCode
+    val api = Generators.generateApi
+
+    val rawPassword = "some-password"
+    val salt = Generators.generateString(withSize = secrets.client.saltSize)
+    val client = Generators.generateClient.copy(
+      realm = realm.id,
+      secret = Secret.derive(rawPassword, salt)(secrets.client),
+      salt = salt
+    )
+    val credentials = BasicHttpCredentials(client.id.toString, rawPassword)
+
+    val request = AccessTokenRequest(
+      grant_type = GrantType.AuthorizationCode,
+      code = code,
+      redirect_uri = Some("some-uri"),
+      client_id = client.id
+    )
+
+    stores.clients.put(client).await
+    stores.owners.put(owner).await
+    stores.apis.put(api).await
+    stores.codes.put(client.id, code, owner, scope = grant.apiAudienceToScope(Seq(api))).await
+    Post(request).addCredentials(credentials) ~> grant.token(realm) ~> check {
+      status should be(StatusCodes.BadRequest)
+      responseAs[JsObject].fields should contain("error" -> JsString("invalid_request"))
+    }
+  }
+
+  import scala.language.implicitConversions
+
+  implicit def authorizationRequestToLocalUri(request: AuthorizationRequest): Uri =
+    Uri(
+      s"/" +
+        s"?response_type=${request.response_type.toString.toLowerCase}" +
+        s"&client_id=${request.client_id}" +
+        s"&redirect_uri=${request.redirect_uri.getOrElse("")}" +
+        s"&scope=${request.scope.getOrElse("")}" +
+        s"&state=${request.state}"
+    )
+
+  implicit def accessTokenRequestToLocalUri(request: AccessTokenRequest): Uri =
+    Uri(
+      s"/" +
+        s"?grant_type=authorization_code" +
+        s"&code=${request.code.value}" +
+        s"&redirect_uri=${request.redirect_uri.getOrElse("")}" +
+        s"&client_id=${request.client_id}"
+    )
+}

--- a/identity/src/test/scala/stasis/test/specs/unit/identity/api/oauth/ClientCredentialsGrantSpec.scala
+++ b/identity/src/test/scala/stasis/test/specs/unit/identity/api/oauth/ClientCredentialsGrantSpec.scala
@@ -1,0 +1,70 @@
+package stasis.test.specs.unit.identity.api.oauth
+
+import akka.http.scaladsl.model
+import akka.http.scaladsl.model.headers.{BasicHttpCredentials, CacheDirectives}
+import akka.http.scaladsl.model.{ContentTypes, StatusCodes, Uri}
+import stasis.identity.api.oauth.ClientCredentialsGrant
+import stasis.identity.api.oauth.ClientCredentialsGrant.{AccessTokenRequest, AccessTokenResponse}
+import stasis.identity.model.GrantType
+import stasis.identity.model.secrets.Secret
+import stasis.identity.model.tokens.TokenType
+import stasis.test.specs.unit.identity.RouteTest
+import stasis.test.specs.unit.identity.model.Generators
+
+class ClientCredentialsGrantSpec extends RouteTest with OAuthFixtures {
+  import de.heikoseeberger.akkahttpplayjson.PlayJsonSupport._
+
+  "ClientCredentialsGrant routes" should "validate access token requests content" in {
+    val request = AccessTokenRequest(
+      grant_type = GrantType.ClientCredentials,
+      scope = Some("some-scope")
+    )
+
+    an[IllegalArgumentException] should be thrownBy request.copy(grant_type = GrantType.Implicit)
+    an[IllegalArgumentException] should be thrownBy request.copy(scope = Some(""))
+  }
+
+  they should "generate access tokens for valid requests" in {
+    val (stores, secrets, providers) = createOAuthFixtures()
+    val grant = new ClientCredentialsGrant(providers)
+
+    val realm = Generators.generateRealm
+
+    val rawPassword = "some-password"
+    val salt = Generators.generateString(withSize = secrets.client.saltSize)
+    val client = Generators.generateClient.copy(
+      realm = realm.id,
+      secret = Secret.derive(rawPassword, salt)(secrets.client),
+      salt = salt
+    )
+    val credentials = BasicHttpCredentials(client.id.toString, rawPassword)
+
+    val request = AccessTokenRequest(
+      grant_type = GrantType.ClientCredentials,
+      scope = grant.clientAudienceToScope(Seq(client))
+    )
+
+    stores.clients.put(client).await
+    Post(request).addCredentials(credentials) ~> grant.token(realm) ~> check {
+      status should be(StatusCodes.OK)
+
+      headers should contain(model.headers.`Content-Type`(ContentTypes.`application/json`))
+      headers should contain(model.headers.`Cache-Control`(CacheDirectives.`no-store`))
+
+      val actualResponse = responseAs[AccessTokenResponse]
+      actualResponse.access_token.value.nonEmpty should be(true)
+      actualResponse.token_type should be(TokenType.Bearer)
+      actualResponse.expires_in.value should be > 0L
+      actualResponse.scope should be(request.scope)
+    }
+  }
+
+  import scala.language.implicitConversions
+
+  implicit def accessTokenRequestToLocalUri(request: AccessTokenRequest): Uri =
+    Uri(
+      s"/" +
+        s"?grant_type=client_credentials" +
+        s"&scope=${request.scope.getOrElse("")}"
+    )
+}

--- a/identity/src/test/scala/stasis/test/specs/unit/identity/api/oauth/ImplicitGrantSpec.scala
+++ b/identity/src/test/scala/stasis/test/specs/unit/identity/api/oauth/ImplicitGrantSpec.scala
@@ -1,0 +1,147 @@
+package stasis.test.specs.unit.identity.api.oauth
+
+import akka.http.scaladsl.model.headers.BasicHttpCredentials
+import akka.http.scaladsl.model.{StatusCodes, Uri}
+import stasis.identity.api.oauth.ImplicitGrant
+import stasis.identity.api.oauth.ImplicitGrant.{AccessTokenResponse, AuthorizationRequest}
+import stasis.identity.model.clients.Client
+import stasis.identity.model.secrets.Secret
+import stasis.identity.model.tokens.{AccessToken, TokenType}
+import stasis.identity.model.{ResponseType, Seconds}
+import stasis.test.specs.unit.identity.RouteTest
+import stasis.test.specs.unit.identity.model.Generators
+
+class ImplicitGrantSpec extends RouteTest with OAuthFixtures {
+  "ImplicitGrant routes" should "validate authorization requests content" in {
+    val request = AuthorizationRequest(
+      response_type = ResponseType.Token,
+      client_id = Client.generateId(),
+      redirect_uri = Some("some-uri"),
+      scope = Some("some-scope"),
+      state = "some-state"
+    )
+
+    an[IllegalArgumentException] should be thrownBy request.copy(response_type = ResponseType.Code)
+    an[IllegalArgumentException] should be thrownBy request.copy(redirect_uri = Some(""))
+    an[IllegalArgumentException] should be thrownBy request.copy(scope = Some(""))
+    an[IllegalArgumentException] should be thrownBy request.copy(state = "")
+  }
+
+  they should "represent access token responses as URI query values" in {
+    val response = AccessTokenResponse(
+      access_token = AccessToken("some-token"),
+      token_type = TokenType.Bearer,
+      expires_in = Seconds(42),
+      state = "some-state",
+      scope = Some("some-scope")
+    )
+
+    val expectedQuery = Uri.Query(
+      Map(
+        "access_token" -> "some-token",
+        "token_type" -> "bearer",
+        "expires_in" -> "42",
+        "state" -> "some-state",
+        "scope" -> "some-scope"
+      )
+    )
+
+    val actualQuery = response.asQuery
+
+    actualQuery should be(expectedQuery)
+  }
+
+  they should "generate access tokens for valid requests" in {
+    val (stores, secrets, providers) = createOAuthFixtures()
+    val grant = new ImplicitGrant(providers)
+
+    val realm = Generators.generateRealm
+    val client = Generators.generateClient.copy(realm = realm.id)
+    val api = Generators.generateApi
+
+    val rawPassword = "some-password"
+    val salt = Generators.generateString(withSize = secrets.owner.saltSize)
+    val owner = Generators.generateResourceOwner.copy(
+      realm = realm.id,
+      password = Secret.derive(rawPassword, salt)(secrets.owner),
+      salt = salt
+    )
+    val credentials = BasicHttpCredentials(owner.username, rawPassword)
+
+    val request = AuthorizationRequest(
+      response_type = ResponseType.Token,
+      client_id = client.id,
+      redirect_uri = Some(client.redirectUri),
+      scope = grant.apiAudienceToScope(Seq(api)),
+      state = Generators.generateString(withSize = 16)
+    )
+
+    stores.clients.put(client).await
+    stores.owners.put(owner).await
+    stores.apis.put(api).await
+    Get(request).addCredentials(credentials) ~> grant.authorization(realm) ~> check {
+      status should be(StatusCodes.Found)
+
+      headers.find(_.is("location")) match {
+        case Some(header) =>
+          val headerValue = header.value()
+          headerValue.contains("access_token") should be(true)
+          headerValue.contains("token_type=bearer") should be(true)
+          headerValue.contains(s"expires_in=${client.tokenExpiration.value}") should be(true)
+          headerValue.contains(s"state=${request.state}") should be(true)
+          headerValue.contains(s"scope=${request.scope.getOrElse("invalid")}") should be(true)
+
+        case None =>
+          fail(s"Unexpected response received; no location found in headers [$headers]")
+      }
+    }
+  }
+
+  they should "not generate access tokens when invalid redirect URIs are provided" in {
+    val (stores, secrets, providers) = createOAuthFixtures()
+    val grant = new ImplicitGrant(providers)
+
+    val realm = Generators.generateRealm
+    val client = Generators.generateClient.copy(realm = realm.id)
+    val api = Generators.generateApi
+
+    val rawPassword = "some-password"
+    val salt = Generators.generateString(withSize = secrets.owner.saltSize)
+    val owner = Generators.generateResourceOwner.copy(
+      realm = realm.id,
+      password = Secret.derive(rawPassword, salt)(secrets.owner),
+      salt = salt
+    )
+    val credentials = BasicHttpCredentials(owner.username, rawPassword)
+
+    val request = AuthorizationRequest(
+      response_type = ResponseType.Token,
+      client_id = client.id,
+      redirect_uri = Some("some-uri"),
+      scope = grant.apiAudienceToScope(Seq(api)),
+      state = Generators.generateString(withSize = 16)
+    )
+
+    stores.clients.put(client).await
+    stores.owners.put(owner).await
+    stores.apis.put(api).await
+    Get(request).addCredentials(credentials) ~> grant.authorization(realm) ~> check {
+      status should be(StatusCodes.BadRequest)
+      responseAs[String] should be(
+        "The request has missing, invalid or mismatching redirection URI and/or client identifier"
+      )
+    }
+  }
+
+  import scala.language.implicitConversions
+
+  implicit def accessTokenRequestToLocalUri(request: AuthorizationRequest): Uri =
+    Uri(
+      s"/" +
+        s"?response_type=token" +
+        s"&client_id=${request.client_id}" +
+        s"&redirect_uri=${request.redirect_uri.getOrElse("")}" +
+        s"&scope=${request.scope.getOrElse("")}" +
+        s"&state=${request.state}"
+    )
+}

--- a/identity/src/test/scala/stasis/test/specs/unit/identity/api/oauth/OAuthFixtures.scala
+++ b/identity/src/test/scala/stasis/test/specs/unit/identity/api/oauth/OAuthFixtures.scala
@@ -1,0 +1,84 @@
+package stasis.test.specs.unit.identity.api.oauth
+
+import org.jose4j.jwk.JsonWebKey
+import stasis.identity.api.oauth.setup.Providers
+import stasis.identity.authentication.oauth.{DefaultClientAuthenticator, DefaultResourceOwnerAuthenticator}
+import stasis.identity.model.apis.ApiStore
+import stasis.identity.model.clients.ClientStore
+import stasis.identity.model.codes.AuthorizationCodeStore
+import stasis.identity.model.codes.generators.DefaultAuthorizationCodeGenerator
+import stasis.identity.model.owners.ResourceOwnerStore
+import stasis.identity.model.realms.RealmStore
+import stasis.identity.model.secrets.Secret
+import stasis.identity.model.tokens.RefreshTokenStore
+import stasis.identity.model.tokens.generators.{JwtBearerAccessTokenGenerator, RandomRefreshTokenGenerator}
+import stasis.test.specs.unit.core.security.jwt.mocks.MockJwksGenerators
+import stasis.test.specs.unit.identity.RouteTest
+import stasis.test.specs.unit.identity.api.oauth.OAuthFixtures.{TestSecretConfig, TestStores}
+import stasis.test.specs.unit.identity.model.Generators
+
+import scala.concurrent.duration._
+
+trait OAuthFixtures { _: RouteTest =>
+  def createOAuthFixtures(
+    stores: TestStores = TestStores(
+      apis = createApiStore(),
+      clients = createClientStore(),
+      realms = createRealmStore(),
+      tokens = createTokenStore(),
+      codes = createCodeStore(),
+      owners = createOwnerStore()
+    ),
+    jwk: JsonWebKey = MockJwksGenerators.generateRandomRsaKey(
+      keyId = Some(Generators.generateString(withSize = 16))
+    ),
+    testSecretConfig: TestSecretConfig = TestSecretConfig()
+  ): (TestStores, TestSecretConfig, Providers) = (
+    stores,
+    testSecretConfig,
+    Providers(
+      apiStore = stores.apis.view,
+      clientStore = stores.clients.view,
+      realmStore = stores.realms,
+      refreshTokenStore = stores.tokens,
+      authorizationCodeStore = stores.codes,
+      accessTokenGenerator = new JwtBearerAccessTokenGenerator(
+        issuer = "test-issuer",
+        jwk = jwk,
+        jwtExpiration = 30.seconds
+      ),
+      authorizationCodeGenerator = new DefaultAuthorizationCodeGenerator(codeSize = 16),
+      refreshTokenGenerator = new RandomRefreshTokenGenerator(tokenSize = 16),
+      clientAuthenticator = new DefaultClientAuthenticator(stores.clients.view, testSecretConfig.client),
+      resourceOwnerAuthenticator = new DefaultResourceOwnerAuthenticator(stores.owners.view, testSecretConfig.owner)
+    )
+  )
+}
+
+object OAuthFixtures {
+  final case class TestStores(
+    apis: ApiStore,
+    clients: ClientStore,
+    realms: RealmStore,
+    tokens: RefreshTokenStore,
+    codes: AuthorizationCodeStore,
+    owners: ResourceOwnerStore
+  )
+
+  final case class TestSecretConfig(
+    client: Secret.ClientConfig = Secret.ClientConfig(
+      algorithm = "PBKDF2WithHmacSHA512",
+      iterations = 10000,
+      derivedKeySize = 32,
+      saltSize = 16,
+      authenticationDelay = 20.millis
+    ),
+    owner: Secret.ResourceOwnerConfig = Secret.ResourceOwnerConfig(
+      algorithm = "PBKDF2WithHmacSHA512",
+      iterations = 10000,
+      derivedKeySize = 32,
+      saltSize = 16,
+      authenticationDelay = 20.millis
+    )
+  )
+}

--- a/identity/src/test/scala/stasis/test/specs/unit/identity/api/oauth/RefreshTokenGrantSpec.scala
+++ b/identity/src/test/scala/stasis/test/specs/unit/identity/api/oauth/RefreshTokenGrantSpec.scala
@@ -1,0 +1,131 @@
+package stasis.test.specs.unit.identity.api.oauth
+
+import akka.http.scaladsl.model
+import akka.http.scaladsl.model.headers.{BasicHttpCredentials, CacheDirectives}
+import akka.http.scaladsl.model.{ContentTypes, StatusCodes, Uri}
+import stasis.identity.api.oauth.RefreshTokenGrant
+import stasis.identity.api.oauth.RefreshTokenGrant.{AccessTokenRequest, AccessTokenResponse}
+import stasis.identity.model.GrantType
+import stasis.identity.model.secrets.Secret
+import stasis.identity.model.tokens.{RefreshToken, TokenType}
+import stasis.test.specs.unit.identity.RouteTest
+import stasis.test.specs.unit.identity.model.Generators
+
+class RefreshTokenGrantSpec extends RouteTest with OAuthFixtures {
+  import de.heikoseeberger.akkahttpplayjson.PlayJsonSupport._
+
+  "RefreshTokenGrant routes" should "validate access token requests content" in {
+    val request = AccessTokenRequest(
+      grant_type = GrantType.RefreshToken,
+      refresh_token = RefreshToken("some-token"),
+      scope = Some("some-scope")
+    )
+
+    an[IllegalArgumentException] should be thrownBy request.copy(grant_type = GrantType.ClientCredentials)
+    an[IllegalArgumentException] should be thrownBy request.copy(refresh_token = RefreshToken(""))
+    an[IllegalArgumentException] should be thrownBy request.copy(scope = Some(""))
+  }
+
+  they should "generate access and refresh tokens for valid refresh tokens" in {
+    val (stores, secrets, providers) = createOAuthFixtures()
+    val grant = new RefreshTokenGrant(providers)
+
+    val realm = Generators.generateRealm
+    val owner = Generators.generateResourceOwner.copy(realm = realm.id)
+    val api = Generators.generateApi
+
+    val rawPassword = "some-password"
+    val salt = Generators.generateString(withSize = secrets.client.saltSize)
+    val client = Generators.generateClient.copy(
+      realm = realm.id,
+      secret = Secret.derive(rawPassword, salt)(secrets.client),
+      salt = salt
+    )
+    val credentials = BasicHttpCredentials(client.id.toString, rawPassword)
+
+    val token = Generators.generateRefreshToken
+
+    val request = AccessTokenRequest(
+      grant_type = GrantType.RefreshToken,
+      refresh_token = token,
+      scope = grant.apiAudienceToScope(Seq(api))
+    )
+
+    stores.owners.put(owner).await
+    stores.apis.put(api).await
+    stores.clients.put(client).await
+    stores.tokens.put(client.id, token, owner, request.scope).await
+    Post(request).addCredentials(credentials) ~> grant.token(realm) ~> check {
+      status should be(StatusCodes.OK)
+
+      headers should contain(model.headers.`Content-Type`(ContentTypes.`application/json`))
+      headers should contain(model.headers.`Cache-Control`(CacheDirectives.`no-store`))
+
+      val actualResponse = responseAs[AccessTokenResponse]
+      actualResponse.access_token.value.nonEmpty should be(true)
+      actualResponse.token_type should be(TokenType.Bearer)
+      actualResponse.expires_in.value should be > 0L
+      actualResponse.refresh_token.exists(_.value.nonEmpty) should be(true)
+      actualResponse.scope should be(request.scope)
+
+      val newTokenGenerated = stores.tokens.get(client.id).await.exists(_.token != token)
+      newTokenGenerated should be(true)
+    }
+  }
+
+  they should "generate only access tokens when refresh tokens are not allowed" in {
+    val (stores, secrets, providers) = createOAuthFixtures()
+    val grant = new RefreshTokenGrant(providers)
+
+    val realm = Generators.generateRealm.copy(refreshTokensAllowed = false)
+    val owner = Generators.generateResourceOwner.copy(realm = realm.id)
+    val api = Generators.generateApi
+
+    val rawPassword = "some-password"
+    val salt = Generators.generateString(withSize = secrets.client.saltSize)
+    val client = Generators.generateClient.copy(
+      realm = realm.id,
+      secret = Secret.derive(rawPassword, salt)(secrets.client),
+      salt = salt
+    )
+    val credentials = BasicHttpCredentials(client.id.toString, rawPassword)
+
+    val token = Generators.generateRefreshToken
+
+    val request = AccessTokenRequest(
+      grant_type = GrantType.RefreshToken,
+      refresh_token = token,
+      scope = grant.apiAudienceToScope(Seq(api))
+    )
+
+    stores.owners.put(owner).await
+    stores.apis.put(api).await
+    stores.clients.put(client).await
+    stores.tokens.put(client.id, token, owner, request.scope).await
+    Post(request).addCredentials(credentials) ~> grant.token(realm) ~> check {
+      status should be(StatusCodes.OK)
+
+      headers should contain(model.headers.`Content-Type`(ContentTypes.`application/json`))
+      headers should contain(model.headers.`Cache-Control`(CacheDirectives.`no-store`))
+
+      val actualResponse = responseAs[AccessTokenResponse]
+      actualResponse.access_token.value.nonEmpty should be(true)
+      actualResponse.token_type should be(TokenType.Bearer)
+      actualResponse.expires_in.value should be > 0L
+      actualResponse.refresh_token should be(None)
+      actualResponse.scope should be(request.scope)
+
+      stores.tokens.tokens.await should be(Map.empty)
+    }
+  }
+
+  import scala.language.implicitConversions
+
+  implicit def accessTokenRequestToLocalUri(request: AccessTokenRequest): Uri =
+    Uri(
+      s"/" +
+        s"?grant_type=refresh_token" +
+        s"&refresh_token=${request.refresh_token.value}" +
+        s"&scope=${request.scope.getOrElse("")}"
+    )
+}

--- a/identity/src/test/scala/stasis/test/specs/unit/identity/api/oauth/ResourceOwnerPasswordCredentialsGrantSpec.scala
+++ b/identity/src/test/scala/stasis/test/specs/unit/identity/api/oauth/ResourceOwnerPasswordCredentialsGrantSpec.scala
@@ -1,0 +1,144 @@
+package stasis.test.specs.unit.identity.api.oauth
+
+import akka.http.scaladsl.model
+import akka.http.scaladsl.model.headers.{BasicHttpCredentials, CacheDirectives}
+import akka.http.scaladsl.model.{ContentTypes, StatusCodes, Uri}
+import stasis.identity.api.oauth.ResourceOwnerPasswordCredentialsGrant
+import stasis.identity.api.oauth.ResourceOwnerPasswordCredentialsGrant.{AccessTokenRequest, AccessTokenResponse}
+import stasis.identity.model.GrantType
+import stasis.identity.model.secrets.Secret
+import stasis.identity.model.tokens.TokenType
+import stasis.test.specs.unit.identity.RouteTest
+import stasis.test.specs.unit.identity.model.Generators
+
+class ResourceOwnerPasswordCredentialsGrantSpec extends RouteTest with OAuthFixtures {
+  import de.heikoseeberger.akkahttpplayjson.PlayJsonSupport._
+
+  "ResourceOwnerPasswordCredentialsGrant routes" should "validate access token requests content" in {
+    val request = AccessTokenRequest(
+      grant_type = GrantType.Password,
+      username = "some-username",
+      password = "some-password",
+      scope = Some("some-scope")
+    )
+
+    an[IllegalArgumentException] should be thrownBy request.copy(grant_type = GrantType.ClientCredentials)
+    an[IllegalArgumentException] should be thrownBy request.copy(username = "")
+    an[IllegalArgumentException] should be thrownBy request.copy(password = "")
+    an[IllegalArgumentException] should be thrownBy request.copy(scope = Some(""))
+  }
+
+  they should "generate access and refresh tokens for valid requests" in {
+    val (stores, secrets, providers) = createOAuthFixtures()
+    val grant = new ResourceOwnerPasswordCredentialsGrant(providers)
+
+    val realm = Generators.generateRealm
+    val api = Generators.generateApi
+
+    val clientRawPassword = "some-password"
+    val clientSalt = Generators.generateString(withSize = secrets.client.saltSize)
+    val client = Generators.generateClient.copy(
+      realm = realm.id,
+      secret = Secret.derive(clientRawPassword, clientSalt)(secrets.client),
+      salt = clientSalt
+    )
+    val credentials = BasicHttpCredentials(client.id.toString, clientRawPassword)
+
+    val ownerRawPassword = "some-password"
+    val ownerSalt = Generators.generateString(withSize = secrets.owner.saltSize)
+    val owner = Generators.generateResourceOwner.copy(
+      realm = realm.id,
+      password = Secret.derive(ownerRawPassword, ownerSalt)(secrets.owner),
+      salt = ownerSalt
+    )
+
+    val request = AccessTokenRequest(
+      grant_type = GrantType.Password,
+      username = owner.username,
+      password = ownerRawPassword,
+      scope = grant.apiAudienceToScope(Seq(api))
+    )
+
+    stores.apis.put(api).await
+    stores.clients.put(client).await
+    stores.owners.put(owner).await
+    Post(request).addCredentials(credentials) ~> grant.token(realm) ~> check {
+      status should be(StatusCodes.OK)
+
+      headers should contain(model.headers.`Content-Type`(ContentTypes.`application/json`))
+      headers should contain(model.headers.`Cache-Control`(CacheDirectives.`no-store`))
+
+      val actualResponse = responseAs[AccessTokenResponse]
+      actualResponse.access_token.value.nonEmpty should be(true)
+      actualResponse.token_type should be(TokenType.Bearer)
+      actualResponse.expires_in.value should be > 0L
+      actualResponse.refresh_token.exists(_.value.nonEmpty) should be(true)
+      actualResponse.scope should be(request.scope)
+
+      val refreshTokenGenerated = stores.tokens.get(client.id).await.nonEmpty
+      refreshTokenGenerated should be(true)
+    }
+  }
+
+  they should "generate only access tokens when refresh tokens are not allowed" in {
+    val (stores, secrets, providers) = createOAuthFixtures()
+    val grant = new ResourceOwnerPasswordCredentialsGrant(providers)
+
+    val realm = Generators.generateRealm.copy(refreshTokensAllowed = false)
+    val api = Generators.generateApi
+
+    val clientRawPassword = "some-password"
+    val clientSalt = Generators.generateString(withSize = secrets.client.saltSize)
+    val client = Generators.generateClient.copy(
+      realm = realm.id,
+      secret = Secret.derive(clientRawPassword, clientSalt)(secrets.client),
+      salt = clientSalt
+    )
+    val credentials = BasicHttpCredentials(client.id.toString, clientRawPassword)
+
+    val ownerRawPassword = "some-password"
+    val ownerSalt = Generators.generateString(withSize = secrets.owner.saltSize)
+    val owner = Generators.generateResourceOwner.copy(
+      realm = realm.id,
+      password = Secret.derive(ownerRawPassword, ownerSalt)(secrets.owner),
+      salt = ownerSalt
+    )
+
+    val request = AccessTokenRequest(
+      grant_type = GrantType.Password,
+      username = owner.username,
+      password = ownerRawPassword,
+      scope = grant.apiAudienceToScope(Seq(api))
+    )
+
+    stores.apis.put(api).await
+    stores.clients.put(client).await
+    stores.owners.put(owner).await
+    Post(request).addCredentials(credentials) ~> grant.token(realm) ~> check {
+      status should be(StatusCodes.OK)
+
+      headers should contain(model.headers.`Content-Type`(ContentTypes.`application/json`))
+      headers should contain(model.headers.`Cache-Control`(CacheDirectives.`no-store`))
+
+      val actualResponse = responseAs[AccessTokenResponse]
+      actualResponse.access_token.value.nonEmpty should be(true)
+      actualResponse.token_type should be(TokenType.Bearer)
+      actualResponse.expires_in.value should be > 0L
+      actualResponse.refresh_token should be(None)
+      actualResponse.scope should be(request.scope)
+
+      stores.tokens.tokens.await should be(Map.empty)
+    }
+  }
+
+  import scala.language.implicitConversions
+
+  implicit def accessTokenRequestToLocalUri(request: AccessTokenRequest): Uri =
+    Uri(
+      s"/" +
+        s"?grant_type=password" +
+        s"&username=${request.username}" +
+        s"&password=${request.password}" +
+        s"&scope=${request.scope.getOrElse("")}"
+    )
+}

--- a/identity/src/test/scala/stasis/test/specs/unit/identity/api/oauth/directives/AccessTokenGenerationSpec.scala
+++ b/identity/src/test/scala/stasis/test/specs/unit/identity/api/oauth/directives/AccessTokenGenerationSpec.scala
@@ -1,0 +1,58 @@
+package stasis.test.specs.unit.identity.api.oauth.directives
+
+import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.server.Directives
+import akka.stream.{ActorMaterializer, Materializer}
+import stasis.identity.api.Formats._
+import stasis.identity.api.oauth.directives.AccessTokenGeneration
+import stasis.identity.model.apis.Api
+import stasis.identity.model.clients.Client
+import stasis.identity.model.owners.ResourceOwner
+import stasis.identity.model.tokens.AccessToken
+import stasis.identity.model.tokens.generators.AccessTokenGenerator
+import stasis.test.specs.unit.identity.RouteTest
+import stasis.test.specs.unit.identity.model.Generators
+
+class AccessTokenGenerationSpec extends RouteTest {
+  "An AccessTokenGeneration directive" should "generate access tokens for clients" in {
+    val expectedToken = "some-token"
+
+    val directive = new AccessTokenGeneration {
+      override implicit protected def mat: Materializer = ActorMaterializer()
+      override protected def accessTokenGenerator: AccessTokenGenerator = createGenerator(expectedToken)
+    }
+
+    val routes = directive.generateAccessToken(client = Generators.generateClient, audience = Seq.empty) { token =>
+      Directives.complete(StatusCodes.OK, token.value)
+    }
+
+    Get() ~> routes ~> check {
+      status should be(StatusCodes.OK)
+      responseAs[String] should be(expectedToken)
+    }
+  }
+
+  it should "generate access tokens for resource owners" in {
+    val expectedToken = "some-token"
+
+    val directive = new AccessTokenGeneration {
+      override implicit protected def mat: Materializer = ActorMaterializer()
+      override protected def accessTokenGenerator: AccessTokenGenerator = createGenerator(expectedToken)
+    }
+
+    val routes = directive.generateAccessToken(owner = Generators.generateResourceOwner, audience = Seq.empty) {
+      token =>
+        Directives.complete(StatusCodes.OK, token.value)
+    }
+
+    Get() ~> routes ~> check {
+      status should be(StatusCodes.OK)
+      responseAs[String] should be(expectedToken)
+    }
+  }
+
+  private def createGenerator(token: String) = new AccessTokenGenerator {
+    override def generate(client: Client, audience: Seq[Client]): AccessToken = AccessToken(value = token)
+    override def generate(owner: ResourceOwner, audience: Seq[Api]): AccessToken = AccessToken(value = token)
+  }
+}

--- a/identity/src/test/scala/stasis/test/specs/unit/identity/api/oauth/directives/AudienceExtractionSpec.scala
+++ b/identity/src/test/scala/stasis/test/specs/unit/identity/api/oauth/directives/AudienceExtractionSpec.scala
@@ -1,0 +1,175 @@
+package stasis.test.specs.unit.identity.api.oauth.directives
+
+import akka.event.LoggingAdapter
+import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.server.Directives
+import akka.stream.{ActorMaterializer, Materializer}
+import play.api.libs.json._
+import stasis.identity.api.Formats._
+import stasis.identity.api.oauth.directives.AudienceExtraction
+import stasis.identity.model.apis.{ApiStore, ApiStoreView}
+import stasis.identity.model.clients.{ClientStore, ClientStoreView}
+import stasis.test.specs.unit.identity.RouteTest
+import stasis.test.specs.unit.identity.model.Generators
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class AudienceExtractionSpec extends RouteTest {
+  import de.heikoseeberger.akkahttpplayjson.PlayJsonSupport._
+
+  "An AudienceExtraction directive" should "convert client audience to scopes" in {
+    val directive = createDirective(clients = createClientStore(), apis = createApiStore())
+
+    val clients = Generators.generateSeq(min = 1, g = Generators.generateClient)
+    val validScope = directive.clientAudienceToScope(clients)
+    val missingScope = directive.clientAudienceToScope(audience = Seq.empty)
+
+    validScope.isDefined should be(true)
+    missingScope.isDefined should be(false)
+
+    val clientIds = validScope
+      .map(_.split(" ").toSeq)
+      .getOrElse(Seq.empty)
+      .flatMap(_.split(":").lastOption)
+      .map(java.util.UUID.fromString)
+
+    clientIds should be(clients.map(_.id))
+  }
+
+  it should "convert API audience to scopes" in {
+    val directive = createDirective(clients = createClientStore(), apis = createApiStore())
+
+    val apis = Generators.generateSeq(min = 1, g = Generators.generateApi)
+    val validScope = directive.apiAudienceToScope(apis)
+    val missingScope = directive.apiAudienceToScope(audience = Seq.empty)
+
+    validScope.isDefined should be(true)
+    missingScope.isDefined should be(false)
+
+    val apiIds = validScope
+      .map(_.split(" ").toSeq)
+      .getOrElse(Seq.empty)
+      .flatMap(_.split(":").lastOption)
+
+    apiIds should be(apis.map(_.id))
+  }
+
+  it should "extract audience from valid client identifiers" in {
+    val clientStore = createClientStore()
+    val apiStore = createApiStore()
+    val directive = createDirective(clients = clientStore, apis = apiStore)
+
+    val clients = Generators.generateSeq(min = 1, g = Generators.generateClient)
+    val scope = directive.clientAudienceToScope(clients)
+
+    val routes = directive.extractClientAudience(scopeOpt = scope) { clients =>
+      Directives.complete(StatusCodes.OK, clients.map(_.id.toString).mkString(","))
+    }
+
+    Future.sequence(clients.map(clientStore.put)).await
+    Get() ~> routes ~> check {
+      status should be(StatusCodes.OK)
+      responseAs[String] should be(clients.map(_.id.toString).mkString(","))
+    }
+  }
+
+  it should "fail to extract audience from invalid client identifiers" in {
+    val clientStore = createClientStore()
+    val apiStore = createApiStore()
+    val directive = createDirective(clients = clientStore, apis = apiStore)
+
+    val invalidScope = s"${AudienceExtraction.UrnPrefix}:some-client"
+
+    val routes = directive.extractClientAudience(scopeOpt = Some(invalidScope)) { _ =>
+      Directives.complete(StatusCodes.OK)
+    }
+
+    Get() ~> routes ~> check {
+      status should be(StatusCodes.BadRequest)
+      responseAs[JsObject].fields should contain("error" -> JsString("invalid_scope"))
+    }
+  }
+
+  it should "extract audience from API identifiers" in {
+    val clientStore = createClientStore()
+    val apiStore = createApiStore()
+    val directive = createDirective(clients = clientStore, apis = apiStore)
+
+    val apis = Generators.generateSeq(min = 1, g = Generators.generateApi)
+    val scope = directive.apiAudienceToScope(apis)
+
+    val routes = directive.extractApiAudience(scopeOpt = scope) { apis =>
+      Directives.complete(StatusCodes.OK, apis.map(_.id).mkString(","))
+    }
+
+    Future.sequence(apis.map(apiStore.put)).await
+    Get() ~> routes ~> check {
+      status should be(StatusCodes.OK)
+      responseAs[String] should be(apis.map(_.id).mkString(","))
+    }
+
+  }
+
+  it should "fail to extract audience from missing scopes" in {
+    val clientStore = createClientStore()
+    val apiStore = createApiStore()
+    val directive = createDirective(clients = clientStore, apis = apiStore)
+
+    val routes = directive.extractClientAudience(scopeOpt = None) { clients =>
+      Directives.complete(StatusCodes.OK, clients.map(_.id.toString).mkString(","))
+    }
+
+    Get() ~> routes ~> check {
+      status should be(StatusCodes.BadRequest)
+      responseAs[JsObject].fields should contain("error" -> JsString("invalid_scope"))
+    }
+  }
+
+  it should "fail to extract audience from invalid scopes" in {
+    val clientStore = createClientStore()
+    val apiStore = createApiStore()
+    val directive = createDirective(clients = clientStore, apis = apiStore)
+
+    val clients = Generators.generateSeq(min = 1, g = Generators.generateClient)
+
+    val routes = directive.extractClientAudience(scopeOpt = Some("invalid-scope")) { clients =>
+      Directives.complete(StatusCodes.OK, clients.map(_.id.toString).mkString(","))
+    }
+
+    Future.sequence(clients.map(clientStore.put)).await
+    Get() ~> routes ~> check {
+      status should be(StatusCodes.BadRequest)
+      responseAs[JsObject].fields should contain("error" -> JsString("invalid_scope"))
+    }
+  }
+
+  it should "fail to extract audience when target entity is missing" in {
+    val clientStore = createFailingClientStore(failingGet = true)
+    val apiStore = createApiStore()
+    val directive = createDirective(clients = clientStore, apis = apiStore)
+
+    val clients = Generators.generateSeq(min = 1, g = Generators.generateClient)
+    val scope = directive.clientAudienceToScope(clients)
+
+    val routes = directive.extractClientAudience(scopeOpt = scope) { clients =>
+      Directives.complete(StatusCodes.OK, clients.map(_.id.toString).mkString(","))
+    }
+
+    Future.sequence(clients.map(clientStore.put)).await
+    Get() ~> routes ~> check {
+      status should be(StatusCodes.InternalServerError)
+    }
+  }
+
+  private def createDirective(
+    clients: ClientStore,
+    apis: ApiStore
+  ) =
+    new AudienceExtraction {
+      override implicit protected def mat: Materializer = ActorMaterializer()
+      override implicit protected def ec: ExecutionContext = system.dispatcher
+      override protected def log: LoggingAdapter = createLogger()
+      override protected def clientStore: ClientStoreView = clients.view
+      override protected def apiStore: ApiStoreView = apis.view
+    }
+}

--- a/identity/src/test/scala/stasis/test/specs/unit/identity/api/oauth/directives/AuthorizationCodeConsumptionSpec.scala
+++ b/identity/src/test/scala/stasis/test/specs/unit/identity/api/oauth/directives/AuthorizationCodeConsumptionSpec.scala
@@ -1,0 +1,124 @@
+package stasis.test.specs.unit.identity.api.oauth.directives
+
+import akka.event.LoggingAdapter
+import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.server.Directives
+import akka.stream.{ActorMaterializer, Materializer}
+import play.api.libs.json._
+import stasis.identity.api.Formats._
+import stasis.identity.api.oauth.directives.AuthorizationCodeConsumption
+import stasis.identity.model.clients.Client
+import stasis.identity.model.codes.AuthorizationCodeStore
+import stasis.test.specs.unit.identity.RouteTest
+import stasis.test.specs.unit.identity.model.Generators
+
+import scala.concurrent.ExecutionContext
+
+class AuthorizationCodeConsumptionSpec extends RouteTest {
+  import de.heikoseeberger.akkahttpplayjson.PlayJsonSupport._
+
+  "An AuthorizationCodeConsumption directive" should "consume valid authorization codes" in {
+    val codes = createCodeStore()
+    val directive = createDirective(codes)
+
+    val client = Client.generateId()
+    val owner = Generators.generateResourceOwner
+    val code = Generators.generateAuthorizationCode
+    val scope = "some-scope"
+
+    val routes = directive.consumeAuthorizationCode(client, code) {
+      case (extractedOwner, extractedScope) =>
+        Directives.complete(
+          StatusCodes.OK,
+          Json.obj(
+            "owner" -> JsString(extractedOwner.username),
+            "scope" -> Json.toJson(extractedScope)
+          )
+        )
+    }
+
+    codes.put(client, code, owner, scope = Some(scope)).await
+    Get() ~> routes ~> check {
+      status should be(StatusCodes.OK)
+      val fields = responseAs[JsObject].fields
+      fields should contain("owner" -> JsString(owner.username))
+      fields should contain("scope" -> JsString(scope))
+      codes.codes.await should be(Map.empty)
+    }
+  }
+
+  it should "fail if the provided and found authorization codes do not match" in {
+    val codes = createCodeStore()
+    val directive = createDirective(codes)
+
+    val client = Client.generateId()
+    val owner = Generators.generateResourceOwner
+    val code = Generators.generateAuthorizationCode
+    val scope = "some-scope"
+
+    val routes = directive.consumeAuthorizationCode(client, code) {
+      case (_, _) =>
+        Directives.complete(StatusCodes.OK)
+    }
+
+    codes.put(client, Generators.generateAuthorizationCode, owner, scope = Some(scope)).await
+    Get() ~> routes ~> check {
+      status should be(StatusCodes.BadRequest)
+      responseAs[JsObject].fields should contain("error" -> JsString("invalid_grant"))
+    }
+  }
+
+  it should "fail if no authorization codes are found for clients" in {
+    val codes = createCodeStore()
+    val directive = createDirective(codes)
+
+    val client = Client.generateId()
+    val code = Generators.generateAuthorizationCode
+
+    val routes = directive.consumeAuthorizationCode(client, code) {
+      case (_, _) =>
+        Directives.complete(StatusCodes.OK)
+    }
+
+    Get() ~> routes ~> check {
+      status should be(StatusCodes.BadRequest)
+      responseAs[JsObject].fields should contain("error" -> JsString("invalid_grant"))
+    }
+  }
+
+  it should "fail if authorization codes could not be queried" in {
+    val codes = createFailingCodeStore(failingGet = true)
+    val directive = createDirective(codes)
+
+    val client = Client.generateId()
+    val owner = Generators.generateResourceOwner
+    val code = Generators.generateAuthorizationCode
+    val scope = "some-scope"
+
+    val routes = directive.consumeAuthorizationCode(client, code) {
+      case (extractedOwner, extractedScope) =>
+        Directives.complete(
+          StatusCodes.OK,
+          Json.obj(
+            "owner" -> JsString(extractedOwner.username),
+            "scope" -> Json.toJson(extractedScope)
+          )
+        )
+    }
+
+    codes.put(client, code, owner, scope = Some(scope)).await
+    Get() ~> routes ~> check {
+      status should be(StatusCodes.InternalServerError)
+    }
+  }
+
+  private def createDirective(
+    codes: AuthorizationCodeStore
+  ) =
+    new AuthorizationCodeConsumption {
+      override implicit protected def mat: Materializer = ActorMaterializer()
+      override implicit protected def ec: ExecutionContext = system.dispatcher
+      override protected def log: LoggingAdapter = createLogger()
+      override protected def authorizationCodeStore: AuthorizationCodeStore = codes
+    }
+}

--- a/identity/src/test/scala/stasis/test/specs/unit/identity/api/oauth/directives/AuthorizationCodeGenerationSpec.scala
+++ b/identity/src/test/scala/stasis/test/specs/unit/identity/api/oauth/directives/AuthorizationCodeGenerationSpec.scala
@@ -1,0 +1,74 @@
+package stasis.test.specs.unit.identity.api.oauth.directives
+
+import akka.event.LoggingAdapter
+import akka.http.scaladsl.model
+import akka.http.scaladsl.model.{StatusCodes, Uri}
+import akka.http.scaladsl.server.Directives
+import akka.stream.{ActorMaterializer, Materializer}
+import stasis.identity.api.Formats._
+import stasis.identity.api.oauth.directives.AuthorizationCodeGeneration
+import stasis.identity.model.clients.Client
+import stasis.identity.model.codes.AuthorizationCodeStore
+import stasis.identity.model.codes.generators.{AuthorizationCodeGenerator, DefaultAuthorizationCodeGenerator}
+import stasis.test.specs.unit.identity.RouteTest
+import stasis.test.specs.unit.identity.model.Generators
+
+class AuthorizationCodeGenerationSpec extends RouteTest {
+  "An AuthorizationCodeGeneration directive" should "generate authorization codes" in {
+    val codes = createCodeStore()
+    val directive = createDirective(codes)
+
+    val client = Client.generateId()
+    val redirectUri = Uri("http://example.com/")
+    val state = "some-state"
+    val owner = Generators.generateResourceOwner
+    val scope = "some-scope"
+
+    val routes = directive.generateAuthorizationCode(client, redirectUri, state, owner, scope = Some(scope)) {
+      generatedCode =>
+        Directives.complete(StatusCodes.OK, generatedCode.value)
+    }
+
+    Get() ~> routes ~> check {
+      status should be(StatusCodes.OK)
+      val expectedCode = codes.get(client).await
+      Some(responseAs[String]) should be(expectedCode.map(_.code.value))
+    }
+  }
+
+  it should "fail if authorization codes could not be stored" in {
+    val codes = createFailingCodeStore(failingPut = true)
+    val directive = createDirective(codes)
+
+    val client = Client.generateId()
+    val redirectUri = Uri("http://example.com/")
+    val state = "some-state"
+    val owner = Generators.generateResourceOwner
+    val scope = "some-scope"
+
+    val routes = directive.generateAuthorizationCode(client, redirectUri, state, owner, scope = Some(scope)) {
+      generatedCode =>
+        Directives.complete(StatusCodes.OK, generatedCode.value)
+    }
+
+    Get() ~> routes ~> check {
+      status should be(StatusCodes.Found)
+      headers should contain(
+        model.headers.Location(Uri(s"$redirectUri?error=server_error&state=$state"))
+      )
+    }
+  }
+
+  private def createDirective(
+    codes: AuthorizationCodeStore
+  ) = new AuthorizationCodeGeneration {
+    override implicit protected def mat: Materializer = ActorMaterializer()
+
+    override protected def log: LoggingAdapter = createLogger()
+
+    override protected def authorizationCodeGenerator: AuthorizationCodeGenerator =
+      new DefaultAuthorizationCodeGenerator(codeSize = 16)
+
+    override protected def authorizationCodeStore: AuthorizationCodeStore = codes
+  }
+}

--- a/identity/src/test/scala/stasis/test/specs/unit/identity/api/oauth/directives/ClientAuthenticationSpec.scala
+++ b/identity/src/test/scala/stasis/test/specs/unit/identity/api/oauth/directives/ClientAuthenticationSpec.scala
@@ -1,0 +1,131 @@
+package stasis.test.specs.unit.identity.api.oauth.directives
+
+import akka.event.LoggingAdapter
+import akka.http.scaladsl.model
+import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.model.headers.{BasicHttpCredentials, HttpChallenges, OAuth2BearerToken}
+import akka.http.scaladsl.server.Directives
+import akka.stream.{ActorMaterializer, Materializer}
+import play.api.libs.json._
+import stasis.identity.api.Formats._
+import stasis.identity.api.oauth.directives.ClientAuthentication
+import stasis.identity.authentication.oauth.{ClientAuthenticator, DefaultClientAuthenticator}
+import stasis.identity.model.clients.ClientStore
+import stasis.identity.model.secrets.Secret
+import stasis.test.specs.unit.identity.RouteTest
+import stasis.test.specs.unit.identity.model.Generators
+
+import scala.concurrent.duration._
+
+class ClientAuthenticationSpec extends RouteTest {
+  import de.heikoseeberger.akkahttpplayjson.PlayJsonSupport._
+
+  "A ClientAuthentication directive" should "successfully authenticate clients" in {
+    val clients = createClientStore()
+    val directive = createDirective(clients)
+
+    val realm = Generators.generateRealm
+
+    val clientPassword = "some-password"
+    val salt = Secret.generateSalt()
+    val secret = Secret.derive(clientPassword, salt)
+    val client = Generators.generateClient.copy(secret = secret, salt = salt)
+    val credentials = BasicHttpCredentials(client.id.toString, clientPassword)
+
+    val routes = directive.authenticateClient(realm = realm) { extractedClient =>
+      Directives.complete(StatusCodes.OK, extractedClient.id.toString)
+    }
+
+    clients.put(client).await
+    Get().addCredentials(credentials) ~> routes ~> check {
+      status should be(StatusCodes.OK)
+      responseAs[JsString] should be(JsString(client.id.toString))
+    }
+  }
+
+  it should "fail if a client could not be authenticated" in {
+    val clients = createClientStore()
+    val directive = createDirective(clients)
+
+    val realm = Generators.generateRealm
+
+    val salt = Secret.generateSalt()
+    val secret = Secret.derive("some-password", salt)
+    val client = Generators.generateClient.copy(secret = secret, salt = salt)
+    val credentials = BasicHttpCredentials(client.id.toString, "invalid-password")
+
+    val routes = directive.authenticateClient(realm = realm) { extractedClient =>
+      Directives.complete(StatusCodes.OK, extractedClient.id.toString)
+    }
+
+    clients.put(client).await
+    Get().addCredentials(credentials) ~> routes ~> check {
+      status should be(StatusCodes.Unauthorized)
+      headers should contain(model.headers.`WWW-Authenticate`(HttpChallenges.basic(realm.id)))
+      responseAs[JsObject].fields should contain("error" -> JsString("invalid_client"))
+    }
+  }
+
+  it should "fail if a client provided unsupported credentials" in {
+    val clients = createClientStore()
+    val directive = createDirective(clients)
+
+    val realm = Generators.generateRealm
+
+    val salt = Secret.generateSalt()
+    val secret = Secret.derive("some-password", salt)
+    val client = Generators.generateClient.copy(secret = secret, salt = salt)
+    val credentials = OAuth2BearerToken("some-token")
+
+    val routes = directive.authenticateClient(realm = realm) { extractedClient =>
+      Directives.complete(StatusCodes.OK, extractedClient.id.toString)
+    }
+
+    clients.put(client).await
+    Get().addCredentials(credentials) ~> routes ~> check {
+      status should be(StatusCodes.Unauthorized)
+      headers should contain(model.headers.`WWW-Authenticate`(HttpChallenges.basic(realm.id)))
+      responseAs[JsObject].fields should contain("error" -> JsString("invalid_client"))
+    }
+  }
+
+  it should "fail if a client provided no credentials" in {
+    val clients = createClientStore()
+    val directive = createDirective(clients)
+
+    val realm = Generators.generateRealm
+    val client = Generators.generateClient
+
+    val routes = directive.authenticateClient(realm = realm) { extractedClient =>
+      Directives.complete(StatusCodes.OK, extractedClient.id.toString)
+    }
+
+    clients.put(client).await
+    Get() ~> routes ~> check {
+      status should be(StatusCodes.Unauthorized)
+      headers should contain(model.headers.`WWW-Authenticate`(HttpChallenges.basic(realm.id)))
+      responseAs[JsObject].fields should contain("error" -> JsString("invalid_client"))
+    }
+  }
+
+  private implicit val secretConfig: Secret.ClientConfig = Secret.ClientConfig(
+    algorithm = "PBKDF2WithHmacSHA512",
+    iterations = 10000,
+    derivedKeySize = 32,
+    saltSize = 16,
+    authenticationDelay = 20.millis
+  )
+
+  private def createDirective(
+    clients: ClientStore
+  ) = new ClientAuthentication {
+    override implicit protected def mat: Materializer = ActorMaterializer()
+
+    override protected def log: LoggingAdapter = createLogger()
+
+    override protected def clientAuthenticator: ClientAuthenticator = new DefaultClientAuthenticator(
+      store = clients.view,
+      secretConfig = secretConfig
+    )
+  }
+}

--- a/identity/src/test/scala/stasis/test/specs/unit/identity/api/oauth/directives/ClientRetrievalSpec.scala
+++ b/identity/src/test/scala/stasis/test/specs/unit/identity/api/oauth/directives/ClientRetrievalSpec.scala
@@ -1,0 +1,89 @@
+package stasis.test.specs.unit.identity.api.oauth.directives
+
+import akka.event.LoggingAdapter
+import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.server.Directives
+import akka.stream.{ActorMaterializer, Materializer}
+import stasis.identity.api.Formats._
+import stasis.identity.api.oauth.directives.ClientRetrieval
+import stasis.identity.model.clients.{ClientStore, ClientStoreView}
+import stasis.test.specs.unit.identity.RouteTest
+import stasis.test.specs.unit.identity.model.Generators
+
+class ClientRetrievalSpec extends RouteTest {
+  "A ClientRetrieval directive" should "retrieve active clients" in {
+    val clients = createClientStore()
+    val directive = createDirective(clients)
+
+    val client = Generators.generateClient
+
+    val routes = directive.retrieveClient(client.id) { extractedClient =>
+      Directives.complete(StatusCodes.OK, extractedClient.id.toString)
+    }
+
+    clients.put(client).await
+    Get() ~> routes ~> check {
+      status should be(StatusCodes.OK)
+      responseAs[String] should be(client.id.toString)
+    }
+  }
+
+  it should "fail if a client is not active" in {
+    val clients = createClientStore()
+    val directive = createDirective(clients)
+
+    val client = Generators.generateClient.copy(active = false)
+
+    val routes = directive.retrieveClient(client.id) { extractedClient =>
+      Directives.complete(StatusCodes.OK, extractedClient.id.toString)
+    }
+
+    clients.put(client).await
+    Get() ~> routes ~> check {
+      status should be(StatusCodes.BadRequest)
+      responseAs[String] should be("The request was made by an inactive client")
+    }
+  }
+
+  it should "fail if a client is not found" in {
+    val clients = createClientStore()
+    val directive = createDirective(clients)
+
+    val client = Generators.generateClient
+
+    val routes = directive.retrieveClient(client.id) { extractedClient =>
+      Directives.complete(StatusCodes.OK, extractedClient.id.toString)
+    }
+
+    Get() ~> routes ~> check {
+      status should be(StatusCodes.BadRequest)
+      responseAs[String] should be(
+        "The request has missing, invalid or mismatching redirection URI and/or client identifier"
+      )
+    }
+  }
+
+  it should "fail if clients could not be queried" in {
+    val clients = createFailingClientStore(failingGet = true)
+    val directive = createDirective(clients)
+
+    val client = Generators.generateClient
+
+    val routes = directive.retrieveClient(client.id) { extractedClient =>
+      Directives.complete(StatusCodes.OK, extractedClient.id.toString)
+    }
+
+    clients.put(client).await
+    Get() ~> routes ~> check {
+      status should be(StatusCodes.InternalServerError)
+    }
+  }
+
+  private def createDirective(
+    clients: ClientStore
+  ) = new ClientRetrieval {
+    override implicit protected def mat: Materializer = ActorMaterializer()
+    override protected def log: LoggingAdapter = createLogger()
+    override protected def clientStore: ClientStoreView = clients.view
+  }
+}

--- a/identity/src/test/scala/stasis/test/specs/unit/identity/api/oauth/directives/RefreshTokenConsumptionSpec.scala
+++ b/identity/src/test/scala/stasis/test/specs/unit/identity/api/oauth/directives/RefreshTokenConsumptionSpec.scala
@@ -1,0 +1,149 @@
+package stasis.test.specs.unit.identity.api.oauth.directives
+
+import akka.event.LoggingAdapter
+import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.server.Directives
+import akka.stream.{ActorMaterializer, Materializer}
+import play.api.libs.json._
+import stasis.identity.api.Formats._
+import stasis.identity.api.oauth.directives.RefreshTokenConsumption
+import stasis.identity.model.clients.Client
+import stasis.identity.model.tokens.RefreshTokenStore
+import stasis.test.specs.unit.identity.RouteTest
+import stasis.test.specs.unit.identity.model.Generators
+
+import scala.concurrent.ExecutionContext
+
+class RefreshTokenConsumptionSpec extends RouteTest {
+  import de.heikoseeberger.akkahttpplayjson.PlayJsonSupport._
+
+  "A RefreshTokenConsumption directive" should "validate provided and stored scopes" in {
+    val tokens = createTokenStore()
+    val directive = createDirective(tokens)
+
+    directive.providedScopeAllowed(
+      stored = Some("a b c d"),
+      provided = Some("b c")
+    ) should be(true) // provided in stored
+
+    directive.providedScopeAllowed(
+      stored = Some("a b c d"),
+      provided = Some("d e")
+    ) should be(false) // provided NOT in stored
+
+    directive.providedScopeAllowed(
+      stored = Some("a b c d"),
+      provided = None
+    ) should be(false) // provided is empty
+
+    directive.providedScopeAllowed(
+      stored = None,
+      provided = Some("b c")
+    ) should be(false) // stored is empty
+  }
+
+  it should "consume valid refresh tokens with expected scopes" in {
+    val tokens = createTokenStore()
+    val directive = createDirective(tokens)
+
+    val client = Client.generateId()
+    val owner = Generators.generateResourceOwner
+    val token = Generators.generateRefreshToken
+    val scope = Some("some-scope")
+
+    val routes = directive.consumeRefreshToken(client, scope, token) { extractedOwner =>
+      Directives.complete(StatusCodes.OK, extractedOwner.username)
+    }
+
+    tokens.put(client, token, owner, scope).await
+    Get() ~> routes ~> check {
+      status should be(StatusCodes.OK)
+      responseAs[String] should be(owner.username)
+      tokens.tokens.await should be(Map.empty)
+    }
+  }
+
+  it should "fail to consume valid refresh tokens without needed scopes" in {
+    val tokens = createTokenStore()
+    val directive = createDirective(tokens)
+
+    val client = Client.generateId()
+    val owner = Generators.generateResourceOwner
+    val token = Generators.generateRefreshToken
+    val scope = Some("some-scope")
+
+    val routes = directive.consumeRefreshToken(client, providedScope = Some("other-scope"), token) { extractedOwner =>
+      Directives.complete(StatusCodes.OK, extractedOwner.username)
+    }
+
+    tokens.put(client, token, owner, scope).await
+    Get() ~> routes ~> check {
+      status should be(StatusCodes.BadRequest)
+      responseAs[JsObject].fields should contain("error" -> JsString("invalid_scope"))
+    }
+  }
+
+  it should "fail if the provided and found refresh tokens do not match" in {
+    val tokens = createTokenStore()
+    val directive = createDirective(tokens)
+
+    val client = Client.generateId()
+    val owner = Generators.generateResourceOwner
+    val token = Generators.generateRefreshToken
+    val scope = Some("some-scope")
+
+    val routes = directive.consumeRefreshToken(client, scope, Generators.generateRefreshToken) { extractedOwner =>
+      Directives.complete(StatusCodes.OK, extractedOwner.username)
+    }
+
+    tokens.put(client, token, owner, scope).await
+    Get() ~> routes ~> check {
+      status should be(StatusCodes.BadRequest)
+      responseAs[JsObject].fields should contain("error" -> JsString("invalid_grant"))
+    }
+  }
+
+  it should "fail if no refresh tokens are found for clients" in {
+    val tokens = createTokenStore()
+    val directive = createDirective(tokens)
+
+    val client = Client.generateId()
+    val token = Generators.generateRefreshToken
+    val scope = Some("some-scope")
+
+    val routes = directive.consumeRefreshToken(client, scope, token) { extractedOwner =>
+      Directives.complete(StatusCodes.OK, extractedOwner.username)
+    }
+
+    Get() ~> routes ~> check {
+      status should be(StatusCodes.BadRequest)
+      responseAs[JsObject].fields should contain("error" -> JsString("invalid_grant"))
+    }
+  }
+
+  it should "fail if refresh tokens could not be queried" in {
+    val tokens = createFailingTokenStore(failingGet = true)
+    val directive = createDirective(tokens)
+
+    val client = Client.generateId()
+    val owner = Generators.generateResourceOwner
+    val token = Generators.generateRefreshToken
+    val scope = Some("some-scope")
+
+    val routes = directive.consumeRefreshToken(client, scope, token) { extractedOwner =>
+      Directives.complete(StatusCodes.OK, extractedOwner.username)
+    }
+
+    tokens.put(client, token, owner, scope).await
+    Get() ~> routes ~> check {
+      status should be(StatusCodes.InternalServerError)
+    }
+  }
+
+  private def createDirective(tokens: RefreshTokenStore) = new RefreshTokenConsumption {
+    override implicit protected def mat: Materializer = ActorMaterializer()
+    override implicit protected def ec: ExecutionContext = system.dispatcher
+    override protected def log: LoggingAdapter = createLogger()
+    override protected def refreshTokenStore: RefreshTokenStore = tokens
+  }
+}

--- a/identity/src/test/scala/stasis/test/specs/unit/identity/api/oauth/directives/RefreshTokenGenerationSpec.scala
+++ b/identity/src/test/scala/stasis/test/specs/unit/identity/api/oauth/directives/RefreshTokenGenerationSpec.scala
@@ -1,0 +1,110 @@
+package stasis.test.specs.unit.identity.api.oauth.directives
+
+import akka.event.LoggingAdapter
+import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.server.Directives
+import akka.stream.{ActorMaterializer, Materializer}
+import stasis.identity.api.Formats._
+import stasis.identity.api.oauth.directives.RefreshTokenGeneration
+import stasis.identity.model.clients.Client
+import stasis.identity.model.tokens.RefreshTokenStore
+import stasis.identity.model.tokens.generators.{RandomRefreshTokenGenerator, RefreshTokenGenerator}
+import stasis.test.specs.unit.identity.RouteTest
+import stasis.test.specs.unit.identity.model.Generators
+
+class RefreshTokenGenerationSpec extends RouteTest {
+  "A RefreshTokenGeneration directive" should "generate refresh tokens" in {
+    val tokens = createTokenStore()
+    val directive = createDirective(tokens)
+
+    val realm = Generators.generateRealm
+    val client = Client.generateId()
+    val owner = Generators.generateResourceOwner
+    val scope = Some("some-scope")
+
+    val routes = directive.generateRefreshToken(realm, client, owner, scope) {
+      case Some(token) =>
+        Directives.complete(StatusCodes.OK, token.value)
+
+      case None =>
+        Directives.complete(
+          StatusCodes.InternalServerError,
+          "Unexpected response received; no token generated"
+        )
+    }
+
+    Get() ~> routes ~> check {
+      val expectedToken = tokens.get(client).await match {
+        case Some(storedToken) => storedToken.token.value
+        case None              => fail("Unexpected response received; no token found")
+      }
+
+      status should be(StatusCodes.OK)
+      responseAs[String] should be(expectedToken)
+    }
+  }
+
+  it should "fail if refresh tokens could not be stored" in {
+    val tokens = createFailingTokenStore(failingPut = true)
+    val directive = createDirective(tokens)
+
+    val realm = Generators.generateRealm
+    val client = Client.generateId()
+    val owner = Generators.generateResourceOwner
+    val scope = Some("some-scope")
+
+    val routes = directive.generateRefreshToken(realm, client, owner, scope) {
+      case Some(token) =>
+        Directives.complete(StatusCodes.OK, token.value)
+
+      case None =>
+        Directives.complete(
+          StatusCodes.InternalServerError,
+          "Unexpected response received; no token generated"
+        )
+    }
+
+    Get() ~> routes ~> check {
+      status should be(StatusCodes.InternalServerError)
+    }
+  }
+
+  it should "fail if refresh token generation is not allowed for a realm" in {
+    val tokens = createTokenStore()
+    val directive = createDirective(tokens)
+
+    val realm = Generators.generateRealm.copy(refreshTokensAllowed = false)
+    val client = Client.generateId()
+    val owner = Generators.generateResourceOwner
+    val scope = Some("some-scope")
+
+    val routes = directive.generateRefreshToken(realm, client, owner, scope) {
+      case Some(_) =>
+        Directives.complete(
+          StatusCodes.InternalServerError,
+          "Unexpected response received; token generated"
+        )
+
+      case None =>
+        Directives.complete(StatusCodes.OK)
+    }
+
+    Get() ~> routes ~> check {
+      status should be(StatusCodes.OK)
+      tokens.tokens.await should be(Map.empty)
+    }
+  }
+
+  private def createDirective(
+    tokens: RefreshTokenStore
+  ) = new RefreshTokenGeneration {
+    override implicit protected def mat: Materializer = ActorMaterializer()
+
+    override protected def log: LoggingAdapter = createLogger()
+
+    override protected def refreshTokenGenerator: RefreshTokenGenerator =
+      new RandomRefreshTokenGenerator(tokenSize = 16)
+
+    override protected def refreshTokenStore: RefreshTokenStore = tokens
+  }
+}

--- a/identity/src/test/scala/stasis/test/specs/unit/identity/authentication/manage/DefaultResourceOwnerAuthenticatorSpec.scala
+++ b/identity/src/test/scala/stasis/test/specs/unit/identity/authentication/manage/DefaultResourceOwnerAuthenticatorSpec.scala
@@ -1,0 +1,162 @@
+package stasis.test.specs.unit.identity.authentication.manage
+
+import java.security.Key
+
+import akka.actor.typed.scaladsl.Behaviors
+import akka.actor.typed.{ActorSystem, Behavior, SpawnProtocol}
+import akka.http.scaladsl.model.headers.OAuth2BearerToken
+import org.jose4j.jws.AlgorithmIdentifiers
+import stasis.core.persistence.backends.memory.MemoryBackend
+import stasis.core.security.exceptions.AuthenticationFailure
+import stasis.core.security.jwt.{JwtAuthenticator, JwtKeyProvider}
+import stasis.identity.authentication.manage.DefaultResourceOwnerAuthenticator
+import stasis.identity.model.owners.{ResourceOwner, ResourceOwnerStore}
+import stasis.identity.model.tokens.generators.JwtBearerAccessTokenGenerator
+import stasis.test.specs.unit.AsyncUnitSpec
+import stasis.test.specs.unit.core.security.jwt.mocks.MockJwksGenerators
+import stasis.test.specs.unit.identity.model.Generators
+
+import scala.concurrent.Future
+import scala.concurrent.duration._
+import scala.util.control.NonFatal
+
+class DefaultResourceOwnerAuthenticatorSpec extends AsyncUnitSpec { test =>
+  "A DefaultResourceOwnerAuthenticator" should "authenticate resource owners with valid JWTs" in {
+    val store = createStore()
+
+    val expectedOwner = Generators.generateResourceOwner
+    val targetApi = Generators.generateApi
+
+    val authenticator = new DefaultResourceOwnerAuthenticator(
+      store = store.view,
+      underlying = new JwtAuthenticator(
+        provider = provider,
+        audience = targetApi.id.toString,
+        expirationTolerance = 10.seconds
+      )
+    )
+
+    val token = tokenGenerator.generate(expectedOwner, audience = Seq(targetApi))
+
+    for {
+      _ <- store.put(expectedOwner)
+      actualOwner <- authenticator.authenticate(credentials = OAuth2BearerToken(token.value))
+    } yield {
+      actualOwner should be(expectedOwner)
+    }
+  }
+
+  it should "fail to authenticate inactive resource owners" in {
+    val store = createStore()
+
+    val expectedOwner = Generators.generateResourceOwner.copy(active = false)
+    val targetApi = Generators.generateApi
+
+    val authenticator = new DefaultResourceOwnerAuthenticator(
+      store = store.view,
+      underlying = new JwtAuthenticator(
+        provider = provider,
+        audience = targetApi.id.toString,
+        expirationTolerance = 10.seconds
+      )
+    )
+
+    val token = tokenGenerator.generate(expectedOwner, audience = Seq(targetApi))
+
+    store
+      .put(expectedOwner)
+      .flatMap { _ =>
+        authenticator.authenticate(credentials = OAuth2BearerToken(token.value))
+      }
+      .map(result => fail(s"Unexpected result received: [$result]"))
+      .recoverWith {
+        case NonFatal(e) =>
+          e shouldBe an[AuthenticationFailure]
+          e.getMessage.contains(s"Resource owner [${expectedOwner.username}] is not active") should be(true)
+      }
+  }
+
+  it should "fail to authenticate resource owners with invalid JWTs" in {
+    val store = createStore()
+
+    val expectedOwner = Generators.generateResourceOwner
+    val targetApi = Generators.generateApi
+
+    val invalidAudience = "some-audience"
+
+    val authenticator = new DefaultResourceOwnerAuthenticator(
+      store = store.view,
+      underlying = new JwtAuthenticator(
+        provider = provider,
+        audience = invalidAudience,
+        expirationTolerance = 10.seconds
+      )
+    )
+
+    val token = tokenGenerator.generate(expectedOwner, audience = Seq(targetApi))
+
+    store
+      .put(expectedOwner)
+      .flatMap { _ =>
+        authenticator.authenticate(credentials = OAuth2BearerToken(token.value))
+      }
+      .map(result => fail(s"Unexpected result received: [$result]"))
+      .recoverWith {
+        case NonFatal(e) =>
+          e shouldBe an[AuthenticationFailure]
+          e.getMessage.contains(s"Expected $invalidAudience as an aud value") should be(true)
+      }
+  }
+
+  it should "fail to authenticate missing resource owners" in {
+    val store = createStore()
+
+    val expectedOwner = Generators.generateResourceOwner
+    val targetApi = Generators.generateApi
+
+    val authenticator = new DefaultResourceOwnerAuthenticator(
+      store = store.view,
+      underlying = new JwtAuthenticator(
+        provider = provider,
+        audience = targetApi.id.toString,
+        expirationTolerance = 10.seconds
+      )
+    )
+
+    val token = tokenGenerator.generate(expectedOwner, audience = Seq(targetApi))
+
+    authenticator
+      .authenticate(credentials = OAuth2BearerToken(token.value))
+      .map(result => fail(s"Unexpected result received: [$result]"))
+      .recoverWith {
+        case NonFatal(e) =>
+          e shouldBe an[AuthenticationFailure]
+          e.getMessage.contains(s"Resource owner [${expectedOwner.username}] not found") should be(true)
+      }
+  }
+
+  private implicit val system: ActorSystem[SpawnProtocol] = ActorSystem(
+    Behaviors.setup(_ => SpawnProtocol.behavior): Behavior[SpawnProtocol],
+    "DefaultResourceOwnerAuthenticatorSpec-manage"
+  )
+
+  private val issuer = "some-issuer"
+
+  private val jwk = MockJwksGenerators.generateRandomRsaKey(Some("some-key"))
+
+  private val provider = new JwtKeyProvider {
+    override def key(id: Option[String]): Future[Key] = Future.successful(jwk.getKey)
+    override def issuer: String = test.issuer
+    override def allowedAlgorithms: Seq[String] = Seq(AlgorithmIdentifiers.RSA_USING_SHA256)
+  }
+
+  private val tokenGenerator = new JwtBearerAccessTokenGenerator(
+    issuer = test.issuer,
+    jwk = jwk,
+    jwtExpiration = 3.seconds
+  )
+
+  private def createStore() = ResourceOwnerStore(
+    MemoryBackend[ResourceOwner.Id, ResourceOwner](name = s"owner-store-${java.util.UUID.randomUUID()}")
+  )
+}

--- a/identity/src/test/scala/stasis/test/specs/unit/identity/authentication/oauth/DefaultClientAuthenticatorSpec.scala
+++ b/identity/src/test/scala/stasis/test/specs/unit/identity/authentication/oauth/DefaultClientAuthenticatorSpec.scala
@@ -1,0 +1,136 @@
+package stasis.test.specs.unit.identity.authentication.oauth
+
+import akka.actor.typed.scaladsl.Behaviors
+import akka.actor.typed.scaladsl.adapter._
+import akka.actor.typed.{ActorSystem, Behavior, SpawnProtocol}
+import akka.http.scaladsl.model.headers.BasicHttpCredentials
+import stasis.core.persistence.backends.memory.MemoryBackend
+import stasis.core.security.exceptions.AuthenticationFailure
+import stasis.identity.authentication.oauth.DefaultClientAuthenticator
+import stasis.identity.model.clients.{Client, ClientStore}
+import stasis.identity.model.secrets.Secret
+import stasis.test.specs.unit.AsyncUnitSpec
+import stasis.test.specs.unit.identity.model.Generators
+
+import scala.concurrent.duration._
+import scala.util.control.NonFatal
+
+class DefaultClientAuthenticatorSpec extends AsyncUnitSpec {
+  "A DefaultClientAuthenticator" should "successfully authenticate clients" in {
+    val store = ClientStore(
+      MemoryBackend[Client.Id, Client](name = s"client-store-${java.util.UUID.randomUUID()}")
+    )
+
+    val expectedClient = Generators.generateClient.copy(
+      secret = clientSecret,
+      salt = clientSalt
+    )
+
+    val authenticator = new DefaultClientAuthenticator(
+      store = store.view,
+      secretConfig = secretConfig
+    )
+
+    for {
+      _ <- store.put(expectedClient)
+      actualClient <- authenticator.authenticate(BasicHttpCredentials(expectedClient.id.toString, clientPassword))
+    } yield {
+      actualClient should be(expectedClient)
+    }
+  }
+
+  it should "fail to authenticate inactive clients" in {
+    val store = ClientStore(
+      MemoryBackend[Client.Id, Client](name = s"client-store-${java.util.UUID.randomUUID()}")
+    )
+
+    val expectedClient = Generators.generateClient.copy(
+      secret = clientSecret,
+      salt = clientSalt,
+      active = false
+    )
+
+    val authenticator = new DefaultClientAuthenticator(
+      store = store.view,
+      secretConfig = secretConfig
+    )
+
+    store
+      .put(expectedClient)
+      .flatMap { _ =>
+        authenticator.authenticate(BasicHttpCredentials(expectedClient.id.toString, clientPassword))
+      }
+      .map(result => fail(s"Unexpected result received: [$result]"))
+      .recoverWith {
+        case NonFatal(e) =>
+          e shouldBe an[AuthenticationFailure]
+          e.getMessage.contains(s"Client [${expectedClient.id}] is not active") should be(true)
+      }
+  }
+
+  it should "fail to authenticate missing clients" in {
+    val store = ClientStore(
+      MemoryBackend[Client.Id, Client](name = s"client-store-${java.util.UUID.randomUUID()}")
+    )
+
+    val expectedClient = Generators.generateClient.copy(
+      secret = clientSecret,
+      salt = clientSalt
+    )
+
+    val authenticator = new DefaultClientAuthenticator(
+      store = store.view,
+      secretConfig = secretConfig
+    )
+
+    authenticator
+      .authenticate(BasicHttpCredentials(expectedClient.id.toString, clientPassword))
+      .map(result => fail(s"Unexpected result received: [$result]"))
+      .recoverWith {
+        case NonFatal(e) =>
+          e shouldBe an[AuthenticationFailure]
+          e.getMessage.contains(s"Client [${expectedClient.id}] was not found") should be(true)
+      }
+  }
+
+  it should "fail to authenticate clients with invalid IDs" in {
+    val store = ClientStore(
+      MemoryBackend[Client.Id, Client](name = s"client-store-${java.util.UUID.randomUUID()}")
+    )
+
+    val clientId = "some-client"
+
+    val authenticator = new DefaultClientAuthenticator(
+      store = store.view,
+      secretConfig = secretConfig
+    )
+
+    authenticator
+      .authenticate(BasicHttpCredentials(clientId, clientPassword))
+      .map(result => fail(s"Unexpected result received: [$result]"))
+      .recoverWith {
+        case NonFatal(e) =>
+          e shouldBe an[AuthenticationFailure]
+          e.getMessage.contains(s"Invalid client identifier provided: [$clientId]") should be(true)
+      }
+  }
+
+  private implicit val system: ActorSystem[SpawnProtocol] = ActorSystem(
+    Behaviors.setup(_ => SpawnProtocol.behavior): Behavior[SpawnProtocol],
+    "DefaultClientAuthenticatorSpec"
+  )
+
+  private implicit val untypedSystem: akka.actor.ActorSystem = system.toUntyped
+
+  private implicit val secretConfig: Secret.ClientConfig = Secret.ClientConfig(
+    algorithm = "PBKDF2WithHmacSHA512",
+    iterations = 10000,
+    derivedKeySize = 32,
+    saltSize = 16,
+    authenticationDelay = 50.millis
+  )
+
+  private val clientPassword = "some-password"
+  private val clientSalt = "some-salt"
+  private val clientSecret = Secret.derive(clientPassword, clientSalt)
+}

--- a/identity/src/test/scala/stasis/test/specs/unit/identity/authentication/oauth/DefaultResourceOwnerAuthenticatorSpec.scala
+++ b/identity/src/test/scala/stasis/test/specs/unit/identity/authentication/oauth/DefaultResourceOwnerAuthenticatorSpec.scala
@@ -1,0 +1,114 @@
+package stasis.test.specs.unit.identity.authentication.oauth
+
+import akka.actor.typed.scaladsl.Behaviors
+import akka.actor.typed.scaladsl.adapter._
+import akka.actor.typed.{ActorSystem, Behavior, SpawnProtocol}
+import akka.http.scaladsl.model.headers.BasicHttpCredentials
+import stasis.core.persistence.backends.memory.MemoryBackend
+import stasis.core.security.exceptions.AuthenticationFailure
+import stasis.identity.authentication.oauth.DefaultResourceOwnerAuthenticator
+import stasis.identity.model.owners.{ResourceOwner, ResourceOwnerStore}
+import stasis.identity.model.secrets.Secret
+import stasis.test.specs.unit.AsyncUnitSpec
+import stasis.test.specs.unit.identity.model.Generators
+
+import scala.concurrent.duration._
+import scala.util.control.NonFatal
+
+class DefaultResourceOwnerAuthenticatorSpec extends AsyncUnitSpec {
+  "A DefaultResourceOwnerAuthenticator" should "successfully authenticate resource owners" in {
+    val store = ResourceOwnerStore(
+      MemoryBackend[ResourceOwner.Id, ResourceOwner](name = s"owner-store-${java.util.UUID.randomUUID()}")
+    )
+
+    val expectedOwner = Generators.generateResourceOwner.copy(
+      password = ownerSecret,
+      salt = ownerSalt
+    )
+
+    val authenticator = new DefaultResourceOwnerAuthenticator(
+      store = store.view,
+      secretConfig = secretConfig
+    )
+
+    for {
+      _ <- store.put(expectedOwner)
+      actualClient <- authenticator.authenticate(BasicHttpCredentials(expectedOwner.username, ownerPassword))
+    } yield {
+      actualClient should be(expectedOwner)
+    }
+  }
+
+  it should "fail to authenticate inactive resource owners" in {
+    val store = ResourceOwnerStore(
+      MemoryBackend[ResourceOwner.Id, ResourceOwner](name = s"owner-store-${java.util.UUID.randomUUID()}")
+    )
+
+    val expectedOwner = Generators.generateResourceOwner.copy(
+      password = ownerSecret,
+      salt = ownerSalt,
+      active = false
+    )
+
+    val authenticator = new DefaultResourceOwnerAuthenticator(
+      store = store.view,
+      secretConfig = secretConfig
+    )
+
+    store
+      .put(expectedOwner)
+      .flatMap { _ =>
+        authenticator.authenticate(BasicHttpCredentials(expectedOwner.username, ownerPassword))
+      }
+      .map(result => fail(s"Unexpected result received: [$result]"))
+      .recoverWith {
+        case NonFatal(e) =>
+          e shouldBe an[AuthenticationFailure]
+          e.getMessage.contains(s"Resource owner [${expectedOwner.username}] is not active") should be(true)
+      }
+  }
+
+  it should "fail to authenticate missing resource owners" in {
+    val store = ResourceOwnerStore(
+      MemoryBackend[ResourceOwner.Id, ResourceOwner](name = s"owner-store-${java.util.UUID.randomUUID()}")
+    )
+
+    val expectedOwner = Generators.generateResourceOwner.copy(
+      password = ownerSecret,
+      salt = ownerSalt
+    )
+
+    val authenticator = new DefaultResourceOwnerAuthenticator(
+      store = store.view,
+      secretConfig = secretConfig
+    )
+
+    authenticator
+      .authenticate(BasicHttpCredentials(expectedOwner.username, ownerPassword))
+      .map(result => fail(s"Unexpected result received: [$result]"))
+      .recoverWith {
+        case NonFatal(e) =>
+          e shouldBe an[AuthenticationFailure]
+          e.getMessage.contains(s"Resource owner [${expectedOwner.username}] was not found") should be(true)
+      }
+  }
+
+  private implicit val system: ActorSystem[SpawnProtocol] = ActorSystem(
+    Behaviors.setup(_ => SpawnProtocol.behavior): Behavior[SpawnProtocol],
+    "DefaultResourceOwnerAuthenticatorSpec-oauth"
+  )
+
+  private implicit val untypedSystem: akka.actor.ActorSystem = system.toUntyped
+
+  private implicit val secretConfig: Secret.ResourceOwnerConfig = Secret.ResourceOwnerConfig(
+    algorithm = "PBKDF2WithHmacSHA512",
+    iterations = 10000,
+    derivedKeySize = 32,
+    saltSize = 16,
+    authenticationDelay = 50.millis
+  )
+
+  private val ownerPassword = "some-password"
+  private val ownerSalt = "some-salt"
+  private val ownerSecret = Secret.derive(ownerPassword, ownerSalt)
+}

--- a/identity/src/test/scala/stasis/test/specs/unit/identity/authentication/oauth/EntityAuthenticatorSpec.scala
+++ b/identity/src/test/scala/stasis/test/specs/unit/identity/authentication/oauth/EntityAuthenticatorSpec.scala
@@ -1,0 +1,87 @@
+package stasis.test.specs.unit.identity.authentication.oauth
+
+import akka.actor.ActorSystem
+import akka.http.scaladsl.model.headers.BasicHttpCredentials
+import stasis.core.security.exceptions.AuthenticationFailure
+import stasis.identity.authentication.oauth.EntityAuthenticator
+import stasis.identity.model.secrets.Secret
+import stasis.test.specs.unit.AsyncUnitSpec
+
+import scala.concurrent.Future
+import scala.concurrent.duration._
+import scala.util.control.NonFatal
+
+class EntityAuthenticatorSpec extends AsyncUnitSpec {
+  "An EntityAuthenticator" should "successfully authenticate entities" in {
+    val authenticator = new MockEntityAuthenticator(secretConfig)
+
+    val entity = "some-entity"
+
+    authenticator
+      .authenticate(BasicHttpCredentials(username = entity, password = entity))
+      .map { result =>
+        result should be(entity)
+      }
+  }
+
+  it should "fail to authenticate entities with invalid credentials" in {
+    val authenticator = new MockEntityAuthenticator(secretConfig)
+
+    val entity = "some-entity"
+
+    authenticator
+      .authenticate(BasicHttpCredentials(username = entity, password = "invalid-password"))
+      .map { result =>
+        fail(s"Unexpected result received: [$result]")
+      }
+      .recoverWith {
+        case NonFatal(e) =>
+          e shouldBe an[AuthenticationFailure]
+          e.getMessage should be(s"Credentials for entity [$entity] do not match")
+      }
+  }
+
+  it should "provide authentication responses after a pre-configured delay" in {
+    val expectedDelay = 200.millis
+    val authenticator = new MockEntityAuthenticator(secretConfig.copy(authenticationDelay = expectedDelay))
+
+    val entity = "some-entity"
+
+    val start = System.currentTimeMillis()
+
+    authenticator
+      .authenticate(BasicHttpCredentials(username = entity, password = entity))
+      .map { result =>
+        val end = System.currentTimeMillis()
+        val duration = (end - start).millis
+
+        result should be(entity)
+        duration should be >= expectedDelay
+      }
+  }
+
+  private implicit val system: ActorSystem = ActorSystem(name = "EntityAuthenticatorSpec")
+
+  private implicit val secretConfig: Secret.ClientConfig = Secret.ClientConfig(
+    algorithm = "PBKDF2WithHmacSHA512",
+    iterations = 10000,
+    derivedKeySize = 32,
+    saltSize = 16,
+    authenticationDelay = 50.millis
+  )
+
+  private class MockEntityAuthenticator(secretConfig: Secret.Config)(implicit protected val system: ActorSystem)
+      extends EntityAuthenticator[String] {
+
+    override implicit protected def config: Secret.Config = secretConfig
+
+    override protected def getEntity(username: String): Future[String] =
+      Future.successful(username)
+
+    override protected def extractSecret: String => Secret =
+      entity => Secret.derive(rawSecret = entity, salt = entity)
+
+    override protected def extractSalt: String => String =
+      entity => entity
+  }
+}

--- a/identity/src/test/scala/stasis/test/specs/unit/identity/model/Generators.scala
+++ b/identity/src/test/scala/stasis/test/specs/unit/identity/model/Generators.scala
@@ -1,0 +1,121 @@
+package stasis.test.specs.unit.identity.model
+
+import java.util.concurrent.ThreadLocalRandom
+
+import scala.concurrent.duration.FiniteDuration
+import scala.util.Random
+
+import akka.util.ByteString
+import stasis.identity.model.apis.Api
+import stasis.identity.model.clients.Client
+import stasis.identity.model.realms.Realm
+import stasis.identity.model.secrets.Secret
+import scala.concurrent.duration._
+
+import stasis.identity.model.codes.AuthorizationCode
+import stasis.identity.model.owners.ResourceOwner
+import stasis.identity.model.tokens.RefreshToken
+
+object Generators {
+  object Defaults {
+    object Apis {
+      final val IdSize = 32
+    }
+
+    object Clients {
+      final val SecretSize = 24
+      final val SaltSize = 16
+    }
+
+    object Codes {
+      final val CodeSize = 64
+    }
+
+    object Owners {
+      final val UsernameSize = 64
+      final val SecretSize = 24
+      final val SaltSize = 16
+    }
+
+    object Realms {
+      final val IdSize = 32
+    }
+
+    object Tokens {
+      final val TokenSize = 64
+    }
+  }
+
+  def generateString(
+    withSize: Int
+  )(implicit rnd: ThreadLocalRandom = ThreadLocalRandom.current()): String = {
+    val random = Random.javaRandomToRandom(rnd)
+    random.alphanumeric.take(withSize).mkString("")
+  }
+
+  def generateFiniteDuration(implicit rnd: ThreadLocalRandom = ThreadLocalRandom.current()): FiniteDuration =
+    rnd.nextLong(0, 1.day.toSeconds).seconds
+
+  def generateApiId(implicit rnd: ThreadLocalRandom = ThreadLocalRandom.current()): Api.Id =
+    generateString(withSize = Defaults.Apis.IdSize)
+
+  def generateRealmId(implicit rnd: ThreadLocalRandom = ThreadLocalRandom.current()): Realm.Id =
+    generateString(withSize = Defaults.Realms.IdSize)
+
+  def generateUri(implicit rnd: ThreadLocalRandom = ThreadLocalRandom.current()): String = {
+    val host = generateString(withSize = 10)
+    val port = rnd.nextInt(50000, 60000)
+    val endpoint = generateString(withSize = 20)
+    s"http://$host:$port/$endpoint"
+  }
+
+  def generateSeq[T](
+    min: Int = 0,
+    max: Int = 10,
+    g: => T
+  )(implicit rnd: ThreadLocalRandom = ThreadLocalRandom.current()): Seq[T] =
+    Stream.continually(g).take(rnd.nextInt(min, max))
+
+  def generateApi(implicit rnd: ThreadLocalRandom = ThreadLocalRandom.current()): Api =
+    Api(
+      id = generateApiId,
+      realm = generateRealmId
+    )
+
+  def generateClient(implicit rnd: ThreadLocalRandom = ThreadLocalRandom.current()): Client =
+    Client(
+      id = Client.generateId(),
+      realm = generateRealmId,
+      allowedScopes = generateSeq(min = 1, g = generateString(withSize = 10)),
+      redirectUri = generateUri,
+      tokenExpiration = generateFiniteDuration,
+      secret = generateSecret(Defaults.Clients.SecretSize),
+      salt = generateString(Defaults.Clients.SaltSize),
+      active = true
+    )
+
+  def generateAuthorizationCode(implicit rnd: ThreadLocalRandom = ThreadLocalRandom.current()): AuthorizationCode =
+    AuthorizationCode(value = generateString(withSize = Defaults.Codes.CodeSize))
+
+  def generateResourceOwner(implicit rnd: ThreadLocalRandom = ThreadLocalRandom.current()): ResourceOwner =
+    ResourceOwner(
+      username = generateString(withSize = Defaults.Owners.UsernameSize),
+      password = generateSecret(withSize = Defaults.Owners.SecretSize),
+      salt = generateString(withSize = Defaults.Owners.SaltSize),
+      realm = generateRealmId,
+      allowedScopes = generateSeq(min = 1, g = generateString(withSize = 10)),
+      active = true
+    )
+
+  def generateRealm(implicit rnd: ThreadLocalRandom = ThreadLocalRandom.current()): Realm =
+    Realm(
+      id = generateRealmId,
+      refreshTokensAllowed = true
+    )
+
+  def generateSecret(withSize: Int)(implicit rnd: ThreadLocalRandom = ThreadLocalRandom.current()): Secret =
+    Secret(ByteString(generateString(withSize)))
+
+  def generateRefreshToken(implicit rnd: ThreadLocalRandom = ThreadLocalRandom.current()): RefreshToken =
+    RefreshToken(value = generateString(withSize = Defaults.Tokens.TokenSize))
+}

--- a/identity/src/test/scala/stasis/test/specs/unit/identity/model/apis/ApiStoreSpec.scala
+++ b/identity/src/test/scala/stasis/test/specs/unit/identity/model/apis/ApiStoreSpec.scala
@@ -1,0 +1,61 @@
+package stasis.test.specs.unit.identity.model.apis
+
+import akka.actor.typed.scaladsl.Behaviors
+import akka.actor.typed.{ActorSystem, Behavior, SpawnProtocol}
+import stasis.core.persistence.backends.memory.MemoryBackend
+import stasis.identity.model.apis.{Api, ApiStore}
+import stasis.test.specs.unit.AsyncUnitSpec
+import stasis.test.specs.unit.identity.model.Generators
+
+class ApiStoreSpec extends AsyncUnitSpec {
+  "An ApiStore" should "add, retrieve and delete APIs" in {
+    val store = createStore()
+
+    val expectedApi = Generators.generateApi
+
+    for {
+      _ <- store.put(expectedApi)
+      actualApi <- store.get(expectedApi.id)
+      someApis <- store.apis
+      _ <- store.delete(expectedApi.id)
+      missingApi <- store.get(expectedApi.id)
+      noApis <- store.apis
+    } yield {
+      actualApi should be(Some(expectedApi))
+      someApis should be(Map(expectedApi.id -> expectedApi))
+      missingApi should be(None)
+      noApis should be(Map.empty)
+    }
+  }
+
+  it should "provide a read-only view" in {
+    val store = createStore()
+    val storeView = store.view
+
+    val expectedApi = Generators.generateApi
+
+    for {
+      _ <- store.put(expectedApi)
+      actualApi <- storeView.get(expectedApi.id)
+      someApis <- storeView.apis
+      _ <- store.delete(expectedApi.id)
+      missingApi <- storeView.get(expectedApi.id)
+      noApis <- storeView.apis
+    } yield {
+      actualApi should be(Some(expectedApi))
+      someApis should be(Map(expectedApi.id -> expectedApi))
+      missingApi should be(None)
+      noApis should be(Map.empty)
+      a[ClassCastException] should be thrownBy { val _ = storeView.asInstanceOf[ApiStore] }
+    }
+  }
+
+  private implicit val system: ActorSystem[SpawnProtocol] = ActorSystem(
+    Behaviors.setup(_ => SpawnProtocol.behavior): Behavior[SpawnProtocol],
+    "ApiStoreSpec"
+  )
+
+  private def createStore() = ApiStore(
+    MemoryBackend[Api.Id, Api](name = s"api-store-${java.util.UUID.randomUUID()}")
+  )
+}

--- a/identity/src/test/scala/stasis/test/specs/unit/identity/model/clients/ClientStoreSpec.scala
+++ b/identity/src/test/scala/stasis/test/specs/unit/identity/model/clients/ClientStoreSpec.scala
@@ -1,0 +1,61 @@
+package stasis.test.specs.unit.identity.model.clients
+
+import akka.actor.typed.scaladsl.Behaviors
+import akka.actor.typed.{ActorSystem, Behavior, SpawnProtocol}
+import stasis.core.persistence.backends.memory.MemoryBackend
+import stasis.identity.model.clients.{Client, ClientStore}
+import stasis.test.specs.unit.AsyncUnitSpec
+import stasis.test.specs.unit.identity.model.Generators
+
+class ClientStoreSpec extends AsyncUnitSpec {
+  "A ClientStore" should "add, retrieve and delete clients" in {
+    val store = createStore()
+
+    val expectedClient = Generators.generateClient
+
+    for {
+      _ <- store.put(expectedClient)
+      actualClient <- store.get(expectedClient.id)
+      someClients <- store.clients
+      _ <- store.delete(expectedClient.id)
+      missingClient <- store.get(expectedClient.id)
+      noClients <- store.clients
+    } yield {
+      actualClient should be(Some(expectedClient))
+      someClients should be(Map(expectedClient.id -> expectedClient))
+      missingClient should be(None)
+      noClients should be(Map.empty)
+    }
+  }
+
+  it should "provide a read-only view" in {
+    val store = createStore()
+    val storeView = store.view
+
+    val expectedClient = Generators.generateClient
+
+    for {
+      _ <- store.put(expectedClient)
+      actualClient <- storeView.get(expectedClient.id)
+      someClients <- storeView.clients
+      _ <- store.delete(expectedClient.id)
+      missingClient <- storeView.get(expectedClient.id)
+      noClients <- storeView.clients
+    } yield {
+      actualClient should be(Some(expectedClient))
+      someClients should be(Map(expectedClient.id -> expectedClient))
+      missingClient should be(None)
+      noClients should be(Map.empty)
+      a[ClassCastException] should be thrownBy { val _ = storeView.asInstanceOf[ClientStore] }
+    }
+  }
+
+  private implicit val system: ActorSystem[SpawnProtocol] = ActorSystem(
+    Behaviors.setup(_ => SpawnProtocol.behavior): Behavior[SpawnProtocol],
+    "ClientStoreSpec"
+  )
+
+  private def createStore() = ClientStore(
+    MemoryBackend[Client.Id, Client](name = s"client-store-${java.util.UUID.randomUUID()}")
+  )
+}

--- a/identity/src/test/scala/stasis/test/specs/unit/identity/model/codes/generators/DefaultAuthorizationCodeGeneratorSpec.scala
+++ b/identity/src/test/scala/stasis/test/specs/unit/identity/model/codes/generators/DefaultAuthorizationCodeGeneratorSpec.scala
@@ -1,0 +1,15 @@
+package stasis.test.specs.unit.identity.model.codes.generators
+
+import stasis.identity.model.codes.generators.DefaultAuthorizationCodeGenerator
+import stasis.test.specs.unit.AsyncUnitSpec
+
+class DefaultAuthorizationCodeGeneratorSpec extends AsyncUnitSpec {
+  "A DefaultAuthorizationCodeGenerator" should "generate random authorization codes" in {
+    val codeSize = 32
+    val generator = new DefaultAuthorizationCodeGenerator(codeSize)
+    val code = generator.generate()
+
+    code.value.length should be(codeSize)
+    code.value.matches("^[A-Za-z0-9]+$") should be(true)
+  }
+}

--- a/identity/src/test/scala/stasis/test/specs/unit/identity/model/owners/ResourceOwnerStoreSpec.scala
+++ b/identity/src/test/scala/stasis/test/specs/unit/identity/model/owners/ResourceOwnerStoreSpec.scala
@@ -1,0 +1,61 @@
+package stasis.test.specs.unit.identity.model.owners
+
+import akka.actor.typed.scaladsl.Behaviors
+import akka.actor.typed.{ActorSystem, Behavior, SpawnProtocol}
+import stasis.core.persistence.backends.memory.MemoryBackend
+import stasis.identity.model.owners.{ResourceOwner, ResourceOwnerStore}
+import stasis.test.specs.unit.AsyncUnitSpec
+import stasis.test.specs.unit.identity.model.Generators
+
+class ResourceOwnerStoreSpec extends AsyncUnitSpec {
+  "A ResourceOwnerStore" should "add, retrieve and delete resource owners" in {
+    val store = createStore()
+
+    val expectedResourceOwner = Generators.generateResourceOwner
+
+    for {
+      _ <- store.put(expectedResourceOwner)
+      actualResourceOwner <- store.get(expectedResourceOwner.username)
+      someResourceOwners <- store.owners
+      _ <- store.delete(expectedResourceOwner.username)
+      missingResourceOwner <- store.get(expectedResourceOwner.username)
+      noResourceOwners <- store.owners
+    } yield {
+      actualResourceOwner should be(Some(expectedResourceOwner))
+      someResourceOwners should be(Map(expectedResourceOwner.username -> expectedResourceOwner))
+      missingResourceOwner should be(None)
+      noResourceOwners should be(Map.empty)
+    }
+  }
+
+  it should "provide a read-only view" in {
+    val store = createStore()
+    val storeView = store.view
+
+    val expectedResourceOwner = Generators.generateResourceOwner
+
+    for {
+      _ <- store.put(expectedResourceOwner)
+      actualResourceOwner <- storeView.get(expectedResourceOwner.username)
+      someResourceOwners <- storeView.owners
+      _ <- store.delete(expectedResourceOwner.username)
+      missingResourceOwner <- storeView.get(expectedResourceOwner.username)
+      noResourceOwners <- storeView.owners
+    } yield {
+      actualResourceOwner should be(Some(expectedResourceOwner))
+      someResourceOwners should be(Map(expectedResourceOwner.username -> expectedResourceOwner))
+      missingResourceOwner should be(None)
+      noResourceOwners should be(Map.empty)
+      a[ClassCastException] should be thrownBy { val _ = storeView.asInstanceOf[ResourceOwnerStore] }
+    }
+  }
+
+  private implicit val system: ActorSystem[SpawnProtocol] = ActorSystem(
+    Behaviors.setup(_ => SpawnProtocol.behavior): Behavior[SpawnProtocol],
+    "ResourceOwnerStoreSpec"
+  )
+
+  private def createStore() = ResourceOwnerStore(
+    MemoryBackend[ResourceOwner.Id, ResourceOwner](name = s"owner-store-${java.util.UUID.randomUUID()}")
+  )
+}

--- a/identity/src/test/scala/stasis/test/specs/unit/identity/model/realms/RealmStoreSpec.scala
+++ b/identity/src/test/scala/stasis/test/specs/unit/identity/model/realms/RealmStoreSpec.scala
@@ -1,0 +1,61 @@
+package stasis.test.specs.unit.identity.model.realms
+
+import akka.actor.typed.scaladsl.Behaviors
+import akka.actor.typed.{ActorSystem, Behavior, SpawnProtocol}
+import stasis.core.persistence.backends.memory.MemoryBackend
+import stasis.identity.model.realms.{Realm, RealmStore}
+import stasis.test.specs.unit.AsyncUnitSpec
+import stasis.test.specs.unit.identity.model.Generators
+
+class RealmStoreSpec extends AsyncUnitSpec {
+  "A RealmStore" should "add, retrieve and delete realms" in {
+    val store = createStore()
+
+    val expectedRealm = Generators.generateRealm
+
+    for {
+      _ <- store.put(expectedRealm)
+      actualRealm <- store.get(expectedRealm.id)
+      someRealms <- store.realms
+      _ <- store.delete(expectedRealm.id)
+      missingRealm <- store.get(expectedRealm.id)
+      noRealms <- store.realms
+    } yield {
+      actualRealm should be(Some(expectedRealm))
+      someRealms should be(Map(expectedRealm.id -> expectedRealm))
+      missingRealm should be(None)
+      noRealms should be(Map.empty)
+    }
+  }
+
+  it should "provide a read-only view" in {
+    val store = createStore()
+    val storeView = store.view
+
+    val expectedRealm = Generators.generateRealm
+
+    for {
+      _ <- store.put(expectedRealm)
+      actualRealm <- storeView.get(expectedRealm.id)
+      someRealms <- storeView.realms
+      _ <- store.delete(expectedRealm.id)
+      missingRealm <- storeView.get(expectedRealm.id)
+      noRealms <- storeView.realms
+    } yield {
+      actualRealm should be(Some(expectedRealm))
+      someRealms should be(Map(expectedRealm.id -> expectedRealm))
+      missingRealm should be(None)
+      noRealms should be(Map.empty)
+      a[ClassCastException] should be thrownBy { val _ = storeView.asInstanceOf[RealmStore] }
+    }
+  }
+
+  private implicit val system: ActorSystem[SpawnProtocol] = ActorSystem(
+    Behaviors.setup(_ => SpawnProtocol.behavior): Behavior[SpawnProtocol],
+    "RealmStoreSpec"
+  )
+
+  private def createStore() = RealmStore(
+    MemoryBackend[Realm.Id, Realm](name = s"realm-store-${java.util.UUID.randomUUID()}")
+  )
+}

--- a/identity/src/test/scala/stasis/test/specs/unit/identity/model/secrets/SecretSpec.scala
+++ b/identity/src/test/scala/stasis/test/specs/unit/identity/model/secrets/SecretSpec.scala
@@ -1,0 +1,49 @@
+package stasis.test.specs.unit.identity.model.secrets
+
+import stasis.identity.model.secrets.Secret
+import stasis.test.specs.unit.AsyncUnitSpec
+import stasis.test.specs.unit.identity.EncodingHelpers
+import stasis.test.specs.unit.identity.model.Generators
+
+import scala.concurrent.duration._
+
+class SecretSpec extends AsyncUnitSpec with EncodingHelpers {
+  "A Secret" should "generate random password salt values" in {
+    val salt = Secret.generateSalt()
+
+    salt.length should be(testConfig.saltSize)
+    salt.matches("^[A-Za-z0-9]+$") should be(true)
+  }
+
+  it should "derive hashed passwords from raw passwords" in {
+    val rawPassword = "some-password"
+    val salt = "some-salt"
+
+    val expectedPassword = "yN/luUaC17kFf8KAwM4vtlFJtG+IL7/dxg6YpOyjB9g=".decodeFromBase64
+    val actualPassword = Secret.derive(rawPassword, salt)
+
+    actualPassword.value.size should be(testConfig.derivedKeySize)
+    actualPassword.value should be(expectedPassword)
+  }
+
+  it should "allow comparing to other raw passwords" in {
+    val rawPassword = "some-password"
+    val salt = "some-salt"
+
+    val hashedPassword = Secret.derive(rawPassword, salt)
+    hashedPassword.isSameAs(rawPassword, salt) should be(true)
+  }
+
+  it should "not expose its value when converted to string" in {
+    val secret = Generators.generateSecret(withSize = testConfig.derivedKeySize)
+    secret.toString should be("Secret")
+  }
+
+  private implicit val testConfig: Secret.Config = Secret.ClientConfig(
+    algorithm = "PBKDF2WithHmacSHA512",
+    iterations = 10000,
+    derivedKeySize = 32,
+    saltSize = 16,
+    authenticationDelay = 3.seconds
+  )
+}

--- a/identity/src/test/scala/stasis/test/specs/unit/identity/model/tokens/RefreshTokenStoreSpec.scala
+++ b/identity/src/test/scala/stasis/test/specs/unit/identity/model/tokens/RefreshTokenStoreSpec.scala
@@ -1,0 +1,72 @@
+package stasis.test.specs.unit.identity.model.tokens
+
+import akka.Done
+import akka.actor.typed.scaladsl.Behaviors
+import akka.actor.typed.{ActorSystem, Behavior, SpawnProtocol}
+import stasis.core.persistence.backends.memory.MemoryBackend
+import stasis.identity.model.clients.Client
+import stasis.identity.model.tokens.{RefreshTokenStore, StoredRefreshToken}
+import stasis.test.specs.unit.AsyncUnitSpec
+import stasis.test.specs.unit.identity.model.Generators
+
+import scala.concurrent.Future
+import scala.concurrent.duration._
+
+class RefreshTokenStoreSpec extends AsyncUnitSpec {
+  "An RefreshTokenStore" should "add, retrieve and delete refresh tokens" in {
+    val store = createStore()
+
+    val client = Client.generateId()
+    val owner = Generators.generateResourceOwner
+    val expectedToken = Generators.generateRefreshToken
+    val expectedStoredToken = StoredRefreshToken(expectedToken, owner, scope = None)
+
+    for {
+      _ <- store.put(client, expectedToken, owner, scope = None)
+      actualToken <- store.get(client)
+      someTokens <- store.tokens
+      _ <- store.delete(client)
+      missingToken <- store.get(client)
+      noTokens <- store.tokens
+    } yield {
+      actualToken should be(Some(expectedStoredToken))
+      someTokens should be(Map(client -> expectedStoredToken))
+      missingToken should be(None)
+      noTokens should be(Map.empty)
+    }
+  }
+
+  it should "expire refresh tokens" in {
+    val expiration = 50.millis
+    val store = createStore(expiration)
+
+    val client = Client.generateId()
+    val owner = Generators.generateResourceOwner
+    val expectedToken = Generators.generateRefreshToken
+    val expectedStoredToken = StoredRefreshToken(expectedToken, owner, scope = None)
+
+    for {
+      _ <- store.put(client, expectedToken, owner, scope = None)
+      actualToken <- store.get(client)
+      someTokens <- store.tokens
+      _ <- akka.pattern.after(expiration * 2, using = system.scheduler)(Future.successful(Done))
+      missingToken <- store.get(client)
+      noTokens <- store.tokens
+    } yield {
+      actualToken should be(Some(expectedStoredToken))
+      someTokens should be(Map(client -> expectedStoredToken))
+      missingToken should be(None)
+      noTokens should be(Map.empty)
+    }
+  }
+
+  private implicit val system: ActorSystem[SpawnProtocol] = ActorSystem(
+    Behaviors.setup(_ => SpawnProtocol.behavior): Behavior[SpawnProtocol],
+    "RefreshTokenStoreSpec"
+  )
+
+  private def createStore(expiration: FiniteDuration = 3.seconds): RefreshTokenStore = RefreshTokenStore(
+    expiration = expiration,
+    MemoryBackend[Client.Id, StoredRefreshToken](name = s"token-store-${java.util.UUID.randomUUID()}")
+  )
+}

--- a/identity/src/test/scala/stasis/test/specs/unit/identity/model/tokens/generators/JwtBearerAccessTokenGeneratorBehaviour.scala
+++ b/identity/src/test/scala/stasis/test/specs/unit/identity/model/tokens/generators/JwtBearerAccessTokenGeneratorBehaviour.scala
@@ -1,0 +1,64 @@
+package stasis.test.specs.unit.identity.model.tokens.generators
+
+import org.jose4j.jwk.JsonWebKey
+import org.jose4j.jws.JsonWebSignature
+import play.api.libs.json.{JsArray, JsObject, JsString, Json}
+import stasis.identity.model.tokens.generators.JwtBearerAccessTokenGenerator
+import stasis.test.specs.unit.AsyncUnitSpec
+import stasis.test.specs.unit.identity.model.Generators
+
+import scala.concurrent.duration._
+
+trait JwtBearerAccessTokenGeneratorBehaviour { _: AsyncUnitSpec =>
+  def jwtBearerAccessTokenGenerator(withKeyType: String, withJwk: JsonWebKey): Unit = {
+    val issuer = "some-issuer"
+    val jwtExpiration = 3.seconds
+    val generator = new JwtBearerAccessTokenGenerator(issuer, withJwk, jwtExpiration)
+
+    it should s"generate JWTs for clients ($withKeyType)" in {
+      val client = Generators.generateClient
+      val audience = Generators.generateSeq(min = 1, g = Generators.generateClient)
+      val token = generator.generate(client, audience)
+
+      val jws = new JsonWebSignature()
+      jws.setCompactSerialization(token.value)
+      jws.setKey(withJwk.getKey)
+
+      jws.verifySignature() should be(true)
+
+      val payload = Json.parse(jws.getPayload).as[JsObject]
+      payload.fields should contain("iss" -> JsString(issuer))
+      payload.fields should contain("sub" -> JsString(client.id.toString))
+      payload.fields should (
+        contain(
+          "aud" -> JsArray(audience.map(aud => JsString(aud.id.toString)))
+        ) or contain(
+          "aud" -> JsString(audience.headOption.map(_.id.toString).getOrElse(""))
+        )
+      )
+    }
+
+    it should s"generate JWTs for resource owners ($withKeyType)" in {
+      val owner = Generators.generateResourceOwner
+      val audience = Generators.generateSeq(min = 1, g = Generators.generateApi)
+      val token = generator.generate(owner, audience)
+
+      val jws = new JsonWebSignature()
+      jws.setCompactSerialization(token.value)
+      jws.setKey(withJwk.getKey)
+
+      jws.verifySignature() should be(true)
+
+      val payload = Json.parse(jws.getPayload).as[JsObject]
+      payload.fields should contain("iss" -> JsString(issuer))
+      payload.fields should contain("sub" -> JsString(owner.username))
+      payload.fields should (
+        contain(
+          "aud" -> JsArray(audience.map(aud => JsString(aud.id.toString)))
+        ) or contain(
+          "aud" -> JsString(audience.headOption.map(_.id.toString).getOrElse(""))
+        )
+      )
+    }
+  }
+}

--- a/identity/src/test/scala/stasis/test/specs/unit/identity/model/tokens/generators/JwtBearerAccessTokenGeneratorSpec.scala
+++ b/identity/src/test/scala/stasis/test/specs/unit/identity/model/tokens/generators/JwtBearerAccessTokenGeneratorSpec.scala
@@ -1,0 +1,21 @@
+package stasis.test.specs.unit.identity.model.tokens.generators
+
+import stasis.test.specs.unit.AsyncUnitSpec
+import stasis.test.specs.unit.core.security.jwt.mocks.MockJwksGenerators
+
+class JwtBearerAccessTokenGeneratorSpec extends AsyncUnitSpec with JwtBearerAccessTokenGeneratorBehaviour {
+  "A JwtBearerAccessTokenGenerator" should behave like jwtBearerAccessTokenGenerator(
+    withKeyType = "RSA",
+    withJwk = MockJwksGenerators.generateRandomRsaKey(Some("rsa-0"))
+  )
+
+  it should behave like jwtBearerAccessTokenGenerator(
+    withKeyType = "EC",
+    withJwk = MockJwksGenerators.generateRandomEcKey(Some("ec-0"))
+  )
+
+  it should behave like jwtBearerAccessTokenGenerator(
+    withKeyType = "Secret",
+    withJwk = MockJwksGenerators.generateRandomSecretKey(Some("oct-0"))
+  )
+}

--- a/identity/src/test/scala/stasis/test/specs/unit/identity/model/tokens/generators/RandomRefreshTokenGeneratorSpec.scala
+++ b/identity/src/test/scala/stasis/test/specs/unit/identity/model/tokens/generators/RandomRefreshTokenGeneratorSpec.scala
@@ -1,0 +1,15 @@
+package stasis.test.specs.unit.identity.model.tokens.generators
+
+import stasis.identity.model.tokens.generators.RandomRefreshTokenGenerator
+import stasis.test.specs.unit.AsyncUnitSpec
+
+class RandomRefreshTokenGeneratorSpec extends AsyncUnitSpec {
+  "A RandomRefreshTokenGenerator" should "generate random refresh tokens" in {
+    val tokenSize = 32
+    val generator = new RandomRefreshTokenGenerator(tokenSize)
+    val token = generator.generate()
+
+    token.value.length should be(tokenSize)
+    token.value.matches("^[A-Za-z0-9]+$") should be(true)
+  }
+}

--- a/server/src/test/resources/application.conf
+++ b/server/src/test/resources/application.conf
@@ -1,5 +1,5 @@
 akka {
   test {
-    timefactor = 3.0
+    timefactor = 5.0
   }
 }


### PR DESCRIPTION
Adds OAuth 2 + JWT bearer token support for:
- Authorization Code Grant
- Implicit Grant
- Resource Owner Password Credentials Grant
- Client Credentials Grant
- Refresh Token Grant