### PR TITLE
Add PKCE grant type

### DIFF
--- a/identity/src/main/scala/stasis/identity/api/Formats.scala
+++ b/identity/src/main/scala/stasis/identity/api/Formats.scala
@@ -11,7 +11,7 @@ import stasis.identity.model.errors.{AuthorizationError, TokenError}
 import stasis.identity.model.owners.ResourceOwner
 import stasis.identity.model.realms.Realm
 import stasis.identity.model.tokens.{AccessToken, RefreshToken, StoredRefreshToken, TokenType}
-import stasis.identity.model.{GrantType, ResponseType, Seconds}
+import stasis.identity.model.{ChallengeMethod, GrantType, ResponseType, Seconds}
 
 object Formats {
   implicit val authorizationErrorFormat: Writes[AuthorizationError] = Writes[AuthorizationError] { error =>
@@ -37,6 +37,11 @@ object Formats {
   implicit val grantTypeFormat: Format[GrantType] = Format[GrantType](
     fjs = Reads[GrantType](_.validate[String].map(convertStringToGrantType)),
     tjs = Writes[GrantType](grantType => JsString(convertGrantTypeToString(grantType)))
+  )
+
+  implicit val challengeMethodFormat: Format[ChallengeMethod] = Format[ChallengeMethod](
+    fjs = Reads[ChallengeMethod](_.validate[String].map(convertStringToChallengeMethod)),
+    tjs = Writes[ChallengeMethod](challengeMethod => JsString(convertChallengeMethodToString(challengeMethod)))
   )
 
   implicit val responseTypeFormat: Format[ResponseType] = Format[ResponseType](
@@ -126,6 +131,9 @@ object Formats {
   implicit val updateOwnerCredentialsFormat: Format[UpdateOwnerCredentials] = Json.format[UpdateOwnerCredentials]
   implicit val createRealmFormat: Format[CreateRealm] = Json.format[CreateRealm]
 
+  implicit val stringToChallengeMethod: Unmarshaller[String, ChallengeMethod] =
+    Unmarshaller.strict { convertStringToChallengeMethod }
+
   implicit val stringToResponseType: Unmarshaller[String, ResponseType] =
     Unmarshaller.strict { convertStringToResponseType }
 
@@ -140,6 +148,14 @@ object Formats {
 
   implicit val stringToRefreshToken: Unmarshaller[String, RefreshToken] =
     Unmarshaller.strict(RefreshToken)
+
+  private def convertStringToChallengeMethod(string: String): ChallengeMethod = string.toLowerCase match {
+    case "plain" => ChallengeMethod.Plain
+    case "s256"  => ChallengeMethod.S256
+  }
+
+  private def convertChallengeMethodToString(challengeMethod: ChallengeMethod): String =
+    challengeMethod.toString.toLowerCase
 
   private def convertStringToResponseType(string: String): ResponseType = string match {
     case "code"  => ResponseType.Code

--- a/identity/src/main/scala/stasis/identity/api/Jwks.scala
+++ b/identity/src/main/scala/stasis/identity/api/Jwks.scala
@@ -5,9 +5,12 @@ import akka.event.{Logging, LoggingAdapter}
 import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server._
+import akka.stream.Materializer
 import org.jose4j.jwk.JsonWebKey
+import stasis.identity.api.directives.BaseApiDirective
 
-class Jwks(keys: Seq[JsonWebKey])(implicit system: ActorSystem) {
+class Jwks(keys: Seq[JsonWebKey])(implicit system: ActorSystem, override val mat: Materializer)
+    extends BaseApiDirective {
   import Jwks._
   import de.heikoseeberger.akkahttpplayjson.PlayJsonSupport._
 
@@ -19,10 +22,12 @@ class Jwks(keys: Seq[JsonWebKey])(implicit system: ActorSystem) {
         extractClientIP { remoteAddress =>
           log.debug("Successfully provided [{}] JWKs to [{}]", keys.size, remoteAddress)
 
-          complete(
-            StatusCodes.OK,
-            JwksResponse(keys = keys)
-          )
+          discardEntity {
+            complete(
+              StatusCodes.OK,
+              JwksResponse(keys = keys)
+            )
+          }
         }
       }
     }

--- a/identity/src/main/scala/stasis/identity/api/OAuth.scala
+++ b/identity/src/main/scala/stasis/identity/api/OAuth.scala
@@ -46,7 +46,7 @@ class OAuth(
                   case responseType =>
                     val message = s"Realm [$realmId]: The request includes an invalid response type: [$responseType]"
                     log.warning(message)
-                    complete(StatusCodes.BadRequest, message)
+                    discardEntity & complete(StatusCodes.BadRequest, message)
                 }
               },
               path("token") {
@@ -69,7 +69,7 @@ class OAuth(
                   case grantType =>
                     val message = s"Realm [$realmId]: The request includes an invalid grant type: [$grantType]"
                     log.warning(message)
-                    complete(StatusCodes.BadRequest, message)
+                    discardEntity & complete(StatusCodes.BadRequest, message)
                 }
               }
             )

--- a/identity/src/main/scala/stasis/identity/api/manage/Apis.scala
+++ b/identity/src/main/scala/stasis/identity/api/manage/Apis.scala
@@ -45,14 +45,14 @@ class Apis(store: ApiStore)(implicit system: ActorSystem, materializer: Material
         )
       },
       path(Segment) { apiId =>
-        validateRealm(realm, store.get(apiId)) { api =>
+        validateRealm(realm, store.get(realm, apiId)) { api =>
           concat(
             get {
               log.info("Realm [{}]: User [{}] successfully retrieved API [{}]", realm, user, apiId)
               complete(api)
             },
             delete {
-              onSuccess(store.delete(apiId)) { _ =>
+              onSuccess(store.delete(realm, apiId)) { _ =>
                 log.info("Realm [{}]: User [{}] successfully deleted API [{}]", realm, user, apiId)
                 complete(StatusCodes.OK)
               }

--- a/identity/src/main/scala/stasis/identity/api/manage/Owners.scala
+++ b/identity/src/main/scala/stasis/identity/api/manage/Owners.scala
@@ -17,12 +17,11 @@ import scala.concurrent.ExecutionContext
 class Owners(
   store: ResourceOwnerStore,
   ownerSecretConfig: Secret.ResourceOwnerConfig
-)(implicit system: ActorSystem, materializer: Materializer)
+)(implicit system: ActorSystem, override val mat: Materializer)
     extends RealmValidation[ResourceOwner] {
   import de.heikoseeberger.akkahttpplayjson.PlayJsonSupport._
   import stasis.identity.api.Formats._
 
-  override implicit protected def mat: Materializer = materializer
   private implicit val ec: ExecutionContext = system.dispatcher
   protected def log: LoggingAdapter = Logging(system, this.getClass.getName)
 
@@ -42,7 +41,7 @@ class Owners(
                 user,
                 owners.size
               )
-              complete(owners.values)
+              discardEntity & complete(owners.values)
             }
           },
           post {
@@ -91,7 +90,7 @@ class Owners(
                       user,
                       ownerUsername
                     )
-                    complete(owner)
+                    discardEntity & complete(owner)
                   },
                   put {
                     entity(as[UpdateOwner]) { request =>
@@ -122,7 +121,7 @@ class Owners(
                         user,
                         ownerUsername
                       )
-                      complete(StatusCodes.OK)
+                      discardEntity & complete(StatusCodes.OK)
                     }
                   }
                 )

--- a/identity/src/main/scala/stasis/identity/api/manage/directives/RealmExtraction.scala
+++ b/identity/src/main/scala/stasis/identity/api/manage/directives/RealmExtraction.scala
@@ -21,9 +21,7 @@ trait RealmExtraction extends BaseApiDirective {
 
         case None =>
           log.warning("Requested realm [{}] was not found", realmId)
-          discardEntity {
-            complete(StatusCodes.NotFound)
-          }
+          discardEntity & complete(StatusCodes.NotFound)
       }
     }
 }

--- a/identity/src/main/scala/stasis/identity/api/manage/directives/RealmValidation.scala
+++ b/identity/src/main/scala/stasis/identity/api/manage/directives/RealmValidation.scala
@@ -41,9 +41,7 @@ trait RealmValidation[T] extends BaseApiDirective {
 
         case None =>
           log.warning("Entity for realm [{}] was not found", realm)
-          discardEntity {
-            complete(StatusCodes.NotFound)
-          }
+          discardEntity & complete(StatusCodes.NotFound)
       }
     }
 }

--- a/identity/src/main/scala/stasis/identity/api/manage/directives/UserAuthentication.scala
+++ b/identity/src/main/scala/stasis/identity/api/manage/directives/UserAuthentication.scala
@@ -39,9 +39,7 @@ trait UserAuthentication extends BaseApiDirective {
                   )
                 )
 
-                discardEntity {
-                  complete(StatusCodes.Unauthorized)
-                }
+                discardEntity & complete(StatusCodes.Unauthorized)
             }
 
           case Some(unsupportedCredentials) =>
@@ -56,9 +54,7 @@ trait UserAuthentication extends BaseApiDirective {
               )
             )
 
-            discardEntity {
-              complete(StatusCodes.Unauthorized)
-            }
+            discardEntity & complete(StatusCodes.Unauthorized)
 
           case None =>
             log.warning(

--- a/identity/src/main/scala/stasis/identity/api/manage/directives/UserAuthorization.scala
+++ b/identity/src/main/scala/stasis/identity/api/manage/directives/UserAuthorization.scala
@@ -30,9 +30,7 @@ trait UserAuthorization extends BaseApiDirective {
               scope
             )
 
-            discardEntity {
-              complete(StatusCodes.Forbidden)
-            }
+            discardEntity & complete(StatusCodes.Forbidden)
           }
 
         case _ =>
@@ -42,9 +40,7 @@ trait UserAuthorization extends BaseApiDirective {
             user.username
           )
 
-          discardEntity {
-            complete(StatusCodes.Forbidden)
-          }
+          discardEntity & complete(StatusCodes.Forbidden)
       }
     }
 }

--- a/identity/src/main/scala/stasis/identity/api/oauth/AuthorizationCodeGrant.scala
+++ b/identity/src/main/scala/stasis/identity/api/oauth/AuthorizationCodeGrant.scala
@@ -42,7 +42,7 @@ class AuthorizationCodeGrant(
           case client if request.redirect_uri.forall(_ == client.redirectUri) =>
             val redirectUri = Uri(request.redirect_uri.getOrElse(client.redirectUri))
 
-            (authenticateResourceOwner(redirectUri, request.state) & extractApiAudience(request.scope)) {
+            (authenticateResourceOwner(redirectUri, request.state) & extractApiAudience(realm.id, request.scope)) {
               (owner, audience) =>
                 val scope = apiAudienceToScope(audience)
 
@@ -94,7 +94,7 @@ class AuthorizationCodeGrant(
         authenticateClient(realm) {
           case client if client.id == request.client_id && request.redirect_uri.forall(_ == client.redirectUri) =>
             consumeAuthorizationCode(client.id, request.code) { (owner, scope) =>
-              extractApiAudience(scope) { audience =>
+              extractApiAudience(realm.id, scope) { audience =>
                 val scope = apiAudienceToScope(audience)
 
                 (generateAccessToken(owner, audience) & generateRefreshToken(realm, client.id, owner, scope)) {

--- a/identity/src/main/scala/stasis/identity/api/oauth/AuthorizationCodeGrant.scala
+++ b/identity/src/main/scala/stasis/identity/api/oauth/AuthorizationCodeGrant.scala
@@ -59,10 +59,12 @@ class AuthorizationCodeGrant(
                     client.id
                   )
 
-                  redirect(
-                    redirectUri.withQuery(AuthorizationResponse(code, request.state, scope).asQuery),
-                    StatusCodes.Found
-                  )
+                  discardEntity {
+                    redirect(
+                      redirectUri.withQuery(AuthorizationResponse(code, request.state, scope).asQuery),
+                      StatusCodes.Found
+                    )
+                  }
                 }
             }
 
@@ -75,10 +77,12 @@ class AuthorizationCodeGrant(
               request.redirect_uri
             )
 
-            complete(
-              StatusCodes.BadRequest,
-              "The request has missing, invalid or mismatching redirection URI and/or client identifier"
-            )
+            discardEntity {
+              complete(
+                StatusCodes.BadRequest,
+                "The request has missing, invalid or mismatching redirection URI and/or client identifier"
+              )
+            }
         }
       }
     }
@@ -109,19 +113,21 @@ class AuthorizationCodeGrant(
                       client.id
                     )
 
-                    complete(
-                      StatusCodes.OK,
-                      List[HttpHeader](
-                        headers.`Content-Type`(ContentTypes.`application/json`),
-                        headers.`Cache-Control`(headers.CacheDirectives.`no-store`)
-                      ),
-                      AccessTokenResponse(
-                        access_token = accessToken,
-                        token_type = TokenType.Bearer,
-                        expires_in = client.tokenExpiration,
-                        refresh_token = refreshToken
+                    discardEntity {
+                      complete(
+                        StatusCodes.OK,
+                        List[HttpHeader](
+                          headers.`Content-Type`(ContentTypes.`application/json`),
+                          headers.`Cache-Control`(headers.CacheDirectives.`no-store`)
+                        ),
+                        AccessTokenResponse(
+                          access_token = accessToken,
+                          token_type = TokenType.Bearer,
+                          expires_in = client.tokenExpiration,
+                          refresh_token = refreshToken
+                        )
                       )
-                    )
+                    }
                 }
               }
             }
@@ -139,10 +145,12 @@ class AuthorizationCodeGrant(
               )
             )
 
-            complete(
-              StatusCodes.BadRequest,
-              TokenError.InvalidRequest
-            )
+            discardEntity {
+              complete(
+                StatusCodes.BadRequest,
+                TokenError.InvalidRequest
+              )
+            }
         }
       }
     }

--- a/identity/src/main/scala/stasis/identity/api/oauth/ClientCredentialsGrant.scala
+++ b/identity/src/main/scala/stasis/identity/api/oauth/ClientCredentialsGrant.scala
@@ -43,19 +43,21 @@ class ClientCredentialsGrant(
               client.id
             )
 
-            complete(
-              StatusCodes.OK,
-              List[HttpHeader](
-                headers.`Content-Type`(ContentTypes.`application/json`),
-                headers.`Cache-Control`(CacheDirectives.`no-store`)
-              ),
-              AccessTokenResponse(
-                access_token = accessToken,
-                token_type = TokenType.Bearer,
-                expires_in = client.tokenExpiration,
-                scope = scope
+            discardEntity {
+              complete(
+                StatusCodes.OK,
+                List[HttpHeader](
+                  headers.`Content-Type`(ContentTypes.`application/json`),
+                  headers.`Cache-Control`(CacheDirectives.`no-store`)
+                ),
+                AccessTokenResponse(
+                  access_token = accessToken,
+                  token_type = TokenType.Bearer,
+                  expires_in = client.tokenExpiration,
+                  scope = scope
+                )
               )
-            )
+            }
           }
         }
       }

--- a/identity/src/main/scala/stasis/identity/api/oauth/ImplicitGrant.scala
+++ b/identity/src/main/scala/stasis/identity/api/oauth/ImplicitGrant.scala
@@ -57,10 +57,12 @@ class ImplicitGrant(
                     client.id
                   )
 
-                  redirect(
-                    redirectUri.withQuery(response.asQuery),
-                    StatusCodes.Found
-                  )
+                  discardEntity {
+                    redirect(
+                      redirectUri.withQuery(response.asQuery),
+                      StatusCodes.Found
+                    )
+                  }
                 }
             }
 
@@ -72,10 +74,12 @@ class ImplicitGrant(
               request.redirect_uri
             )
 
-            complete(
-              StatusCodes.BadRequest,
-              "The request has missing, invalid or mismatching redirection URI and/or client identifier"
-            )
+            discardEntity {
+              complete(
+                StatusCodes.BadRequest,
+                "The request has missing, invalid or mismatching redirection URI and/or client identifier"
+              )
+            }
         }
       }
     }

--- a/identity/src/main/scala/stasis/identity/api/oauth/ImplicitGrant.scala
+++ b/identity/src/main/scala/stasis/identity/api/oauth/ImplicitGrant.scala
@@ -38,7 +38,7 @@ class ImplicitGrant(
           case client if request.redirect_uri.forall(_ == client.redirectUri) =>
             val redirectUri = Uri(request.redirect_uri.getOrElse(client.redirectUri))
 
-            (authenticateResourceOwner(redirectUri, request.state) & extractApiAudience(request.scope)) {
+            (authenticateResourceOwner(redirectUri, request.state) & extractApiAudience(realm.id, request.scope)) {
               (owner, audience) =>
                 generateAccessToken(owner, audience) { accessToken =>
                   val scope = apiAudienceToScope(audience)

--- a/identity/src/main/scala/stasis/identity/api/oauth/PkceAuthorizationCodeGrant.scala
+++ b/identity/src/main/scala/stasis/identity/api/oauth/PkceAuthorizationCodeGrant.scala
@@ -44,7 +44,7 @@ class PkceAuthorizationCodeGrant(
           case client if request.redirect_uri.forall(_ == client.redirectUri) =>
             val redirectUri = Uri(request.redirect_uri.getOrElse(client.redirectUri))
 
-            (authenticateResourceOwner(redirectUri, request.state) & extractApiAudience(request.scope)) {
+            (authenticateResourceOwner(redirectUri, request.state) & extractApiAudience(realm.id, request.scope)) {
               (owner, audience) =>
                 val scope = apiAudienceToScope(audience)
 
@@ -99,7 +99,7 @@ class PkceAuthorizationCodeGrant(
         retrieveClient(request.client_id) {
           case client if client.id == request.client_id && request.redirect_uri.forall(_ == client.redirectUri) =>
             consumeAuthorizationCode(client.id, request.code, request.code_verifier) { (owner, scope) =>
-              extractApiAudience(scope) { audience =>
+              extractApiAudience(realm.id, scope) { audience =>
                 val scope = apiAudienceToScope(audience)
 
                 (generateAccessToken(owner, audience) & generateRefreshToken(realm, client.id, owner, scope)) {

--- a/identity/src/main/scala/stasis/identity/api/oauth/PkceAuthorizationCodeGrant.scala
+++ b/identity/src/main/scala/stasis/identity/api/oauth/PkceAuthorizationCodeGrant.scala
@@ -63,10 +63,12 @@ class PkceAuthorizationCodeGrant(
                     client.id
                   )
 
-                  redirect(
-                    redirectUri.withQuery(AuthorizationResponse(code, request.state, scope).asQuery),
-                    StatusCodes.Found
-                  )
+                  discardEntity {
+                    redirect(
+                      redirectUri.withQuery(AuthorizationResponse(code, request.state, scope).asQuery),
+                      StatusCodes.Found
+                    )
+                  }
                 }
             }
 
@@ -79,10 +81,12 @@ class PkceAuthorizationCodeGrant(
               request.redirect_uri
             )
 
-            complete(
-              StatusCodes.BadRequest,
-              "The request has missing, invalid or mismatching redirection URI and/or client identifier"
-            )
+            discardEntity {
+              complete(
+                StatusCodes.BadRequest,
+                "The request has missing, invalid or mismatching redirection URI and/or client identifier"
+              )
+            }
         }
       }
     }
@@ -114,19 +118,21 @@ class PkceAuthorizationCodeGrant(
                       client.id
                     )
 
-                    complete(
-                      StatusCodes.OK,
-                      List[HttpHeader](
-                        headers.`Content-Type`(ContentTypes.`application/json`),
-                        headers.`Cache-Control`(headers.CacheDirectives.`no-store`)
-                      ),
-                      AccessTokenResponse(
-                        access_token = accessToken,
-                        token_type = TokenType.Bearer,
-                        expires_in = client.tokenExpiration,
-                        refresh_token = refreshToken
+                    discardEntity {
+                      complete(
+                        StatusCodes.OK,
+                        List[HttpHeader](
+                          headers.`Content-Type`(ContentTypes.`application/json`),
+                          headers.`Cache-Control`(headers.CacheDirectives.`no-store`)
+                        ),
+                        AccessTokenResponse(
+                          access_token = accessToken,
+                          token_type = TokenType.Bearer,
+                          expires_in = client.tokenExpiration,
+                          refresh_token = refreshToken
+                        )
                       )
-                    )
+                    }
                 }
               }
             }
@@ -144,10 +150,12 @@ class PkceAuthorizationCodeGrant(
               )
             )
 
-            complete(
-              StatusCodes.BadRequest,
-              TokenError.InvalidRequest
-            )
+            discardEntity {
+              complete(
+                StatusCodes.BadRequest,
+                TokenError.InvalidRequest
+              )
+            }
         }
       }
     }
@@ -190,7 +198,6 @@ object PkceAuthorizationCodeGrant {
     state: String,
     scope: Option[String]
   ) {
-    // TODO - make generic?
     def asQuery: Uri.Query =
       Uri.Query(
         scope.foldLeft(

--- a/identity/src/main/scala/stasis/identity/api/oauth/RefreshTokenGrant.scala
+++ b/identity/src/main/scala/stasis/identity/api/oauth/RefreshTokenGrant.scala
@@ -35,7 +35,7 @@ class RefreshTokenGrant(
       ).as(AccessTokenRequest) { request =>
         authenticateClient(realm) { client =>
           consumeRefreshToken(client.id, request.scope, request.refresh_token) { owner =>
-            extractApiAudience(request.scope) { audience =>
+            extractApiAudience(realm.id, request.scope) { audience =>
               val scope = apiAudienceToScope(audience)
 
               (generateAccessToken(owner, audience) & generateRefreshToken(realm, client.id, owner, scope)) {

--- a/identity/src/main/scala/stasis/identity/api/oauth/RefreshTokenGrant.scala
+++ b/identity/src/main/scala/stasis/identity/api/oauth/RefreshTokenGrant.scala
@@ -50,20 +50,22 @@ class RefreshTokenGrant(
                     client.id
                   )
 
-                  complete(
-                    StatusCodes.OK,
-                    List[HttpHeader](
-                      headers.`Content-Type`(ContentTypes.`application/json`),
-                      headers.`Cache-Control`(headers.CacheDirectives.`no-store`)
-                    ),
-                    AccessTokenResponse(
-                      access_token = accessToken,
-                      token_type = TokenType.Bearer,
-                      expires_in = client.tokenExpiration,
-                      refresh_token = refreshToken,
-                      scope = scope
+                  discardEntity {
+                    complete(
+                      StatusCodes.OK,
+                      List[HttpHeader](
+                        headers.`Content-Type`(ContentTypes.`application/json`),
+                        headers.`Cache-Control`(headers.CacheDirectives.`no-store`)
+                      ),
+                      AccessTokenResponse(
+                        access_token = accessToken,
+                        token_type = TokenType.Bearer,
+                        expires_in = client.tokenExpiration,
+                        refresh_token = refreshToken,
+                        scope = scope
+                      )
                     )
-                  )
+                  }
               }
             }
           }

--- a/identity/src/main/scala/stasis/identity/api/oauth/ResourceOwnerPasswordCredentialsGrant.scala
+++ b/identity/src/main/scala/stasis/identity/api/oauth/ResourceOwnerPasswordCredentialsGrant.scala
@@ -51,20 +51,22 @@ class ResourceOwnerPasswordCredentialsGrant(
                     client.id
                   )
 
-                  complete(
-                    StatusCodes.OK,
-                    List[HttpHeader](
-                      headers.`Content-Type`(ContentTypes.`application/json`),
-                      headers.`Cache-Control`(headers.CacheDirectives.`no-store`)
-                    ),
-                    AccessTokenResponse(
-                      access_token = accessToken,
-                      token_type = TokenType.Bearer,
-                      expires_in = client.tokenExpiration,
-                      refresh_token = refreshToken,
-                      scope = scope
+                  discardEntity {
+                    complete(
+                      StatusCodes.OK,
+                      List[HttpHeader](
+                        headers.`Content-Type`(ContentTypes.`application/json`),
+                        headers.`Cache-Control`(headers.CacheDirectives.`no-store`)
+                      ),
+                      AccessTokenResponse(
+                        access_token = accessToken,
+                        token_type = TokenType.Bearer,
+                        expires_in = client.tokenExpiration,
+                        refresh_token = refreshToken,
+                        scope = scope
+                      )
                     )
-                  )
+                  }
               }
             }
           }

--- a/identity/src/main/scala/stasis/identity/api/oauth/ResourceOwnerPasswordCredentialsGrant.scala
+++ b/identity/src/main/scala/stasis/identity/api/oauth/ResourceOwnerPasswordCredentialsGrant.scala
@@ -36,7 +36,7 @@ class ResourceOwnerPasswordCredentialsGrant(
       ).as(AccessTokenRequest) { request =>
         authenticateClient(realm) { client =>
           authenticateResourceOwner(request.username, request.password) { owner =>
-            extractApiAudience(request.scope) { audience =>
+            extractApiAudience(realm.id, request.scope) { audience =>
               val scope = apiAudienceToScope(audience)
 
               (generateAccessToken(owner, audience) & generateRefreshToken(realm, client.id, owner, scope)) {

--- a/identity/src/main/scala/stasis/identity/api/oauth/directives/AudienceExtraction.scala
+++ b/identity/src/main/scala/stasis/identity/api/oauth/directives/AudienceExtraction.scala
@@ -9,6 +9,7 @@ import stasis.identity.api.directives.BaseApiDirective
 import stasis.identity.model.apis.{Api, ApiStoreView}
 import stasis.identity.model.clients.{Client, ClientStoreView}
 import stasis.identity.model.errors.TokenError
+import stasis.identity.model.realms.Realm
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.matching.Regex
@@ -52,13 +53,13 @@ trait AudienceExtraction extends BaseApiDirective {
       }
     }
 
-  def extractApiAudience(scopeOpt: Option[String]): Directive1[Seq[Api]] =
+  def extractApiAudience(realm: Realm.Id, scopeOpt: Option[String]): Directive1[Seq[Api]] =
     Directive { inner =>
       extractAudienceFromScope(scopeOpt) { apiIds =>
         getAudienceFromStore(
           audience = apiIds,
           audienceType = "API",
-          get = apiStore.get
+          get = (id: Api.Id) => apiStore.get(realm, id)
         )(result => inner(Tuple1(result)))
       }
     }

--- a/identity/src/main/scala/stasis/identity/api/oauth/directives/AuthorizationCodeConsumption.scala
+++ b/identity/src/main/scala/stasis/identity/api/oauth/directives/AuthorizationCodeConsumption.scala
@@ -1,20 +1,26 @@
 package stasis.identity.api.oauth.directives
 
+import java.nio.charset.{Charset, StandardCharsets}
+import java.security.MessageDigest
+
 import akka.event.LoggingAdapter
 import akka.http.scaladsl.model.StatusCodes
-import akka.http.scaladsl.server.Directive
+import akka.http.scaladsl.server.{Directive, Route}
 import akka.http.scaladsl.server.Directives._
+import com.google.common.io.BaseEncoding
 import stasis.identity.api.Formats._
 import stasis.identity.api.directives.BaseApiDirective
+import stasis.identity.model.ChallengeMethod
 import stasis.identity.model.clients.Client
 import stasis.identity.model.codes.{AuthorizationCode, AuthorizationCodeStore, StoredAuthorizationCode}
 import stasis.identity.model.errors.TokenError
 import stasis.identity.model.owners.ResourceOwner
 
 import scala.concurrent.ExecutionContext
-import scala.util.{Failure, Success}
+import scala.util.{Failure, Success, Try}
 
 trait AuthorizationCodeConsumption extends BaseApiDirective {
+  import AuthorizationCodeConsumption._
   import de.heikoseeberger.akkahttpplayjson.PlayJsonSupport._
 
   protected implicit def ec: ExecutionContext
@@ -26,22 +32,15 @@ trait AuthorizationCodeConsumption extends BaseApiDirective {
     client: Client.Id,
     providedCode: AuthorizationCode
   ): Directive[(ResourceOwner, Option[String])] =
-    Directive { inner =>
-      onComplete(
-        for {
-          storedCode <- authorizationCodeStore.get(client)
-          _ <- authorizationCodeStore.delete(client)
-        } yield {
-          storedCode
-        }
-      ) {
-        case Success(Some(StoredAuthorizationCode(`providedCode`, owner, scope))) =>
+    consumeCode(
+      client,
+      handler = inner => {
+        case Success(Some(StoredAuthorizationCode(`providedCode`, owner, scope, None))) =>
           inner(Tuple2(owner, scope))
 
-        case Success(Some(StoredAuthorizationCode(storedCode, owner, _))) =>
+        case Success(Some(StoredAuthorizationCode(`providedCode`, owner, _, Some(_)))) =>
           log.warning(
-            "Authorization code [{}] stored for client [{}] and owner [{}] did not match provided code",
-            storedCode,
+            "Authorization code for client [{}] and owner [{}] has challenge but none was expected",
             client,
             owner.username
           )
@@ -52,11 +51,64 @@ trait AuthorizationCodeConsumption extends BaseApiDirective {
               TokenError.InvalidGrant
             )
           }
+      }
+    )
 
-        case Success(None) =>
+  def consumeAuthorizationCode(
+    client: Client.Id,
+    providedCode: AuthorizationCode,
+    verifier: String
+  ): Directive[(ResourceOwner, Option[String])] =
+    consumeCode(
+      client,
+      handler = inner => {
+        case Success(Some(StoredAuthorizationCode(`providedCode`, owner, scope, Some(challenge)))) =>
+          val verifierMatchesChallenge = challenge.method match {
+            case Some(ChallengeMethod.S256) =>
+              val hashedVerifier =
+                MessageDigest
+                  .getInstance(ChallengeVerification.DigestAlgorithm)
+                  .digest(verifier.getBytes(ChallengeVerification.Charset))
+
+              val encodedVerifier =
+                BaseEncoding
+                  .base64Url()
+                  .encode(hashedVerifier)
+
+              encodedVerifier == challenge.value
+
+            case Some(ChallengeMethod.Plain) | None =>
+              log.warning(
+                "Plain code verifier transformation method used for client [{}] and owner [{}]",
+                client,
+                owner.username
+              )
+
+              verifier == challenge.value
+          }
+
+          if (verifierMatchesChallenge) {
+            inner(Tuple2(owner, scope))
+          } else {
+            log.warning(
+              "Authorization code for client [{}] and owner [{}] did not have matching challenge and verifier",
+              client,
+              owner.username
+            )
+
+            discardEntity {
+              complete(
+                StatusCodes.BadRequest,
+                TokenError.InvalidGrant
+              )
+            }
+          }
+
+        case Success(Some(StoredAuthorizationCode(`providedCode`, owner, _, None))) =>
           log.warning(
-            "No authorization code found for client [{}]",
-            client
+            "Authorization code for client [{}] and owner [{}] has no challenge but one was expected",
+            client,
+            owner.username
           )
 
           discardEntity {
@@ -65,20 +117,75 @@ trait AuthorizationCodeConsumption extends BaseApiDirective {
               TokenError.InvalidGrant
             )
           }
+      }
+    )
 
-        case Failure(e) =>
-          log.error(
-            e,
-            "Failed to consume authorization code for client [{}]: [{}]",
-            client,
-            e.getMessage
-          )
-
-          discardEntity {
-            complete(
-              StatusCodes.InternalServerError
+  private def consumeCode(
+    client: Client.Id,
+    handler: (
+      ((ResourceOwner, Option[String])) => Route
+    ) => PartialFunction[Try[Option[StoredAuthorizationCode]], Route]
+  ): Directive[(ResourceOwner, Option[String])] =
+    Directive { inner =>
+      onComplete(
+        for {
+          storedCode <- authorizationCodeStore.get(client)
+          _ <- authorizationCodeStore.delete(client)
+        } yield {
+          storedCode
+        }
+      ) {
+        handler(inner).orElse {
+          case Success(Some(StoredAuthorizationCode(storedCode, owner, _, _))) =>
+            log.warning(
+              "Authorization code [{}] stored for client [{}] and owner [{}] did not match provided code",
+              storedCode,
+              client,
+              owner.username
             )
-          }
+
+            discardEntity {
+              complete(
+                StatusCodes.BadRequest,
+                TokenError.InvalidGrant
+              )
+            }
+
+          case Success(None) =>
+            log.warning(
+              "No authorization code found for client [{}]",
+              client
+            )
+
+            discardEntity {
+              complete(
+                StatusCodes.BadRequest,
+                TokenError.InvalidGrant
+              )
+            }
+
+          case Failure(e) =>
+            log.error(
+              e,
+              "Failed to consume authorization code for client [{}]: [{}]",
+              client,
+              e.getMessage
+            )
+
+            discardEntity {
+              complete(
+                StatusCodes.InternalServerError
+              )
+            }
+        }
+
       }
     }
+}
+
+object AuthorizationCodeConsumption {
+  object ChallengeVerification {
+    final val DigestAlgorithm: String = "SHA-256"
+    final val Charset: Charset = StandardCharsets.US_ASCII
+  }
 }

--- a/identity/src/main/scala/stasis/identity/model/ChallengeMethod.scala
+++ b/identity/src/main/scala/stasis/identity/model/ChallengeMethod.scala
@@ -1,0 +1,8 @@
+package stasis.identity.model
+
+sealed trait ChallengeMethod
+
+object ChallengeMethod {
+  case object Plain extends ChallengeMethod
+  case object S256 extends ChallengeMethod
+}

--- a/identity/src/main/scala/stasis/identity/model/apis/ApiStore.scala
+++ b/identity/src/main/scala/stasis/identity/model/apis/ApiStore.scala
@@ -1,27 +1,27 @@
 package stasis.identity.model.apis
 
 import scala.concurrent.Future
-
 import akka.Done
 import stasis.core.persistence.backends.KeyValueBackend
+import stasis.identity.model.realms.Realm
 
 trait ApiStore { store =>
   def put(api: Api): Future[Done]
-  def delete(api: Api.Id): Future[Boolean]
-  def get(api: Api.Id): Future[Option[Api]]
-  def apis: Future[Map[Api.Id, Api]]
+  def delete(realm: Realm.Id, api: Api.Id): Future[Boolean]
+  def get(realm: Realm.Id, api: Api.Id): Future[Option[Api]]
+  def apis: Future[Map[(Realm.Id, Api.Id), Api]]
 
   def view: ApiStoreView = new ApiStoreView {
-    override def get(api: Api.Id): Future[Option[Api]] = store.get(api)
-    override def apis: Future[Map[Api.Id, Api]] = store.apis
+    override def get(realm: Realm.Id, api: Api.Id): Future[Option[Api]] = store.get(realm, api)
+    override def apis: Future[Map[(Realm.Id, Api.Id), Api]] = store.apis
   }
 }
 
 object ApiStore {
-  def apply(backend: KeyValueBackend[Api.Id, Api]): ApiStore = new ApiStore {
-    override def put(api: Api): Future[Done] = backend.put(api.id, api)
-    override def delete(api: Api.Id): Future[Boolean] = backend.delete(api)
-    override def get(api: Api.Id): Future[Option[Api]] = backend.get(api)
-    override def apis: Future[Map[Api.Id, Api]] = backend.entries
+  def apply(backend: KeyValueBackend[(Realm.Id, Api.Id), Api]): ApiStore = new ApiStore {
+    override def put(api: Api): Future[Done] = backend.put(api.realm -> api.id, api)
+    override def delete(realm: Realm.Id, api: Api.Id): Future[Boolean] = backend.delete(realm, api)
+    override def get(realm: Realm.Id, api: Api.Id): Future[Option[Api]] = backend.get(realm, api)
+    override def apis: Future[Map[(Realm.Id, Api.Id), Api]] = backend.entries
   }
 }

--- a/identity/src/main/scala/stasis/identity/model/apis/ApiStoreView.scala
+++ b/identity/src/main/scala/stasis/identity/model/apis/ApiStoreView.scala
@@ -1,8 +1,10 @@
 package stasis.identity.model.apis
 
+import stasis.identity.model.realms.Realm
+
 import scala.concurrent.Future
 
 trait ApiStoreView {
-  def get(api: Api.Id): Future[Option[Api]]
-  def apis: Future[Map[Api.Id, Api]]
+  def get(realm: Realm.Id, api: Api.Id): Future[Option[Api]]
+  def apis: Future[Map[(Realm.Id, Api.Id), Api]]
 }

--- a/identity/src/main/scala/stasis/identity/model/codes/AuthorizationCodeStore.scala
+++ b/identity/src/main/scala/stasis/identity/model/codes/AuthorizationCodeStore.scala
@@ -1,15 +1,15 @@
 package stasis.identity.model.codes
 
-import scala.concurrent.duration.FiniteDuration
-import scala.concurrent.{ExecutionContext, Future}
 import akka.Done
 import akka.actor.typed.{ActorSystem, SpawnProtocol}
 import stasis.core.persistence.backends.KeyValueBackend
 import stasis.identity.model.clients.Client
-import stasis.identity.model.owners.ResourceOwner
+
+import scala.concurrent.duration.FiniteDuration
+import scala.concurrent.{ExecutionContext, Future}
 
 trait AuthorizationCodeStore {
-  def put(client: Client.Id, code: AuthorizationCode, owner: ResourceOwner, scope: Option[String]): Future[Done]
+  def put(client: Client.Id, code: StoredAuthorizationCode): Future[Done]
   def delete(client: Client.Id): Future[Boolean]
   def get(client: Client.Id): Future[Option[StoredAuthorizationCode]]
   def codes: Future[Map[Client.Id, StoredAuthorizationCode]]
@@ -23,14 +23,9 @@ object AuthorizationCodeStore {
     new AuthorizationCodeStore {
       private implicit val ec: ExecutionContext = system.executionContext
 
-      override def put(
-        client: Client.Id,
-        code: AuthorizationCode,
-        owner: ResourceOwner,
-        scope: Option[String]
-      ): Future[Done] =
+      override def put(client: Client.Id, code: StoredAuthorizationCode): Future[Done] =
         backend
-          .put(client, StoredAuthorizationCode(code, owner, scope))
+          .put(client, code)
           .map { result =>
             val _ = akka.pattern.after(expiration, system.scheduler)(backend.delete(client))
             result

--- a/identity/src/main/scala/stasis/identity/model/codes/StoredAuthorizationCode.scala
+++ b/identity/src/main/scala/stasis/identity/model/codes/StoredAuthorizationCode.scala
@@ -1,9 +1,19 @@
 package stasis.identity.model.codes
 
+import stasis.identity.model.ChallengeMethod
+import stasis.identity.model.codes.StoredAuthorizationCode.Challenge
 import stasis.identity.model.owners.ResourceOwner
 
 final case class StoredAuthorizationCode(
   code: AuthorizationCode,
   owner: ResourceOwner,
-  scope: Option[String]
+  scope: Option[String],
+  challenge: Option[Challenge]
 )
+
+object StoredAuthorizationCode {
+  final case class Challenge(value: String, method: Option[ChallengeMethod])
+
+  def apply(code: AuthorizationCode, owner: ResourceOwner, scope: Option[String]): StoredAuthorizationCode =
+    new StoredAuthorizationCode(code, owner, scope, challenge = None)
+}

--- a/identity/src/test/scala/stasis/test/specs/unit/identity/RouteTest.scala
+++ b/identity/src/test/scala/stasis/test/specs/unit/identity/RouteTest.scala
@@ -36,7 +36,7 @@ trait RouteTest extends AsyncUnitSpec with ScalatestRouteTest {
   def createLogger(): LoggingAdapter = Logging(system, this.getClass.getName)
 
   def createApiStore(): ApiStore = ApiStore(
-    MemoryBackend[Api.Id, Api](name = s"api-store-${java.util.UUID.randomUUID()}")
+    MemoryBackend[(Realm.Id, Api.Id), Api](name = s"api-store-${java.util.UUID.randomUUID()}")
   )
 
   def createClientStore(): ClientStore = ClientStore(
@@ -68,7 +68,7 @@ trait RouteTest extends AsyncUnitSpec with ScalatestRouteTest {
     failingEntries: Boolean = false,
     failingContains: Boolean = false
   ): ApiStore = ApiStore(
-    new FailingMemoryBackend[Api.Id, Api] {
+    new FailingMemoryBackend[(Realm.Id, Api.Id), Api] {
       override def system: ActorSystem[SpawnProtocol] = typedSystem
       override def storeName: String = s"api-store-${java.util.UUID.randomUUID()}"
       override def putFails: Boolean = failingPut

--- a/identity/src/test/scala/stasis/test/specs/unit/identity/api/FormatsSpec.scala
+++ b/identity/src/test/scala/stasis/test/specs/unit/identity/api/FormatsSpec.scala
@@ -5,7 +5,7 @@ import stasis.identity.api.Formats._
 import stasis.identity.model.codes.StoredAuthorizationCode
 import stasis.identity.model.errors.{AuthorizationError, TokenError}
 import stasis.identity.model.tokens.{AccessToken, RefreshToken, StoredRefreshToken, TokenType}
-import stasis.identity.model.{GrantType, ResponseType, Seconds}
+import stasis.identity.model.{ChallengeMethod, GrantType, ResponseType, Seconds}
 import stasis.test.specs.unit.UnitSpec
 import stasis.test.specs.unit.identity.model.Generators
 
@@ -48,6 +48,19 @@ class FormatsSpec extends UnitSpec {
       case (grant, json) =>
         grantTypeFormat.writes(grant).toString should be(json)
         grantTypeFormat.reads(Json.parse(json).as[JsString]).asOpt should be(Some(grant))
+    }
+  }
+
+  they should "convert challenge methods t/from JSON" in {
+    val challenges = Map(
+      ChallengeMethod.Plain -> "\"plain\"",
+      ChallengeMethod.S256 -> "\"s256\""
+    )
+
+    challenges.foreach {
+      case (challenge, json) =>
+        challengeMethodFormat.writes(challenge).toString should be(json)
+        challengeMethodFormat.reads(Json.parse(json).as[JsString]).asOpt should be(Some(challenge))
     }
   }
 

--- a/identity/src/test/scala/stasis/test/specs/unit/identity/api/ManageSpec.scala
+++ b/identity/src/test/scala/stasis/test/specs/unit/identity/api/ManageSpec.scala
@@ -8,6 +8,7 @@ import stasis.identity.api.Manage
 import stasis.identity.api.manage.setup.Config
 import stasis.identity.model.apis.Api
 import stasis.identity.model.clients.Client
+import stasis.identity.model.codes.StoredAuthorizationCode
 import stasis.identity.model.realms.Realm
 import stasis.identity.model.secrets.Secret
 import stasis.test.specs.unit.identity.RouteTest
@@ -40,7 +41,7 @@ class ManageSpec extends RouteTest with ManageFixtures {
     val code = Generators.generateAuthorizationCode
     val owner = Generators.generateResourceOwner
 
-    providers.codeStore.put(client, code, owner, scope = None).await
+    providers.codeStore.put(client, StoredAuthorizationCode(code, owner, scope = None)).await
     Get(s"/master/codes/$client").addCredentials(credentials) ~> manage.routes ~> check {
       status should be(StatusCodes.OK)
       responseAs[JsObject].fields should contain("code" -> JsString(code.value))

--- a/identity/src/test/scala/stasis/test/specs/unit/identity/api/OAuthSpec.scala
+++ b/identity/src/test/scala/stasis/test/specs/unit/identity/api/OAuthSpec.scala
@@ -18,7 +18,7 @@ class OAuthSpec extends RouteTest with OAuthFixtures {
 
     val realm = Generators.generateRealm
     val client = Generators.generateClient.copy(realm = realm.id)
-    val api = Generators.generateApi
+    val api = Generators.generateApi.copy(realm = realm.id)
 
     val rawPassword = "some-password"
     val salt = Generators.generateString(withSize = secrets.owner.saltSize)
@@ -72,7 +72,7 @@ class OAuthSpec extends RouteTest with OAuthFixtures {
 
     val realm = Generators.generateRealm
     val client = Generators.generateClient.copy(realm = realm.id)
-    val api = Generators.generateApi
+    val api = Generators.generateApi.copy(realm = realm.id)
 
     val rawPassword = "some-password"
     val salt = Generators.generateString(withSize = secrets.owner.saltSize)
@@ -131,7 +131,7 @@ class OAuthSpec extends RouteTest with OAuthFixtures {
 
     val realm = Generators.generateRealm
     val client = Generators.generateClient.copy(realm = realm.id)
-    val api = Generators.generateApi
+    val api = Generators.generateApi.copy(realm = realm.id)
 
     val rawPassword = "some-password"
     val salt = Generators.generateString(withSize = secrets.owner.saltSize)
@@ -201,7 +201,7 @@ class OAuthSpec extends RouteTest with OAuthFixtures {
     val realm = Generators.generateRealm
     val owner = Generators.generateResourceOwner
     val code = Generators.generateAuthorizationCode
-    val api = Generators.generateApi
+    val api = Generators.generateApi.copy(realm = realm.id)
 
     val rawPassword = "some-password"
     val salt = Generators.generateString(withSize = secrets.client.saltSize)
@@ -252,7 +252,7 @@ class OAuthSpec extends RouteTest with OAuthFixtures {
     val realm = Generators.generateRealm
     val owner = Generators.generateResourceOwner
     val code = Generators.generateAuthorizationCode
-    val api = Generators.generateApi
+    val api = Generators.generateApi.copy(realm = realm.id)
 
     val rawPassword = "some-password"
     val salt = Generators.generateString(withSize = secrets.client.saltSize)
@@ -347,7 +347,7 @@ class OAuthSpec extends RouteTest with OAuthFixtures {
 
     val realm = Generators.generateRealm
     val owner = Generators.generateResourceOwner.copy(realm = realm.id)
-    val api = Generators.generateApi
+    val api = Generators.generateApi.copy(realm = realm.id)
 
     val rawPassword = "some-password"
     val salt = Generators.generateString(withSize = secrets.client.saltSize)
@@ -395,7 +395,7 @@ class OAuthSpec extends RouteTest with OAuthFixtures {
     val oauth = new OAuth(providers)
 
     val realm = Generators.generateRealm
-    val api = Generators.generateApi
+    val api = Generators.generateApi.copy(realm = realm.id)
 
     val clientRawPassword = "some-password"
     val clientSalt = Generators.generateString(withSize = secrets.client.saltSize)

--- a/identity/src/test/scala/stasis/test/specs/unit/identity/api/OAuthSpec.scala
+++ b/identity/src/test/scala/stasis/test/specs/unit/identity/api/OAuthSpec.scala
@@ -5,6 +5,7 @@ import akka.http.scaladsl.model.headers.{BasicHttpCredentials, CacheDirectives}
 import akka.http.scaladsl.model.{ContentTypes, StatusCodes, Uri}
 import stasis.identity.api.OAuth
 import stasis.identity.api.oauth.directives.AudienceExtraction
+import stasis.identity.model.codes.StoredAuthorizationCode
 import stasis.identity.model.secrets.Secret
 import stasis.test.specs.unit.identity.RouteTest
 import stasis.test.specs.unit.identity.api.oauth.OAuthFixtures
@@ -31,16 +32,82 @@ class OAuthSpec extends RouteTest with OAuthFixtures {
     val state = Generators.generateString(withSize = 16)
     val scope = s"${AudienceExtraction.UrnPrefix}:${api.id}"
 
+    val uri =
+      s"/${realm.id}/authorization" +
+        s"?response_type=code" +
+        s"&client_id=${client.id}" +
+        s"&scope=$scope" +
+        s"&state=$state"
+
     stores.realms.put(realm).await
     stores.clients.put(client).await
     stores.owners.put(owner).await
     stores.apis.put(api).await
-    Get(
-      s"/${realm.id}/authorization?response_type=code&client_id=${client.id}&scope=$scope&state=$state"
-    ).addCredentials(credentials) ~> oauth.routes ~> check {
+    Get(uri).addCredentials(credentials) ~> oauth.routes ~> check {
       status should be(StatusCodes.Found)
       stores.codes.get(client.id).await match {
         case Some(storedCode) =>
+          storedCode.challenge should be(None)
+
+          headers should contain(
+            model.headers.Location(
+              Uri(
+                s"${client.redirectUri}" +
+                  s"?code=${storedCode.code.value}" +
+                  s"&state=$state" +
+                  s"&scope=$scope"
+              )
+            )
+          )
+
+        case None =>
+          fail("Unexpected response received; no authorization code found")
+      }
+    }
+  }
+
+  they should "handle PKCE code authorization requests" in {
+    val (stores, secrets, providers) = createOAuthFixtures()
+    val oauth = new OAuth(providers)
+
+    val realm = Generators.generateRealm
+    val client = Generators.generateClient.copy(realm = realm.id)
+    val api = Generators.generateApi
+
+    val rawPassword = "some-password"
+    val salt = Generators.generateString(withSize = secrets.owner.saltSize)
+    val owner = Generators.generateResourceOwner.copy(
+      realm = realm.id,
+      password = Secret.derive(rawPassword, salt)(secrets.owner),
+      salt = salt
+    )
+    val credentials = BasicHttpCredentials(owner.username, rawPassword)
+
+    val state = Generators.generateString(withSize = 16)
+    val scope = s"${AudienceExtraction.UrnPrefix}:${api.id}"
+    val storedChallenge = StoredAuthorizationCode.Challenge(
+      value = Generators.generateString(withSize = 128),
+      method = None
+    )
+
+    val uri =
+      s"/${realm.id}/authorization" +
+        s"?response_type=code" +
+        s"&client_id=${client.id}" +
+        s"&scope=$scope" +
+        s"&state=$state" +
+        s"&code_challenge=${storedChallenge.value}"
+
+    stores.realms.put(realm).await
+    stores.clients.put(client).await
+    stores.owners.put(owner).await
+    stores.apis.put(api).await
+    Get(uri).addCredentials(credentials) ~> oauth.routes ~> check {
+      status should be(StatusCodes.Found)
+      stores.codes.get(client.id).await match {
+        case Some(storedCode) =>
+          storedCode.challenge should be(Some(storedChallenge))
+
           headers should contain(
             model.headers.Location(
               Uri(
@@ -78,13 +145,18 @@ class OAuthSpec extends RouteTest with OAuthFixtures {
     val scope = s"${AudienceExtraction.UrnPrefix}:${api.id}"
     val state = Generators.generateString(withSize = 16)
 
+    val uri =
+      s"/${realm.id}/authorization" +
+        s"?response_type=token" +
+        s"&client_id=${client.id}" +
+        s"&scope=$scope" +
+        s"&state=$state"
+
     stores.realms.put(realm).await
     stores.clients.put(client).await
     stores.owners.put(owner).await
     stores.apis.put(api).await
-    Get(
-      s"/${realm.id}/authorization?response_type=token&client_id=${client.id}&scope=$scope&state=$state"
-    ).addCredentials(credentials) ~> oauth.routes ~> check {
+    Get(uri).addCredentials(credentials) ~> oauth.routes ~> check {
       status should be(StatusCodes.Found)
 
       headers.find(_.is("location")) match {
@@ -109,10 +181,12 @@ class OAuthSpec extends RouteTest with OAuthFixtures {
     val realm = Generators.generateRealm
     val responseType = "some-response"
 
+    val uri =
+      s"/${realm.id}/authorization" +
+        s"?response_type=$responseType"
+
     stores.realms.put(realm).await
-    Get(
-      s"/${realm.id}/authorization?response_type=$responseType"
-    ) ~> oauth.routes ~> check {
+    Get(uri) ~> oauth.routes ~> check {
       status should be(StatusCodes.BadRequest)
       responseAs[String] should be(
         s"Realm [${realm.id}]: The request includes an invalid response type: [$responseType]"
@@ -138,14 +212,82 @@ class OAuthSpec extends RouteTest with OAuthFixtures {
     )
     val credentials = BasicHttpCredentials(client.id.toString, rawPassword)
 
+    val storedCode = StoredAuthorizationCode(
+      code,
+      owner,
+      scope = Some(s"${AudienceExtraction.UrnPrefix}:${api.id}")
+    )
+
+    val uri =
+      s"/${realm.id}/token" +
+        s"?grant_type=authorization_code" +
+        s"&code=${code.value}" +
+        s"&client_id=${client.id}"
+
     stores.realms.put(realm).await
     stores.clients.put(client).await
     stores.owners.put(owner).await
     stores.apis.put(api).await
-    stores.codes.put(client.id, code, owner, scope = Some(s"${AudienceExtraction.UrnPrefix}:${api.id}")).await
-    Post(
-      s"/${realm.id}/token?grant_type=authorization_code&code=${code.value}&client_id=${client.id}"
-    ).addCredentials(credentials) ~> oauth.routes ~> check {
+    stores.codes.put(client.id, storedCode).await
+    Post(uri).addCredentials(credentials) ~> oauth.routes ~> check {
+      status should be(StatusCodes.OK)
+      headers should contain(model.headers.`Content-Type`(ContentTypes.`application/json`))
+      headers should contain(model.headers.`Cache-Control`(CacheDirectives.`no-store`))
+
+      val actualResponse = responseAs[String]
+      actualResponse.contains("access_token") should be(true)
+      actualResponse.contains("token_type") should be(true)
+      actualResponse.contains("expires_in") should be(true)
+      actualResponse.contains("refresh_token") should be(true)
+
+      val refreshTokenGenerated = stores.tokens.get(client.id).await.nonEmpty
+      refreshTokenGenerated should be(true)
+    }
+  }
+
+  they should "handle PKCE authorization code token grants" in {
+    val (stores, secrets, providers) = createOAuthFixtures()
+    val oauth = new OAuth(providers)
+
+    val realm = Generators.generateRealm
+    val owner = Generators.generateResourceOwner
+    val code = Generators.generateAuthorizationCode
+    val api = Generators.generateApi
+
+    val rawPassword = "some-password"
+    val salt = Generators.generateString(withSize = secrets.client.saltSize)
+    val client = Generators.generateClient.copy(
+      realm = realm.id,
+      secret = Secret.derive(rawPassword, salt)(secrets.client),
+      salt = salt
+    )
+    val credentials = BasicHttpCredentials(client.id.toString, rawPassword)
+
+    val storedChallenge = StoredAuthorizationCode.Challenge(
+      value = Generators.generateString(withSize = 128),
+      method = None
+    )
+
+    val storedCode = StoredAuthorizationCode(
+      code,
+      owner,
+      scope = Some(s"${AudienceExtraction.UrnPrefix}:${api.id}"),
+      Some(storedChallenge)
+    )
+
+    val uri =
+      s"/${realm.id}/token" +
+        s"?grant_type=authorization_code" +
+        s"&code=${code.value}" +
+        s"&client_id=${client.id}" +
+        s"&code_verifier=${storedChallenge.value}"
+
+    stores.realms.put(realm).await
+    stores.clients.put(client).await
+    stores.owners.put(owner).await
+    stores.apis.put(api).await
+    stores.codes.put(client.id, storedCode).await
+    Post(uri).addCredentials(credentials) ~> oauth.routes ~> check {
       status should be(StatusCodes.OK)
       headers should contain(model.headers.`Content-Type`(ContentTypes.`application/json`))
       headers should contain(model.headers.`Cache-Control`(CacheDirectives.`no-store`))
@@ -178,11 +320,14 @@ class OAuthSpec extends RouteTest with OAuthFixtures {
 
     val scope = s"${AudienceExtraction.UrnPrefix}:${client.id}"
 
+    val uri =
+      s"/${realm.id}/token" +
+        s"?grant_type=client_credentials" +
+        s"&scope=$scope"
+
     stores.realms.put(realm).await
     stores.clients.put(client).await
-    Post(
-      s"/${realm.id}/token?grant_type=client_credentials&scope=$scope"
-    ).addCredentials(credentials) ~> oauth.routes ~> check {
+    Post(uri).addCredentials(credentials) ~> oauth.routes ~> check {
       status should be(StatusCodes.OK)
 
       headers should contain(model.headers.`Content-Type`(ContentTypes.`application/json`))
@@ -216,14 +361,18 @@ class OAuthSpec extends RouteTest with OAuthFixtures {
     val token = Generators.generateRefreshToken
     val scope = s"${AudienceExtraction.UrnPrefix}:${api.id}"
 
+    val uri =
+      s"/${realm.id}/token" +
+        s"?grant_type=refresh_token" +
+        s"&refresh_token=${token.value}" +
+        s"&scope=$scope"
+
     stores.realms.put(realm).await
     stores.owners.put(owner).await
     stores.apis.put(api).await
     stores.clients.put(client).await
     stores.tokens.put(client.id, token, owner, Some(scope)).await
-    Post(
-      s"/${realm.id}/token?grant_type=refresh_token&refresh_token=${token.value}&scope=$scope"
-    ).addCredentials(credentials) ~> oauth.routes ~> check {
+    Post(uri).addCredentials(credentials) ~> oauth.routes ~> check {
       status should be(StatusCodes.OK)
 
       headers should contain(model.headers.`Content-Type`(ContentTypes.`application/json`))
@@ -266,13 +415,18 @@ class OAuthSpec extends RouteTest with OAuthFixtures {
     )
     val scope = s"${AudienceExtraction.UrnPrefix}:${api.id}"
 
+    val uri =
+      s"/${realm.id}/token" +
+        s"?grant_type=password" +
+        s"&username=${owner.username}" +
+        s"&password=$ownerRawPassword" +
+        s"&scope=$scope"
+
     stores.realms.put(realm).await
     stores.apis.put(api).await
     stores.clients.put(client).await
     stores.owners.put(owner).await
-    Post(
-      s"/${realm.id}/token?grant_type=password&username=${owner.username}&password=$ownerRawPassword&scope=$scope"
-    ).addCredentials(credentials) ~> oauth.routes ~> check {
+    Post(uri).addCredentials(credentials) ~> oauth.routes ~> check {
       status should be(StatusCodes.OK)
 
       headers should contain(model.headers.`Content-Type`(ContentTypes.`application/json`))
@@ -297,10 +451,12 @@ class OAuthSpec extends RouteTest with OAuthFixtures {
     val realm = Generators.generateRealm
     val grantType = "some-grant"
 
+    val uri =
+      s"/${realm.id}/token" +
+        s"?grant_type=$grantType"
+
     stores.realms.put(realm).await
-    Post(
-      s"/${realm.id}/token?grant_type=$grantType"
-    ) ~> oauth.routes ~> check {
+    Post(uri) ~> oauth.routes ~> check {
       status should be(StatusCodes.BadRequest)
       responseAs[String] should be(
         s"Realm [${realm.id}]: The request includes an invalid grant type: [$grantType]"

--- a/identity/src/test/scala/stasis/test/specs/unit/identity/api/manage/ApisSpec.scala
+++ b/identity/src/test/scala/stasis/test/specs/unit/identity/api/manage/ApisSpec.scala
@@ -38,7 +38,7 @@ class ApisSpec extends RouteTest {
 
     Post().withEntity(request) ~> apis.routes(user, realm) ~> check {
       status should be(StatusCodes.OK)
-      store.get(request.id).await should be(Some(request.toApi(realm)))
+      store.get(realm, request.id).await should be(Some(request.toApi(realm)))
     }
   }
 

--- a/identity/src/test/scala/stasis/test/specs/unit/identity/api/manage/ManageFixtures.scala
+++ b/identity/src/test/scala/stasis/test/specs/unit/identity/api/manage/ManageFixtures.scala
@@ -18,7 +18,7 @@ import scala.concurrent.duration._
 trait ManageFixtures { _: RouteTest =>
   def createManageProviders(expiration: FiniteDuration = 3.seconds) = Providers(
     apiStore = ApiStore(
-      MemoryBackend[Api.Id, Api](name = s"api-store-${java.util.UUID.randomUUID()}")
+      MemoryBackend[(Realm.Id, Api.Id), Api](name = s"api-store-${java.util.UUID.randomUUID()}")
     ),
     clientStore = ClientStore(
       MemoryBackend[Client.Id, Client](name = s"client-store-${java.util.UUID.randomUUID()}")

--- a/identity/src/test/scala/stasis/test/specs/unit/identity/api/oauth/AuthorizationCodeGrantSpec.scala
+++ b/identity/src/test/scala/stasis/test/specs/unit/identity/api/oauth/AuthorizationCodeGrantSpec.scala
@@ -71,7 +71,7 @@ class AuthorizationCodeGrantSpec extends RouteTest with OAuthFixtures {
 
     val realm = Generators.generateRealm
     val client = Generators.generateClient.copy(realm = realm.id)
-    val api = Generators.generateApi
+    val api = Generators.generateApi.copy(realm = realm.id)
 
     val rawPassword = "some-password"
     val salt = Generators.generateString(withSize = secrets.owner.saltSize)
@@ -122,7 +122,7 @@ class AuthorizationCodeGrantSpec extends RouteTest with OAuthFixtures {
 
     val realm = Generators.generateRealm
     val client = Generators.generateClient.copy(realm = realm.id)
-    val api = Generators.generateApi
+    val api = Generators.generateApi.copy(realm = realm.id)
 
     val rawPassword = "some-password"
     val salt = Generators.generateString(withSize = secrets.owner.saltSize)
@@ -160,7 +160,7 @@ class AuthorizationCodeGrantSpec extends RouteTest with OAuthFixtures {
     val realm = Generators.generateRealm
     val owner = Generators.generateResourceOwner
     val code = Generators.generateAuthorizationCode
-    val api = Generators.generateApi
+    val api = Generators.generateApi.copy(realm = realm.id)
 
     val rawPassword = "some-password"
     val salt = Generators.generateString(withSize = secrets.client.saltSize)
@@ -205,7 +205,7 @@ class AuthorizationCodeGrantSpec extends RouteTest with OAuthFixtures {
     val realm = Generators.generateRealm.copy(refreshTokensAllowed = false)
     val owner = Generators.generateResourceOwner
     val code = Generators.generateAuthorizationCode
-    val api = Generators.generateApi
+    val api = Generators.generateApi.copy(realm = realm.id)
 
     val rawPassword = "some-password"
     val salt = Generators.generateString(withSize = secrets.client.saltSize)
@@ -250,7 +250,7 @@ class AuthorizationCodeGrantSpec extends RouteTest with OAuthFixtures {
     val realm = Generators.generateRealm
     val owner = Generators.generateResourceOwner
     val code = Generators.generateAuthorizationCode
-    val api = Generators.generateApi
+    val api = Generators.generateApi.copy(realm = realm.id)
 
     val rawPassword = "some-password"
     val salt = Generators.generateString(withSize = secrets.client.saltSize)

--- a/identity/src/test/scala/stasis/test/specs/unit/identity/api/oauth/ImplicitGrantSpec.scala
+++ b/identity/src/test/scala/stasis/test/specs/unit/identity/api/oauth/ImplicitGrantSpec.scala
@@ -57,7 +57,7 @@ class ImplicitGrantSpec extends RouteTest with OAuthFixtures {
 
     val realm = Generators.generateRealm
     val client = Generators.generateClient.copy(realm = realm.id)
-    val api = Generators.generateApi
+    val api = Generators.generateApi.copy(realm = realm.id)
 
     val rawPassword = "some-password"
     val salt = Generators.generateString(withSize = secrets.owner.saltSize)
@@ -103,7 +103,7 @@ class ImplicitGrantSpec extends RouteTest with OAuthFixtures {
 
     val realm = Generators.generateRealm
     val client = Generators.generateClient.copy(realm = realm.id)
-    val api = Generators.generateApi
+    val api = Generators.generateApi.copy(realm = realm.id)
 
     val rawPassword = "some-password"
     val salt = Generators.generateString(withSize = secrets.owner.saltSize)

--- a/identity/src/test/scala/stasis/test/specs/unit/identity/api/oauth/PkceAuthorizationCodeGrantSpec.scala
+++ b/identity/src/test/scala/stasis/test/specs/unit/identity/api/oauth/PkceAuthorizationCodeGrantSpec.scala
@@ -76,7 +76,7 @@ class PkceAuthorizationCodeGrantSpec extends RouteTest with OAuthFixtures {
 
     val realm = Generators.generateRealm
     val client = Generators.generateClient.copy(realm = realm.id)
-    val api = Generators.generateApi
+    val api = Generators.generateApi.copy(realm = realm.id)
 
     val rawPassword = "some-password"
     val salt = Generators.generateString(withSize = secrets.owner.saltSize)
@@ -131,7 +131,7 @@ class PkceAuthorizationCodeGrantSpec extends RouteTest with OAuthFixtures {
 
     val realm = Generators.generateRealm
     val client = Generators.generateClient.copy(realm = realm.id)
-    val api = Generators.generateApi
+    val api = Generators.generateApi.copy(realm = realm.id)
 
     val rawPassword = "some-password"
     val salt = Generators.generateString(withSize = secrets.owner.saltSize)
@@ -171,7 +171,7 @@ class PkceAuthorizationCodeGrantSpec extends RouteTest with OAuthFixtures {
     val realm = Generators.generateRealm
     val owner = Generators.generateResourceOwner
     val code = Generators.generateAuthorizationCode
-    val api = Generators.generateApi
+    val api = Generators.generateApi.copy(realm = realm.id)
 
     val rawPassword = "some-password"
     val salt = Generators.generateString(withSize = secrets.client.saltSize)
@@ -229,7 +229,7 @@ class PkceAuthorizationCodeGrantSpec extends RouteTest with OAuthFixtures {
     val realm = Generators.generateRealm.copy(refreshTokensAllowed = false)
     val owner = Generators.generateResourceOwner
     val code = Generators.generateAuthorizationCode
-    val api = Generators.generateApi
+    val api = Generators.generateApi.copy(realm = realm.id)
 
     val rawPassword = "some-password"
     val salt = Generators.generateString(withSize = secrets.client.saltSize)
@@ -287,7 +287,7 @@ class PkceAuthorizationCodeGrantSpec extends RouteTest with OAuthFixtures {
     val realm = Generators.generateRealm
     val owner = Generators.generateResourceOwner
     val code = Generators.generateAuthorizationCode
-    val api = Generators.generateApi
+    val api = Generators.generateApi.copy(realm = realm.id)
 
     val rawPassword = "some-password"
     val salt = Generators.generateString(withSize = secrets.client.saltSize)
@@ -335,7 +335,7 @@ class PkceAuthorizationCodeGrantSpec extends RouteTest with OAuthFixtures {
     val realm = Generators.generateRealm
     val owner = Generators.generateResourceOwner
     val code = Generators.generateAuthorizationCode
-    val api = Generators.generateApi
+    val api = Generators.generateApi.copy(realm = realm.id)
 
     val rawPassword = "some-password"
     val salt = Generators.generateString(withSize = secrets.client.saltSize)

--- a/identity/src/test/scala/stasis/test/specs/unit/identity/api/oauth/PkceAuthorizationCodeGrantSpec.scala
+++ b/identity/src/test/scala/stasis/test/specs/unit/identity/api/oauth/PkceAuthorizationCodeGrantSpec.scala
@@ -4,32 +4,35 @@ import akka.http.scaladsl.model
 import akka.http.scaladsl.model.headers.{BasicHttpCredentials, CacheDirectives}
 import akka.http.scaladsl.model.{ContentTypes, StatusCodes, Uri}
 import play.api.libs.json._
-import stasis.identity.api.oauth.AuthorizationCodeGrant
-import stasis.identity.api.oauth.AuthorizationCodeGrant._
+import stasis.identity.api.oauth.PkceAuthorizationCodeGrant
+import stasis.identity.api.oauth.PkceAuthorizationCodeGrant._
 import stasis.identity.model.clients.Client
 import stasis.identity.model.codes.{AuthorizationCode, StoredAuthorizationCode}
 import stasis.identity.model.secrets.Secret
 import stasis.identity.model.tokens.TokenType
-import stasis.identity.model.{GrantType, ResponseType}
+import stasis.identity.model.{ChallengeMethod, GrantType, ResponseType}
 import stasis.test.specs.unit.identity.RouteTest
 import stasis.test.specs.unit.identity.model.Generators
 
-class AuthorizationCodeGrantSpec extends RouteTest with OAuthFixtures {
+class PkceAuthorizationCodeGrantSpec extends RouteTest with OAuthFixtures {
   import de.heikoseeberger.akkahttpplayjson.PlayJsonSupport._
 
-  "AuthorizationCodeGrant routes" should "validate authorization requests content" in {
+  "PkceAuthorizationCodeGrant routes" should "validate authorization requests content" in {
     val request = AuthorizationRequest(
       response_type = ResponseType.Code,
       client_id = Client.generateId(),
       redirect_uri = Some("some-uri"),
       scope = Some("some-scope"),
-      state = "some-state"
+      state = "some-state",
+      code_challenge = "some-challenge",
+      code_challenge_method = None
     )
 
     an[IllegalArgumentException] should be thrownBy request.copy(response_type = ResponseType.Token)
     an[IllegalArgumentException] should be thrownBy request.copy(redirect_uri = Some(""))
     an[IllegalArgumentException] should be thrownBy request.copy(scope = Some(""))
     an[IllegalArgumentException] should be thrownBy request.copy(state = "")
+    an[IllegalArgumentException] should be thrownBy request.copy(code_challenge = "")
   }
 
   they should "validate access token requests content" in {
@@ -37,12 +40,14 @@ class AuthorizationCodeGrantSpec extends RouteTest with OAuthFixtures {
       grant_type = GrantType.AuthorizationCode,
       code = AuthorizationCode("some-code"),
       redirect_uri = Some("some-uri"),
-      client_id = Client.generateId()
+      client_id = Client.generateId(),
+      code_verifier = "some-verifier"
     )
 
     an[IllegalArgumentException] should be thrownBy request.copy(grant_type = GrantType.Implicit)
     an[IllegalArgumentException] should be thrownBy request.copy(code = AuthorizationCode(""))
     an[IllegalArgumentException] should be thrownBy request.copy(redirect_uri = Some(""))
+    an[IllegalArgumentException] should be thrownBy request.copy(code_verifier = "")
   }
 
   they should "represent authorization responses as URI query values" in {
@@ -67,7 +72,7 @@ class AuthorizationCodeGrantSpec extends RouteTest with OAuthFixtures {
 
   they should "generate authorization codes for valid requests" in {
     val (stores, secrets, providers) = createOAuthFixtures()
-    val grant = new AuthorizationCodeGrant(providers)
+    val grant = new PkceAuthorizationCodeGrant(providers)
 
     val realm = Generators.generateRealm
     val client = Generators.generateClient.copy(realm = realm.id)
@@ -87,7 +92,9 @@ class AuthorizationCodeGrantSpec extends RouteTest with OAuthFixtures {
       client_id = client.id,
       redirect_uri = Some(client.redirectUri),
       scope = grant.apiAudienceToScope(Seq(api)),
-      state = Generators.generateString(withSize = 16)
+      state = Generators.generateString(withSize = 16),
+      code_challenge = Generators.generateString(withSize = 128),
+      code_challenge_method = Some(ChallengeMethod.Plain)
     )
 
     stores.clients.put(client).await
@@ -97,7 +104,9 @@ class AuthorizationCodeGrantSpec extends RouteTest with OAuthFixtures {
       status should be(StatusCodes.Found)
       stores.codes.get(client.id).await match {
         case Some(storedCode) =>
-          storedCode.challenge should be(None)
+          storedCode.challenge should be(
+            Some(StoredAuthorizationCode.Challenge(request.code_challenge, request.code_challenge_method))
+          )
 
           headers should contain(
             model.headers.Location(
@@ -118,7 +127,7 @@ class AuthorizationCodeGrantSpec extends RouteTest with OAuthFixtures {
 
   they should "not generate authorization codes when invalid redirect URIs are provided" in {
     val (stores, secrets, providers) = createOAuthFixtures()
-    val grant = new AuthorizationCodeGrant(providers)
+    val grant = new PkceAuthorizationCodeGrant(providers)
 
     val realm = Generators.generateRealm
     val client = Generators.generateClient.copy(realm = realm.id)
@@ -138,7 +147,9 @@ class AuthorizationCodeGrantSpec extends RouteTest with OAuthFixtures {
       client_id = client.id,
       redirect_uri = Some("some-uri"),
       scope = grant.apiAudienceToScope(Seq(api)),
-      state = Generators.generateString(withSize = 16)
+      state = Generators.generateString(withSize = 16),
+      code_challenge = Generators.generateString(withSize = 128),
+      code_challenge_method = None
     )
 
     stores.clients.put(client).await
@@ -155,7 +166,7 @@ class AuthorizationCodeGrantSpec extends RouteTest with OAuthFixtures {
 
   they should "generate access and refresh tokens for valid authorization codes" in {
     val (stores, secrets, providers) = createOAuthFixtures()
-    val grant = new AuthorizationCodeGrant(providers)
+    val grant = new PkceAuthorizationCodeGrant(providers)
 
     val realm = Generators.generateRealm
     val owner = Generators.generateResourceOwner
@@ -171,17 +182,30 @@ class AuthorizationCodeGrantSpec extends RouteTest with OAuthFixtures {
     )
     val credentials = BasicHttpCredentials(client.id.toString, rawPassword)
 
+    val challenge = StoredAuthorizationCode.Challenge(
+      value = Generators.generateString(withSize = 128),
+      method = Some(ChallengeMethod.Plain)
+    )
+
+    val storedCode = StoredAuthorizationCode(
+      code = code,
+      owner = owner,
+      scope = grant.apiAudienceToScope(Seq(api)),
+      challenge = Some(challenge)
+    )
+
     val request = AccessTokenRequest(
       grant_type = GrantType.AuthorizationCode,
       code = code,
       redirect_uri = Some(client.redirectUri),
-      client_id = client.id
+      client_id = client.id,
+      code_verifier = challenge.value
     )
 
     stores.clients.put(client).await
     stores.owners.put(owner).await
     stores.apis.put(api).await
-    stores.codes.put(client.id, StoredAuthorizationCode(code, owner, scope = grant.apiAudienceToScope(Seq(api)))).await
+    stores.codes.put(client.id, storedCode).await
     Post(request).addCredentials(credentials) ~> grant.token(realm) ~> check {
       status should be(StatusCodes.OK)
       headers should contain(model.headers.`Content-Type`(ContentTypes.`application/json`))
@@ -200,7 +224,7 @@ class AuthorizationCodeGrantSpec extends RouteTest with OAuthFixtures {
 
   they should "generate only access tokens when refresh tokens are not allowed" in {
     val (stores, secrets, providers) = createOAuthFixtures()
-    val grant = new AuthorizationCodeGrant(providers)
+    val grant = new PkceAuthorizationCodeGrant(providers)
 
     val realm = Generators.generateRealm.copy(refreshTokensAllowed = false)
     val owner = Generators.generateResourceOwner
@@ -216,17 +240,30 @@ class AuthorizationCodeGrantSpec extends RouteTest with OAuthFixtures {
     )
     val credentials = BasicHttpCredentials(client.id.toString, rawPassword)
 
+    val challenge = StoredAuthorizationCode.Challenge(
+      value = Generators.generateString(withSize = 128),
+      method = Some(ChallengeMethod.Plain)
+    )
+
+    val storedCode = StoredAuthorizationCode(
+      code = code,
+      owner = owner,
+      scope = grant.apiAudienceToScope(Seq(api)),
+      challenge = Some(challenge)
+    )
+
     val request = AccessTokenRequest(
       grant_type = GrantType.AuthorizationCode,
       code = code,
       redirect_uri = Some(client.redirectUri),
-      client_id = client.id
+      client_id = client.id,
+      code_verifier = challenge.value
     )
 
     stores.clients.put(client).await
     stores.owners.put(owner).await
     stores.apis.put(api).await
-    stores.codes.put(client.id, StoredAuthorizationCode(code, owner, scope = grant.apiAudienceToScope(Seq(api)))).await
+    stores.codes.put(client.id, storedCode).await
     Post(request).addCredentials(credentials) ~> grant.token(realm) ~> check {
       status should be(StatusCodes.OK)
       headers should contain(model.headers.`Content-Type`(ContentTypes.`application/json`))
@@ -245,7 +282,7 @@ class AuthorizationCodeGrantSpec extends RouteTest with OAuthFixtures {
 
   they should "not generate access or refresh tokens when invalid redirect URIs are provided" in {
     val (stores, secrets, providers) = createOAuthFixtures()
-    val grant = new AuthorizationCodeGrant(providers)
+    val grant = new PkceAuthorizationCodeGrant(providers)
 
     val realm = Generators.generateRealm
     val owner = Generators.generateResourceOwner
@@ -261,20 +298,81 @@ class AuthorizationCodeGrantSpec extends RouteTest with OAuthFixtures {
     )
     val credentials = BasicHttpCredentials(client.id.toString, rawPassword)
 
+    val challenge = StoredAuthorizationCode.Challenge(
+      value = Generators.generateString(withSize = 128),
+      method = Some(ChallengeMethod.Plain)
+    )
+
+    val storedCode = StoredAuthorizationCode(
+      code = code,
+      owner = owner,
+      scope = grant.apiAudienceToScope(Seq(api)),
+      challenge = Some(challenge)
+    )
+
     val request = AccessTokenRequest(
       grant_type = GrantType.AuthorizationCode,
       code = code,
       redirect_uri = Some("some-uri"),
-      client_id = client.id
+      client_id = client.id,
+      code_verifier = challenge.value
     )
 
     stores.clients.put(client).await
     stores.owners.put(owner).await
     stores.apis.put(api).await
-    stores.codes.put(client.id, StoredAuthorizationCode(code, owner, scope = grant.apiAudienceToScope(Seq(api)))).await
+    stores.codes.put(client.id, storedCode).await
     Post(request).addCredentials(credentials) ~> grant.token(realm) ~> check {
       status should be(StatusCodes.BadRequest)
       responseAs[JsObject].fields should contain("error" -> JsString("invalid_request"))
+    }
+  }
+
+  they should "not generate access or refresh tokens when invalid code verifiers are provided" in {
+    val (stores, secrets, providers) = createOAuthFixtures()
+    val grant = new PkceAuthorizationCodeGrant(providers)
+
+    val realm = Generators.generateRealm
+    val owner = Generators.generateResourceOwner
+    val code = Generators.generateAuthorizationCode
+    val api = Generators.generateApi
+
+    val rawPassword = "some-password"
+    val salt = Generators.generateString(withSize = secrets.client.saltSize)
+    val client = Generators.generateClient.copy(
+      realm = realm.id,
+      secret = Secret.derive(rawPassword, salt)(secrets.client),
+      salt = salt
+    )
+    val credentials = BasicHttpCredentials(client.id.toString, rawPassword)
+
+    val challenge = StoredAuthorizationCode.Challenge(
+      value = Generators.generateString(withSize = 128),
+      method = Some(ChallengeMethod.Plain)
+    )
+
+    val storedCode = StoredAuthorizationCode(
+      code = code,
+      owner = owner,
+      scope = grant.apiAudienceToScope(Seq(api)),
+      challenge = Some(challenge)
+    )
+
+    val request = AccessTokenRequest(
+      grant_type = GrantType.AuthorizationCode,
+      code = code,
+      redirect_uri = Some(client.redirectUri),
+      client_id = client.id,
+      code_verifier = Generators.generateString(withSize = 128)
+    )
+
+    stores.clients.put(client).await
+    stores.owners.put(owner).await
+    stores.apis.put(api).await
+    stores.codes.put(client.id, storedCode).await
+    Post(request).addCredentials(credentials) ~> grant.token(realm) ~> check {
+      status should be(StatusCodes.BadRequest)
+      responseAs[JsObject].fields should contain("error" -> JsString("invalid_grant"))
     }
   }
 
@@ -287,7 +385,9 @@ class AuthorizationCodeGrantSpec extends RouteTest with OAuthFixtures {
         s"&client_id=${request.client_id}" +
         s"&redirect_uri=${request.redirect_uri.getOrElse("")}" +
         s"&scope=${request.scope.getOrElse("")}" +
-        s"&state=${request.state}"
+        s"&state=${request.state}" +
+        s"&code_challenge=${request.code_challenge}" +
+        request.code_challenge_method.map(m => s"&code_challenge_method=$m").getOrElse("")
     )
 
   implicit def accessTokenRequestToLocalUri(request: AccessTokenRequest): Uri =
@@ -296,6 +396,7 @@ class AuthorizationCodeGrantSpec extends RouteTest with OAuthFixtures {
         s"?grant_type=authorization_code" +
         s"&code=${request.code.value}" +
         s"&redirect_uri=${request.redirect_uri.getOrElse("")}" +
-        s"&client_id=${request.client_id}"
+        s"&client_id=${request.client_id}" +
+        s"&code_verifier=${request.code_verifier}"
     )
 }

--- a/identity/src/test/scala/stasis/test/specs/unit/identity/api/oauth/RefreshTokenGrantSpec.scala
+++ b/identity/src/test/scala/stasis/test/specs/unit/identity/api/oauth/RefreshTokenGrantSpec.scala
@@ -32,7 +32,7 @@ class RefreshTokenGrantSpec extends RouteTest with OAuthFixtures {
 
     val realm = Generators.generateRealm
     val owner = Generators.generateResourceOwner.copy(realm = realm.id)
-    val api = Generators.generateApi
+    val api = Generators.generateApi.copy(realm = realm.id)
 
     val rawPassword = "some-password"
     val salt = Generators.generateString(withSize = secrets.client.saltSize)
@@ -79,7 +79,7 @@ class RefreshTokenGrantSpec extends RouteTest with OAuthFixtures {
 
     val realm = Generators.generateRealm.copy(refreshTokensAllowed = false)
     val owner = Generators.generateResourceOwner.copy(realm = realm.id)
-    val api = Generators.generateApi
+    val api = Generators.generateApi.copy(realm = realm.id)
 
     val rawPassword = "some-password"
     val salt = Generators.generateString(withSize = secrets.client.saltSize)

--- a/identity/src/test/scala/stasis/test/specs/unit/identity/api/oauth/ResourceOwnerPasswordCredentialsGrantSpec.scala
+++ b/identity/src/test/scala/stasis/test/specs/unit/identity/api/oauth/ResourceOwnerPasswordCredentialsGrantSpec.scala
@@ -33,7 +33,7 @@ class ResourceOwnerPasswordCredentialsGrantSpec extends RouteTest with OAuthFixt
     val grant = new ResourceOwnerPasswordCredentialsGrant(providers)
 
     val realm = Generators.generateRealm
-    val api = Generators.generateApi
+    val api = Generators.generateApi.copy(realm = realm.id)
 
     val clientRawPassword = "some-password"
     val clientSalt = Generators.generateString(withSize = secrets.client.saltSize)
@@ -85,7 +85,7 @@ class ResourceOwnerPasswordCredentialsGrantSpec extends RouteTest with OAuthFixt
     val grant = new ResourceOwnerPasswordCredentialsGrant(providers)
 
     val realm = Generators.generateRealm.copy(refreshTokensAllowed = false)
-    val api = Generators.generateApi
+    val api = Generators.generateApi.copy(realm = realm.id)
 
     val clientRawPassword = "some-password"
     val clientSalt = Generators.generateString(withSize = secrets.client.saltSize)

--- a/identity/src/test/scala/stasis/test/specs/unit/identity/api/oauth/directives/AudienceExtractionSpec.scala
+++ b/identity/src/test/scala/stasis/test/specs/unit/identity/api/oauth/directives/AudienceExtractionSpec.scala
@@ -94,11 +94,12 @@ class AudienceExtractionSpec extends RouteTest {
     val clientStore = createClientStore()
     val apiStore = createApiStore()
     val directive = createDirective(clients = clientStore, apis = apiStore)
+    val realm = Generators.generateRealmId
 
-    val apis = Generators.generateSeq(min = 1, g = Generators.generateApi)
+    val apis = Generators.generateSeq(min = 1, g = Generators.generateApi.copy(realm = realm))
     val scope = directive.apiAudienceToScope(apis)
 
-    val routes = directive.extractApiAudience(scopeOpt = scope) { apis =>
+    val routes = directive.extractApiAudience(realm, scopeOpt = scope) { apis =>
       Directives.complete(StatusCodes.OK, apis.map(_.id).mkString(","))
     }
 

--- a/identity/src/test/scala/stasis/test/specs/unit/identity/model/codes/AuthorizationCodeStoreSpec.scala
+++ b/identity/src/test/scala/stasis/test/specs/unit/identity/model/codes/AuthorizationCodeStoreSpec.scala
@@ -22,7 +22,7 @@ class AuthorizationCodeStoreSpec extends AsyncUnitSpec {
     val expectedStoredCode = StoredAuthorizationCode(expectedCode, owner, scope = None)
 
     for {
-      _ <- store.put(client, expectedCode, owner, scope = None)
+      _ <- store.put(client, StoredAuthorizationCode(expectedCode, owner, scope = None))
       actualCode <- store.get(client)
       someCodes <- store.codes
       _ <- store.delete(client)
@@ -46,7 +46,7 @@ class AuthorizationCodeStoreSpec extends AsyncUnitSpec {
     val expectedStoredCode = StoredAuthorizationCode(expectedCode, owner, scope = None)
 
     for {
-      _ <- store.put(client, expectedCode, owner, scope = None)
+      _ <- store.put(client, StoredAuthorizationCode(expectedCode, owner, scope = None))
       actualCode <- store.get(client)
       someCodes <- store.codes
       _ <- akka.pattern.after(expiration * 2, using = system.scheduler)(Future.successful(Done))


### PR DESCRIPTION
- `identity` Added PKCE authorization code grant
- `identity` Updated APIs to be unique per realm instead of globally unique
- `identity` Updated to always discard unconsumed entities