### PR TITLE
Add service discovery

### DIFF
--- a/client-android/app/src/main/java/stasis/client_android/api/clients/MockServiceDiscoveryClient.kt
+++ b/client-android/app/src/main/java/stasis/client_android/api/clients/MockServiceDiscoveryClient.kt
@@ -1,0 +1,21 @@
+package stasis.client_android.api.clients
+
+import stasis.client_android.lib.discovery.ServiceDiscoveryClient
+import stasis.client_android.lib.discovery.ServiceDiscoveryRequest
+import stasis.client_android.lib.discovery.ServiceDiscoveryResult
+import stasis.client_android.lib.utils.Try
+import stasis.client_android.lib.utils.Try.Success
+
+class MockServiceDiscoveryClient : ServiceDiscoveryClient {
+    override val attributes: ServiceDiscoveryClient.Attributes =
+        object : ServiceDiscoveryClient.Attributes {
+            override fun asServiceDiscoveryRequest(isInitialRequest: Boolean): ServiceDiscoveryRequest =
+                ServiceDiscoveryRequest(
+                    isInitialRequest = isInitialRequest,
+                    attributes = emptyMap()
+                )
+        }
+
+    override suspend fun latest(isInitialRequest: Boolean): Try<ServiceDiscoveryResult> =
+        Success(ServiceDiscoveryResult.KeepExisting)
+}

--- a/client-android/app/src/main/java/stasis/client_android/settings/Settings.kt
+++ b/client-android/app/src/main/java/stasis/client_android/settings/Settings.kt
@@ -30,6 +30,11 @@ object Settings {
             ?: Defaults.CommandRefreshInterval
     }
 
+    fun SharedPreferences.getDiscoveryInterval(): Duration {
+        return getString(Keys.DiscoveryInterval, null)?.toLongOrNull()?.let { Duration.ofSeconds(it) }
+            ?: Defaults.DiscoveryInterval
+    }
+
     fun parseDateTimeFormat(format: String): DateTimeFormat =
         when (format) {
             "system" -> DateTimeFormat.System
@@ -70,6 +75,7 @@ object Settings {
         const val SchedulingEnabled: String = "scheduling_enabled"
         const val PingInterval: String = "ping_interval"
         const val CommandRefreshInterval: String = "command_refresh_interval"
+        const val DiscoveryInterval: String = "discovery_interval"
         const val ShowCommands: String = "show_commands"
         const val ResetConfig: String = "reset_config"
     }
@@ -80,10 +86,11 @@ object Settings {
         const val SchedulingEnabled: Boolean = true
         val PingInterval: Duration = Duration.ofMinutes(3)
         val CommandRefreshInterval: Duration = Duration.ofMinutes(5)
+        val DiscoveryInterval: Duration = Duration.ofMinutes(30)
     }
 
     sealed class DateTimeFormat {
-        object System : DateTimeFormat()
-        object Iso : DateTimeFormat()
+        data object System : DateTimeFormat()
+        data object Iso : DateTimeFormat()
     }
 }

--- a/client-android/app/src/main/res/values/arrays.xml
+++ b/client-android/app/src/main/res/values/arrays.xml
@@ -34,4 +34,21 @@
         <item>600</item>
         <item>1800</item>
     </string-array>
+
+    <string-array name="settings_discovery_interval_entries">
+        <item>5 minutes</item>
+        <item>15 minutes</item>
+        <item>30 minutes</item>
+        <item>1 hour</item>
+        <item>3 hours</item>
+        <item>6 hours</item>
+    </string-array>
+    <string-array name="settings_discovery_interval_values">
+        <item>300</item>
+        <item>900</item>
+        <item>1800</item>
+        <item>3600</item>
+        <item>10800</item>
+        <item>21600</item>
+    </string-array>
 </resources>

--- a/client-android/app/src/main/res/values/strings.xml
+++ b/client-android/app/src/main/res/values/strings.xml
@@ -675,6 +675,7 @@
     <string name="settings_date_time_format_hint">Show dates as %1$s and time as %2$s</string>
     <string name="settings_ping_interval_hint">The client will contact the server every %1$s</string>
     <string name="settings_command_refresh_interval_hint">The client will query the server for new commands every %1$s</string>
+    <string name="settings_discovery_interval_hint">The client will query the server for new API endpoints every %1$s</string>
     <string name="settings_manage_user_credentials_update_password_title">Update password</string>
     <string name="settings_manage_user_credentials_update_password_summary">Allows updating the password for the current user</string>
     <string name="settings_manage_user_credentials_update_salt_title">Update salt value</string>
@@ -778,6 +779,7 @@
     <string name="settings_commands_error">Command retrieval failed with: %1$s</string>
     <string name="settings_command_parameters_title">[%1$s] %2$s</string>
     <string name="settings_command_parameters_info">%1$s</string>
+    <string name="settings_discovery_interval_title">Server discovery interval</string>
     <string name="settings_reset_config_title">Reset configuration</string>
     <string name="settings_reset_config_summary">Clears the client\'s configuration and device secret</string>
     <string name="settings_reset_config_confirm_title">Clear all configuration and log out?</string>

--- a/client-android/app/src/main/res/xml/preferences.xml
+++ b/client-android/app/src/main/res/xml/preferences.xml
@@ -73,6 +73,12 @@
             app:key="command_refresh_interval"
             app:title="@string/settings_command_refresh_interval_title" />
 
+        <DropDownPreference
+            app:entries="@array/settings_discovery_interval_entries"
+            app:entryValues="@array/settings_discovery_interval_values"
+            app:key="discovery_interval"
+            app:title="@string/settings_discovery_interval_title" />
+
         <Preference
             app:key="reset_config"
             app:summary="@string/settings_reset_config_summary"

--- a/client-android/app/src/test/java/stasis/test/client_android/settings/SettingsSpec.kt
+++ b/client-android/app/src/test/java/stasis/test/client_android/settings/SettingsSpec.kt
@@ -13,6 +13,7 @@ import org.robolectric.annotation.Config
 import stasis.client_android.settings.Settings
 import stasis.client_android.settings.Settings.getCommandRefreshInterval
 import stasis.client_android.settings.Settings.getDateTimeFormat
+import stasis.client_android.settings.Settings.getDiscoveryInterval
 import stasis.client_android.settings.Settings.getPingInterval
 import stasis.client_android.settings.Settings.getRestrictionsIgnored
 import stasis.client_android.settings.Settings.getSchedulingEnabled
@@ -191,6 +192,20 @@ class SettingsSpec {
     }
 
     @Test
+    fun supportRetrievingDefaultDiscoveryInterval() {
+        val preferences = mockk<SharedPreferences>()
+        every {
+            preferences.getString(
+                Settings.Keys.DiscoveryInterval,
+                null
+            )
+        } returns "1800"
+
+        val expectedState = Settings.Defaults.DiscoveryInterval
+        assertThat(preferences.getDiscoveryInterval(), equalTo(expectedState))
+    }
+
+    @Test
     fun supportRetrievingUserDefinedPingInterval() {
         val preferences = mockk<SharedPreferences>()
         every {
@@ -216,5 +231,19 @@ class SettingsSpec {
 
         val expectedState = Duration.ofSeconds(10)
         assertThat(preferences.getCommandRefreshInterval(), equalTo(expectedState))
+    }
+
+    @Test
+    fun supportRetrievingUserDefinedDiscoveryInterval() {
+        val preferences = mockk<SharedPreferences>()
+        every {
+            preferences.getString(
+                Settings.Keys.DiscoveryInterval,
+                null
+            )
+        } returns "1234"
+
+        val expectedState = Duration.ofSeconds(1234)
+        assertThat(preferences.getDiscoveryInterval(), equalTo(expectedState))
     }
 }

--- a/client-android/lib/src/main/kotlin/stasis/client_android/lib/api/clients/Clients.kt
+++ b/client-android/lib/src/main/kotlin/stasis/client_android/lib/api/clients/Clients.kt
@@ -1,6 +1,43 @@
 package stasis.client_android.lib.api.clients
 
-data class Clients(
-    val api: ServerApiEndpointClient,
+import stasis.client_android.lib.discovery.exceptions.DiscoveryFailure
+import stasis.client_android.lib.discovery.providers.client.ServiceDiscoveryProvider
+import stasis.client_android.lib.utils.Try
+import stasis.client_android.lib.utils.Try.Failure
+import java.util.concurrent.atomic.AtomicReference
+
+sealed interface Clients {
+    val api: ServerApiEndpointClient
     val core: ServerCoreEndpointClient
-)
+
+    fun withDiscovery(discovery: Try<ServiceDiscoveryProvider>)
+
+    data class Static(
+        override val api: ServerApiEndpointClient,
+        override val core: ServerCoreEndpointClient
+    ) : Clients {
+        override fun withDiscovery(discovery: Try<ServiceDiscoveryProvider>) = Unit // do nothing
+    }
+
+    class Discovered : Clients {
+        private val discoveryRef: AtomicReference<Try<ServiceDiscoveryProvider>> =
+            AtomicReference(Failure(DiscoveryFailure("No discovery provider found")))
+
+        override val api: ServerApiEndpointClient
+            get() = discoveryRef.get().get().latest(ServerApiEndpointClient::class.java)
+
+        override val core: ServerCoreEndpointClient
+            get() = discoveryRef.get().get().latest(ServerCoreEndpointClient::class.java)
+
+        override fun withDiscovery(discovery: Try<ServiceDiscoveryProvider>) =
+            discoveryRef.set(discovery)
+    }
+
+    companion object {
+        operator fun invoke(api: ServerApiEndpointClient, core: ServerCoreEndpointClient): Clients =
+            Static(api = api, core = core)
+
+        fun discovered(): Clients =
+            Discovered()
+    }
+}

--- a/client-android/lib/src/main/kotlin/stasis/client_android/lib/api/clients/ServerApiEndpointClient.kt
+++ b/client-android/lib/src/main/kotlin/stasis/client_android/lib/api/clients/ServerApiEndpointClient.kt
@@ -1,6 +1,7 @@
 package stasis.client_android.lib.api.clients
 
 import okio.ByteString
+import stasis.client_android.lib.discovery.ServiceApiClient
 import stasis.client_android.lib.model.DatasetMetadata
 import stasis.client_android.lib.model.server.api.requests.CreateDatasetDefinition
 import stasis.client_android.lib.model.server.api.requests.CreateDatasetEntry
@@ -24,7 +25,7 @@ import stasis.core.commands.proto.Command
 import java.time.Instant
 
 @Suppress("TooManyFunctions")
-interface ServerApiEndpointClient {
+interface ServerApiEndpointClient : ServiceApiClient {
     val self: DeviceId
     val server: String
 

--- a/client-android/lib/src/main/kotlin/stasis/client_android/lib/api/clients/ServerCoreEndpointClient.kt
+++ b/client-android/lib/src/main/kotlin/stasis/client_android/lib/api/clients/ServerCoreEndpointClient.kt
@@ -1,11 +1,12 @@
 package stasis.client_android.lib.api.clients
 
 import okio.Source
+import stasis.client_android.lib.discovery.ServiceApiClient
 import stasis.client_android.lib.model.core.CrateId
 import stasis.client_android.lib.model.core.Manifest
 import stasis.client_android.lib.model.core.NodeId
 
-interface ServerCoreEndpointClient {
+interface ServerCoreEndpointClient : ServiceApiClient {
     val self: NodeId
     val server: String
 

--- a/client-android/lib/src/main/kotlin/stasis/client_android/lib/api/clients/ServiceApiClientFactory.kt
+++ b/client-android/lib/src/main/kotlin/stasis/client_android/lib/api/clients/ServiceApiClientFactory.kt
@@ -1,0 +1,34 @@
+package stasis.client_android.lib.api.clients
+
+import stasis.client_android.lib.discovery.ServiceApiClient
+import stasis.client_android.lib.discovery.ServiceApiEndpoint
+import stasis.client_android.lib.discovery.ServiceDiscoveryClient
+import stasis.client_android.lib.model.core.networking.EndpointAddress
+
+class ServiceApiClientFactory(
+    private val createServerCoreEndpointClient: (String) -> ServerCoreEndpointClient,
+    private val createServerApiEndpointClient: (String, ServerCoreEndpointClient) -> ServerApiEndpointClient,
+    private val createServiceDiscoveryClient: (String) -> ServiceDiscoveryClient
+) : ServiceApiClient.Factory {
+    override fun create(endpoint: ServiceApiEndpoint.Api, coreClient: ServiceApiClient): ServiceApiClient =
+        createServerApiEndpointClient(
+            endpoint.uri,
+            when (coreClient) {
+                is ServerCoreEndpointClient -> coreClient
+                else -> throw IllegalArgumentException(
+                    "Cannot create API endpoint client with core client of type [${coreClient.javaClass.simpleName}]"
+                )
+            }
+        )
+
+    override fun create(endpoint: ServiceApiEndpoint.Core): ServiceApiClient =
+        when (val address = endpoint.address) {
+            is EndpointAddress.HttpEndpointAddress -> createServerCoreEndpointClient(address.uri)
+            else -> throw IllegalArgumentException(
+                "Cannot create core endpoint client for address of type [${address.javaClass.simpleName}]"
+            )
+        }
+
+    override fun create(endpoint: ServiceApiEndpoint.Discovery): ServiceApiClient =
+        createServiceDiscoveryClient(endpoint.uri)
+}

--- a/client-android/lib/src/main/kotlin/stasis/client_android/lib/api/clients/internal/ClientExtensions.kt
+++ b/client-android/lib/src/main/kotlin/stasis/client_android/lib/api/clients/internal/ClientExtensions.kt
@@ -41,6 +41,8 @@ abstract class ClientExtensions {
         .add(Adapters.ForBigInteger)
         .add(Adapters.ForDatasetDefinitionRetentionPolicy)
         .add(Adapters.ForCommandParametersAsJson)
+        .add(Adapters.ForServiceDiscoveryResult)
+        .add(Adapters.ForEndpointAddress)
         .add(KotlinJsonAdapterFactory())
         .build()
 

--- a/client-android/lib/src/main/kotlin/stasis/client_android/lib/collection/DefaultBackupCollector.kt
+++ b/client-android/lib/src/main/kotlin/stasis/client_android/lib/collection/DefaultBackupCollector.kt
@@ -3,7 +3,7 @@ package stasis.client_android.lib.collection
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.asFlow
 import kotlinx.coroutines.flow.map
-import stasis.client_android.lib.api.clients.ServerApiEndpointClient
+import stasis.client_android.lib.api.clients.Clients
 import stasis.client_android.lib.model.DatasetMetadata
 import stasis.client_android.lib.model.EntityMetadata
 import stasis.client_android.lib.model.SourceEntity
@@ -13,13 +13,13 @@ class DefaultBackupCollector(
     private val entities: List<Path>,
     private val latestMetadata: DatasetMetadata?,
     private val metadataCollector: BackupMetadataCollector,
-    private val api: ServerApiEndpointClient
+    private val clients: Clients
 ) : BackupCollector {
     override fun collect(): Flow<SourceEntity> =
         collectEntityMetadata(
             entities = entities,
             latestMetadata = latestMetadata,
-            api = api
+            clients = clients
         ).map { (entity, entityMetadata) ->
             metadataCollector.collect(entity = entity, existingMetadata = entityMetadata)
         }
@@ -29,11 +29,11 @@ class DefaultBackupCollector(
         fun collectEntityMetadata(
             entities: List<Path>,
             latestMetadata: DatasetMetadata?,
-            api: ServerApiEndpointClient
+            clients: Clients
         ): Flow<Pair<Path, EntityMetadata?>> =
             when (latestMetadata) {
                 null -> entities.asFlow().map { entity -> entity to null }
-                else -> entities.asFlow().map { entity -> entity to latestMetadata.collect(entity, api) }
+                else -> entities.asFlow().map { entity -> entity to latestMetadata.collect(entity, clients) }
             }
     }
 }

--- a/client-android/lib/src/main/kotlin/stasis/client_android/lib/collection/DefaultRecoveryCollector.kt
+++ b/client-android/lib/src/main/kotlin/stasis/client_android/lib/collection/DefaultRecoveryCollector.kt
@@ -4,7 +4,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.asFlow
 import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.flow
-import stasis.client_android.lib.api.clients.ServerApiEndpointClient
+import stasis.client_android.lib.api.clients.Clients
 import stasis.client_android.lib.model.DatasetMetadata
 import stasis.client_android.lib.model.EntityMetadata
 import stasis.client_android.lib.model.FilesystemMetadata
@@ -16,11 +16,11 @@ class DefaultRecoveryCollector(
     private val keep: (Path, FilesystemMetadata.EntityState) -> Boolean,
     private val destination: TargetEntity.Destination,
     private val metadataCollector: RecoveryMetadataCollector,
-    private val api: ServerApiEndpointClient
+    private val clients: Clients
 ) : RecoveryCollector {
     override fun collect(): Flow<TargetEntity> = flow {
         emitAll(
-            collectEntityMetadata(targetMetadata, keep, api).map { entityMetadata ->
+            collectEntityMetadata(targetMetadata, keep, clients).map { entityMetadata ->
                 metadataCollector.collect(
                     entity = entityMetadata.path,
                     destination = destination,
@@ -34,10 +34,10 @@ class DefaultRecoveryCollector(
         suspend fun collectEntityMetadata(
             targetMetadata: DatasetMetadata,
             keep: (Path, FilesystemMetadata.EntityState) -> Boolean,
-            api: ServerApiEndpointClient
+            clients: Clients
         ): List<EntityMetadata> =
             targetMetadata.filesystem.entities.toList()
                 .filter { (entity, state) -> keep(entity, state) }
-                .map { (entity, _) -> targetMetadata.require(entity = entity, api = api) }
+                .map { (entity, _) -> targetMetadata.require(entity = entity, clients = clients) }
     }
 }

--- a/client-android/lib/src/main/kotlin/stasis/client_android/lib/discovery/ClientDiscoveryAttributes.kt
+++ b/client-android/lib/src/main/kotlin/stasis/client_android/lib/discovery/ClientDiscoveryAttributes.kt
@@ -1,0 +1,21 @@
+package stasis.client_android.lib.discovery
+
+import stasis.client_android.lib.model.core.NodeId
+import stasis.client_android.lib.model.server.devices.DeviceId
+import stasis.client_android.lib.model.server.users.UserId
+
+data class ClientDiscoveryAttributes(
+    val user: UserId,
+    val device: DeviceId,
+    val node: NodeId
+) : ServiceDiscoveryClient.Attributes {
+    override fun asServiceDiscoveryRequest(isInitialRequest: Boolean): ServiceDiscoveryRequest =
+        ServiceDiscoveryRequest(
+            isInitialRequest = isInitialRequest,
+            attributes = mapOf(
+                "user" to user.toString(),
+                "device" to device.toString(),
+                "node" to node.toString()
+            )
+        )
+}

--- a/client-android/lib/src/main/kotlin/stasis/client_android/lib/discovery/ServiceApiClient.kt
+++ b/client-android/lib/src/main/kotlin/stasis/client_android/lib/discovery/ServiceApiClient.kt
@@ -1,0 +1,9 @@
+package stasis.client_android.lib.discovery
+
+interface ServiceApiClient {
+    interface Factory {
+        fun create(endpoint: ServiceApiEndpoint.Api, coreClient: ServiceApiClient): ServiceApiClient
+        fun create(endpoint: ServiceApiEndpoint.Core): ServiceApiClient
+        fun create(endpoint: ServiceApiEndpoint.Discovery): ServiceApiClient
+    }
+}

--- a/client-android/lib/src/main/kotlin/stasis/client_android/lib/discovery/ServiceApiEndpoint.kt
+++ b/client-android/lib/src/main/kotlin/stasis/client_android/lib/discovery/ServiceApiEndpoint.kt
@@ -1,0 +1,25 @@
+package stasis.client_android.lib.discovery
+
+import stasis.client_android.lib.model.core.networking.EndpointAddress
+
+sealed class ServiceApiEndpoint {
+    abstract val id: String
+
+    data class Api(val uri: String) : ServiceApiEndpoint() {
+        override val id: String by lazy { "api__$uri" }
+    }
+
+    data class Core(val address: EndpointAddress) : ServiceApiEndpoint() {
+        override val id: String by lazy {
+            when (address) {
+                is EndpointAddress.HttpEndpointAddress -> "core_http__${address.uri}"
+                is EndpointAddress.GrpcEndpointAddress -> "core_grpc__${address.host}:${address.port}"
+            }
+        }
+
+    }
+
+    data class Discovery(val uri: String) : ServiceApiEndpoint() {
+        override val id: String by lazy { "discovery__$uri" }
+    }
+}

--- a/client-android/lib/src/main/kotlin/stasis/client_android/lib/discovery/ServiceDiscoveryClient.kt
+++ b/client-android/lib/src/main/kotlin/stasis/client_android/lib/discovery/ServiceDiscoveryClient.kt
@@ -1,0 +1,13 @@
+package stasis.client_android.lib.discovery
+
+import stasis.client_android.lib.utils.Try
+
+interface ServiceDiscoveryClient : ServiceApiClient {
+    val attributes: Attributes
+
+    suspend fun latest(isInitialRequest: Boolean): Try<ServiceDiscoveryResult>
+
+    interface Attributes {
+        fun asServiceDiscoveryRequest(isInitialRequest: Boolean): ServiceDiscoveryRequest
+    }
+}

--- a/client-android/lib/src/main/kotlin/stasis/client_android/lib/discovery/ServiceDiscoveryRequest.kt
+++ b/client-android/lib/src/main/kotlin/stasis/client_android/lib/discovery/ServiceDiscoveryRequest.kt
@@ -1,0 +1,17 @@
+package stasis.client_android.lib.discovery
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
+data class ServiceDiscoveryRequest(
+    @Json(name = "is_initial_request")
+    val isInitialRequest: Boolean,
+    val attributes: Map<String, String>
+) {
+    val id: String by lazy {
+        attributes.toList()
+            .sortedBy { it.first }
+            .joinToString(separator = "::") { (k, v) -> "$k=$v" }
+    }
+}

--- a/client-android/lib/src/main/kotlin/stasis/client_android/lib/discovery/ServiceDiscoveryResult.kt
+++ b/client-android/lib/src/main/kotlin/stasis/client_android/lib/discovery/ServiceDiscoveryResult.kt
@@ -1,0 +1,28 @@
+package stasis.client_android.lib.discovery
+
+sealed class ServiceDiscoveryResult {
+    abstract val asString: String
+
+    data object KeepExisting : ServiceDiscoveryResult() {
+        override val asString: String = "result=keep-existing"
+    }
+
+    data class SwitchTo(
+        val endpoints: Endpoints,
+        val recreateExisting: Boolean
+    ) : ServiceDiscoveryResult() {
+        override val asString: String by lazy {
+            "result=switch-to,endpoints=${endpoints.asString},recreate-existing=$recreateExisting"
+        }
+    }
+
+    data class Endpoints(
+        val api: ServiceApiEndpoint.Api,
+        val core: ServiceApiEndpoint.Core,
+        val discovery: ServiceApiEndpoint.Discovery
+    ) {
+        val asString: String by lazy {
+            listOf(api.id, core.id, discovery.id).joinToString(separator = ";")
+        }
+    }
+}

--- a/client-android/lib/src/main/kotlin/stasis/client_android/lib/discovery/exceptions/DiscoveryFailure.kt
+++ b/client-android/lib/src/main/kotlin/stasis/client_android/lib/discovery/exceptions/DiscoveryFailure.kt
@@ -1,0 +1,3 @@
+package stasis.client_android.lib.discovery.exceptions
+
+class DiscoveryFailure(message: String) : Exception(message)

--- a/client-android/lib/src/main/kotlin/stasis/client_android/lib/discovery/http/HttpServiceDiscoveryClient.kt
+++ b/client-android/lib/src/main/kotlin/stasis/client_android/lib/discovery/http/HttpServiceDiscoveryClient.kt
@@ -1,0 +1,25 @@
+package stasis.client_android.lib.discovery.http
+
+import stasis.client_android.lib.api.clients.internal.ClientExtensions
+import stasis.client_android.lib.discovery.ServiceDiscoveryClient
+import stasis.client_android.lib.discovery.ServiceDiscoveryResult
+import stasis.client_android.lib.security.HttpCredentials
+import stasis.client_android.lib.utils.AsyncOps
+import stasis.client_android.lib.utils.Try
+
+class HttpServiceDiscoveryClient(
+    apiUrl: String,
+    override val credentials: suspend () -> HttpCredentials,
+    override val attributes: ServiceDiscoveryClient.Attributes
+) : ServiceDiscoveryClient, ClientExtensions() {
+    override val retryConfig: AsyncOps.RetryConfig = AsyncOps.RetryConfig.Default
+
+    private val server: String = apiUrl.trimEnd { it == '/' }
+
+    override suspend fun latest(isInitialRequest: Boolean): Try<ServiceDiscoveryResult> =
+        jsonRequest<ServiceDiscoveryResult> { builder ->
+            builder
+                .url("$server/v1/discovery/provide")
+                .post(attributes.asServiceDiscoveryRequest(isInitialRequest).toBody())
+        }
+}

--- a/client-android/lib/src/main/kotlin/stasis/client_android/lib/discovery/providers/client/ServiceDiscoveryProvider.kt
+++ b/client-android/lib/src/main/kotlin/stasis/client_android/lib/discovery/providers/client/ServiceDiscoveryProvider.kt
@@ -1,0 +1,193 @@
+package stasis.client_android.lib.discovery.providers.client
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import stasis.client_android.lib.discovery.ServiceApiClient
+import stasis.client_android.lib.discovery.ServiceDiscoveryClient
+import stasis.client_android.lib.discovery.ServiceDiscoveryResult
+import stasis.client_android.lib.discovery.exceptions.DiscoveryFailure
+import stasis.client_android.lib.utils.Try
+import stasis.client_android.lib.utils.Try.Companion.map
+import java.lang.Long.max
+import java.time.Duration
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.ThreadLocalRandom
+import kotlin.coroutines.cancellation.CancellationException
+
+interface ServiceDiscoveryProvider {
+    fun <T : ServiceApiClient> latest(forClass: Class<T>): T
+    fun stop()
+
+    class Disabled(
+        private val initialClients: List<ServiceApiClient>
+    ) : ServiceDiscoveryProvider {
+        override fun <T : ServiceApiClient> latest(forClass: Class<T>): T =
+            extractClient(from = initialClients, forClass = forClass)
+
+        override fun stop() = Unit // do nothing
+    }
+
+    class Default(
+        private val initialDelay: Duration,
+        private val interval: Duration,
+        initialClients: Map<String, ServiceApiClient>,
+        private val clientFactory: ServiceApiClient.Factory,
+        coroutineScope: CoroutineScope
+    ) : ServiceDiscoveryProvider {
+        private val job: Job
+
+        private val clients: ConcurrentHashMap<String, ServiceApiClient> = ConcurrentHashMap(initialClients)
+
+        init {
+            job = coroutineScope.launch {
+                delay(timeMillis = initialDelay.toMillis())
+                scheduleNext()
+            }
+        }
+
+        override fun <T : ServiceApiClient> latest(forClass: Class<T>): T {
+            val rnd = ThreadLocalRandom.current()
+            val collected = clients.values.filterIsInstance(forClass)
+            return extractClient(from = collected.shuffled(rnd), forClass = forClass)
+        }
+
+        override fun stop() {
+            job.cancel()
+        }
+
+        private suspend fun scheduleNext(): Unit = withContext(Dispatchers.IO) {
+            try {
+                val result = discoverServices(
+                    client = extractClient(from = clients.values.toList(), ServiceDiscoveryClient::class.java),
+                    isInitialRequest = true
+                ).get()
+
+                when (result) {
+                    is ServiceDiscoveryResult.KeepExisting -> Unit // do nothing
+                    is ServiceDiscoveryResult.SwitchTo -> if (result.recreateExisting) {
+                        clients.clear()
+                        val core = clientFactory.create(result.endpoints.core)
+                        clients[result.endpoints.core.id] = core
+                        clients[result.endpoints.api.id] = clientFactory.create(result.endpoints.api, core)
+                        clients[result.endpoints.discovery.id] = clientFactory.create(result.endpoints.discovery)
+                    } else {
+                        val core = clients.computeIfAbsent(result.endpoints.core.id) {
+                            clientFactory.create(result.endpoints.core)
+                        }
+
+                        clients.computeIfAbsent(result.endpoints.api.id) {
+                            clientFactory.create(
+                                result.endpoints.api,
+                                core
+                            )
+                        }
+
+                        clients.computeIfAbsent(result.endpoints.discovery.id) {
+                            clientFactory.create(result.endpoints.discovery)
+                        }
+
+                        clients.keys.filter { k ->
+                            k != result.endpoints.core.id && k != result.endpoints.api.id && k != result.endpoints.discovery.id
+                        }.forEach { k -> clients.remove(k) }
+                    }
+                }
+
+                delay(timeMillis = fullInterval())
+            } catch (_: CancellationException) {
+                // do nothing
+            } catch (_: Throwable) {
+                delay(timeMillis = reducedInterval())
+            } finally {
+                scheduleNext()
+            }
+        }
+
+        private fun fullInterval(): Long =
+            fuzzyInterval(interval = interval.toMillis())
+
+        private fun reducedInterval(): Long =
+            max(
+                fuzzyInterval(interval = interval.toMillis() / FailureIntervalReduction),
+                initialDelay.toMillis()
+            )
+
+        @Suppress("MagicNumber")
+        private fun fuzzyInterval(interval: Long): Long {
+            val low = (interval - (interval * 0.02)).toLong()
+            val high = (interval + (interval * 0.03)).toLong()
+
+            return ThreadLocalRandom.current().nextLong(low, high)
+        }
+    }
+
+    companion object {
+        suspend operator fun invoke(
+            initialDelay: Duration,
+            interval: Duration,
+            initialClients: List<ServiceApiClient>,
+            clientFactory: ServiceApiClient.Factory,
+            coroutineScope: CoroutineScope,
+        ) = discoverServices(
+            client = extractClient(from = initialClients, ServiceDiscoveryClient::class.java),
+            isInitialRequest = true
+        ).map {
+            when (it) {
+                is ServiceDiscoveryResult.KeepExisting -> Disabled(initialClients)
+
+                is ServiceDiscoveryResult.SwitchTo -> {
+                    val core = clientFactory.create(it.endpoints.core)
+
+                    Default(
+                        initialDelay = initialDelay,
+                        interval = interval,
+                        initialClients = mapOf(
+                            it.endpoints.core.id to core,
+                            it.endpoints.api.id to clientFactory.create(it.endpoints.api, core),
+                            it.endpoints.discovery.id to clientFactory.create(it.endpoints.discovery)
+                        ),
+                        clientFactory = clientFactory,
+                        coroutineScope = coroutineScope
+                    )
+                }
+            }
+        }
+
+        fun create(
+            initialDelay: Duration,
+            interval: Duration,
+            initialClients: List<ServiceApiClient>,
+            clientFactory: ServiceApiClient.Factory,
+            onCreated: (Try<ServiceDiscoveryProvider>) -> Unit,
+            coroutineScope: CoroutineScope,
+        ) {
+            coroutineScope.launch {
+                val provider = ServiceDiscoveryProvider(
+                    initialDelay = initialDelay,
+                    interval = interval,
+                    initialClients = initialClients,
+                    clientFactory = clientFactory,
+                    coroutineScope = coroutineScope,
+                )
+
+                onCreated(provider)
+            }
+        }
+
+        private suspend fun discoverServices(
+            client: ServiceDiscoveryClient,
+            isInitialRequest: Boolean
+        ): Try<ServiceDiscoveryResult> = client.latest(isInitialRequest)
+
+        private fun <T : ServiceApiClient> extractClient(from: List<ServiceApiClient>, forClass: Class<T>): T =
+            when (val client = from.filterIsInstance(forClass).firstOrNull()) {
+                null -> throw DiscoveryFailure("Service client [${forClass.name}] was not found")
+                else -> client
+            }
+
+        const val FailureIntervalReduction: Int = 10
+    }
+}

--- a/client-android/lib/src/main/kotlin/stasis/client_android/lib/model/core/networking/EndpointAddress.kt
+++ b/client-android/lib/src/main/kotlin/stasis/client_android/lib/model/core/networking/EndpointAddress.kt
@@ -1,0 +1,13 @@
+package stasis.client_android.lib.model.core.networking
+
+sealed class EndpointAddress {
+    data class HttpEndpointAddress(
+        val uri: String
+    ) : EndpointAddress()
+
+    data class GrpcEndpointAddress(
+        val host: String,
+        val port: Int,
+        val tlsEnabled: Boolean
+    ) : EndpointAddress()
+}

--- a/client-android/lib/src/main/kotlin/stasis/client_android/lib/ops/backup/stages/EntityDiscovery.kt
+++ b/client-android/lib/src/main/kotlin/stasis/client_android/lib/ops/backup/stages/EntityDiscovery.kt
@@ -53,7 +53,7 @@ interface EntityDiscovery {
                         checksum = providers.checksum,
                         compression = providers.compression
                     ),
-                    api = providers.clients.api
+                    clients = providers.clients
                 )
             }
     }

--- a/client-android/lib/src/main/kotlin/stasis/client_android/lib/ops/recovery/Recovery.kt
+++ b/client-android/lib/src/main/kotlin/stasis/client_android/lib/ops/recovery/Recovery.kt
@@ -101,7 +101,7 @@ class Recovery(
                 keep = { entity, _ -> query?.matches(entity.toAbsolutePath()) ?: true },
                 destination = destination.toTargetEntityDestination(),
                 metadataCollector = RecoveryMetadataCollector.Default(checksum = providers.checksum),
-                api = providers.clients.api
+                clients = providers.clients
             )
 
         sealed class Collector {
@@ -132,6 +132,7 @@ class Recovery(
                                 )
                             )
                     }
+
                     is Collector.WithEntry -> providers.clients.api.datasetEntry(collector.entry)
                 }
 

--- a/client-android/lib/src/main/kotlin/stasis/client_android/lib/security/CredentialsProvider.kt
+++ b/client-android/lib/src/main/kotlin/stasis/client_android/lib/security/CredentialsProvider.kt
@@ -22,7 +22,7 @@ import java.time.Instant
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicReference
 
-@Suppress("LongParameterList")
+@Suppress("LongParameterList", "TooManyFunctions")
 class CredentialsProvider(
     private val config: Config,
     private val oAuthClient: OAuthClient,
@@ -292,6 +292,18 @@ class CredentialsProvider(
         f: (Try<AccessTokenResponse>) -> Unit,
     ): CredentialsProvider {
         onApiTokenUpdatedHandlers[observer] = f
+
+        return this
+    }
+
+    fun removeOnCoreTokenUpdatedHandler(observer: Any): CredentialsProvider {
+        onCoreTokenUpdatedHandlers.remove(observer)
+
+        return this
+    }
+
+    fun removeOnApiTokenUpdatedHandler(observer: Any): CredentialsProvider {
+        onApiTokenUpdatedHandlers.remove(observer)
 
         return this
     }

--- a/client-android/lib/src/test/kotlin/stasis/test/client_android/lib/api/clients/ClientsSpec.kt
+++ b/client-android/lib/src/test/kotlin/stasis/test/client_android/lib/api/clients/ClientsSpec.kt
@@ -1,0 +1,70 @@
+package stasis.test.client_android.lib.api.clients
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.should
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.types.beInstanceOf
+import stasis.client_android.lib.api.clients.Clients
+import stasis.client_android.lib.api.clients.ServerApiEndpointClient
+import stasis.client_android.lib.discovery.ServiceApiClient
+import stasis.client_android.lib.discovery.exceptions.DiscoveryFailure
+import stasis.client_android.lib.discovery.providers.client.ServiceDiscoveryProvider
+import stasis.client_android.lib.utils.Try.Failure
+import stasis.client_android.lib.utils.Try.Success
+import stasis.test.client_android.lib.mocks.MockServerApiEndpointClient
+import stasis.test.client_android.lib.mocks.MockServerCoreEndpointClient
+
+class ClientsSpec : WordSpec({
+    "Clients" should {
+        "provide static clients" {
+            val staticApiClient = MockServerApiEndpointClient()
+            val staticCoreClient = MockServerCoreEndpointClient()
+
+            val static = Clients(api = staticApiClient, core = staticCoreClient)
+            static should beInstanceOf<Clients.Static>()
+
+            static.api shouldBe (staticApiClient)
+            static.core shouldBe (staticCoreClient)
+
+            static.withDiscovery(discovery = Failure(RuntimeException("Test failure")))
+
+            static.api shouldBe (staticApiClient)
+            static.core shouldBe (staticCoreClient)
+        }
+
+        "provide discovery-based clients" {
+            val staticApiClient = MockServerApiEndpointClient()
+            val staticCoreClient = MockServerCoreEndpointClient()
+
+            val discoveryProvider = object : ServiceDiscoveryProvider {
+                @Suppress("UNCHECKED_CAST")
+                override fun <T : ServiceApiClient> latest(forClass: Class<T>): T =
+                    if (forClass == ServerApiEndpointClient::class.java) {
+                        MockServerApiEndpointClient() as T
+                    } else {
+                        MockServerCoreEndpointClient() as T
+                    }
+
+                override fun stop() = Unit
+            }
+
+            val discovery = Clients.discovered()
+            discovery should beInstanceOf<Clients.Discovered>()
+            val e1 = shouldThrow<DiscoveryFailure> { discovery.api }
+            val e2 = shouldThrow<DiscoveryFailure> { discovery.core }
+
+            e1.message shouldBe ("No discovery provider found")
+            e2.message shouldBe ("No discovery provider found")
+
+            discovery.withDiscovery(discovery = Failure(RuntimeException("Test failure")))
+            shouldThrow<RuntimeException> { discovery.api }
+            shouldThrow<RuntimeException> { discovery.core }
+
+            discovery.withDiscovery(discovery = Success(discoveryProvider))
+            discovery.api shouldNotBe staticApiClient
+            discovery.core shouldNotBe staticCoreClient
+        }
+    }
+})

--- a/client-android/lib/src/test/kotlin/stasis/test/client_android/lib/api/clients/ServiceApiClientFactorySpec.kt
+++ b/client-android/lib/src/test/kotlin/stasis/test/client_android/lib/api/clients/ServiceApiClientFactorySpec.kt
@@ -1,0 +1,106 @@
+package stasis.test.client_android.lib.api.clients
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.shouldBe
+import stasis.client_android.lib.api.clients.ServiceApiClientFactory
+import stasis.client_android.lib.discovery.ServiceApiClient
+import stasis.client_android.lib.discovery.ServiceApiEndpoint
+import stasis.client_android.lib.model.core.networking.EndpointAddress
+import stasis.test.client_android.lib.mocks.MockServerApiEndpointClient
+import stasis.test.client_android.lib.mocks.MockServerCoreEndpointClient
+import stasis.test.client_android.lib.mocks.MockServiceDiscoveryClient
+
+class ServiceApiClientFactorySpec : WordSpec({
+    "A ServiceApiClientFactory" should {
+        "support creating API clients" {
+            val expectedClient = MockServerApiEndpointClient()
+
+            val factory = ServiceApiClientFactory(
+                createServerCoreEndpointClient = { throw UnsupportedOperationException() },
+                createServerApiEndpointClient = { _, _ -> expectedClient },
+                createServiceDiscoveryClient = { throw UnsupportedOperationException() }
+            )
+
+            val actualClient = factory.create(
+                endpoint = ServiceApiEndpoint.Api(uri = "test-uri"),
+                coreClient = MockServerCoreEndpointClient()
+            )
+
+            actualClient shouldBe (expectedClient)
+        }
+
+        "fail to create API clients if an invalid core client is provided" {
+            val factory = ServiceApiClientFactory(
+                createServerCoreEndpointClient = { throw UnsupportedOperationException() },
+                createServerApiEndpointClient = { _, _ -> MockServerApiEndpointClient() },
+                createServiceDiscoveryClient = { throw UnsupportedOperationException() }
+            )
+
+            val e = shouldThrow<IllegalArgumentException> {
+                factory.create(
+                    endpoint = ServiceApiEndpoint.Api(uri = "test-uri"),
+                    coreClient = object : ServiceApiClient {}
+                )
+            }
+
+            e.message shouldBe ("Cannot create API endpoint client with core client of type []")
+        }
+
+        "support creating core clients" {
+            val expectedClient = MockServerCoreEndpointClient()
+
+            val factory = ServiceApiClientFactory(
+                createServerCoreEndpointClient = { expectedClient },
+                createServerApiEndpointClient = { _, _ -> throw UnsupportedOperationException() },
+                createServiceDiscoveryClient = { throw UnsupportedOperationException() }
+            )
+
+            val actualClient = factory.create(
+                endpoint = ServiceApiEndpoint.Core(address = EndpointAddress.HttpEndpointAddress(uri = "test-uri"))
+            )
+
+            actualClient shouldBe (expectedClient)
+        }
+
+        "fail to create core clients if an unsupported core address is provided" {
+            val expectedClient = MockServerCoreEndpointClient()
+
+            val factory = ServiceApiClientFactory(
+                createServerCoreEndpointClient = { expectedClient },
+                createServerApiEndpointClient = { _, _ -> throw UnsupportedOperationException() },
+                createServiceDiscoveryClient = { throw UnsupportedOperationException() }
+            )
+
+            val e = shouldThrow<IllegalArgumentException> {
+                factory.create(
+                    endpoint = ServiceApiEndpoint.Core(
+                        address = EndpointAddress.GrpcEndpointAddress(
+                            host = "localhost",
+                            port = 1234,
+                            tlsEnabled = false
+                        )
+                    )
+                )
+            }
+
+            e.message shouldBe ("Cannot create core endpoint client for address of type [GrpcEndpointAddress]")
+        }
+
+        "support creating discovery clients" {
+            val expectedClient = MockServiceDiscoveryClient()
+
+            val factory = ServiceApiClientFactory(
+                createServerCoreEndpointClient = { throw UnsupportedOperationException() },
+                createServerApiEndpointClient = { _, _ -> throw UnsupportedOperationException() },
+                createServiceDiscoveryClient = { expectedClient }
+            )
+
+            val actualClient = factory.create(
+                endpoint = ServiceApiEndpoint.Discovery(uri = "test-uri")
+            )
+
+            actualClient shouldBe (expectedClient)
+        }
+    }
+})

--- a/client-android/lib/src/test/kotlin/stasis/test/client_android/lib/collection/DefaultBackupCollectorSpec.kt
+++ b/client-android/lib/src/test/kotlin/stasis/test/client_android/lib/collection/DefaultBackupCollectorSpec.kt
@@ -6,6 +6,7 @@ import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.flow.fold
 import kotlinx.coroutines.flow.toList
 import stasis.client_android.lib.analysis.Checksum
+import stasis.client_android.lib.api.clients.Clients
 import stasis.client_android.lib.collection.BackupMetadataCollector
 import stasis.client_android.lib.collection.DefaultBackupCollector
 import stasis.client_android.lib.model.DatasetMetadata
@@ -16,6 +17,7 @@ import stasis.test.client_android.lib.Fixtures
 import stasis.test.client_android.lib.ResourceHelpers.asTestResource
 import stasis.test.client_android.lib.mocks.MockCompression
 import stasis.test.client_android.lib.mocks.MockServerApiEndpointClient
+import stasis.test.client_android.lib.mocks.MockServerCoreEndpointClient
 
 class DefaultBackupCollectorSpec : WordSpec({
     "A DefaultBackupCollector" should {
@@ -32,7 +34,7 @@ class DefaultBackupCollectorSpec : WordSpec({
                     checksum = Checksum.Companion.MD5,
                     compression = MockCompression()
                 ),
-                api = mockApiClient
+                clients = Clients(api = mockApiClient, core = MockServerCoreEndpointClient())
             )
 
             val sourceFiles = collector
@@ -74,7 +76,7 @@ class DefaultBackupCollectorSpec : WordSpec({
                     metadataChanged = emptyMap(),
                     filesystem = FilesystemMetadata(entities = mapOf(file1 to FilesystemMetadata.EntityState.New))
                 ),
-                api = mockApiClient
+                clients = Clients(api = mockApiClient, core = MockServerCoreEndpointClient())
             ).toList()
 
             collectedFiles.size shouldBe (2)
@@ -102,7 +104,7 @@ class DefaultBackupCollectorSpec : WordSpec({
                 .collectEntityMetadata(
                     entities = listOf(file1, file2),
                     latestMetadata = null,
-                    api = mockApiClient
+                    clients = Clients(api = mockApiClient, core = MockServerCoreEndpointClient())
                 ).toList()
 
             collectedFiles.size shouldBe (2)

--- a/client-android/lib/src/test/kotlin/stasis/test/client_android/lib/collection/DefaultRecoveryCollectorSpec.kt
+++ b/client-android/lib/src/test/kotlin/stasis/test/client_android/lib/collection/DefaultRecoveryCollectorSpec.kt
@@ -4,6 +4,7 @@ import io.kotest.core.spec.style.WordSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import kotlinx.coroutines.flow.fold
+import stasis.client_android.lib.api.clients.Clients
 import stasis.client_android.lib.collection.DefaultRecoveryCollector
 import stasis.client_android.lib.model.DatasetMetadata
 import stasis.client_android.lib.model.EntityMetadata
@@ -13,6 +14,7 @@ import stasis.test.client_android.lib.Fixtures
 import stasis.test.client_android.lib.ResourceHelpers.asTestResource
 import stasis.test.client_android.lib.mocks.MockRecoveryMetadataCollector
 import stasis.test.client_android.lib.mocks.MockServerApiEndpointClient
+import stasis.test.client_android.lib.mocks.MockServerCoreEndpointClient
 import java.math.BigInteger
 import java.nio.file.Paths
 import java.time.Instant
@@ -81,7 +83,7 @@ class DefaultRecoveryCollectorSpec : WordSpec({
                         file3Metadata.path to file3Metadata
                     )
                 ),
-                api = MockServerApiEndpointClient()
+                clients = Clients(api = MockServerApiEndpointClient(), core = MockServerCoreEndpointClient())
             )
 
             val targetFiles = collector
@@ -123,7 +125,7 @@ class DefaultRecoveryCollectorSpec : WordSpec({
             val actualMetadata = DefaultRecoveryCollector.collectEntityMetadata(
                 targetMetadata = targetMetadata,
                 keep = { _, state -> state == FilesystemMetadata.EntityState.New },
-                api = MockServerApiEndpointClient()
+                clients = Clients(api = MockServerApiEndpointClient(), core = MockServerCoreEndpointClient())
             )
 
             actualMetadata shouldBe (

--- a/client-android/lib/src/test/kotlin/stasis/test/client_android/lib/discovery/ClientDiscoveryAttributesSpec.kt
+++ b/client-android/lib/src/test/kotlin/stasis/test/client_android/lib/discovery/ClientDiscoveryAttributesSpec.kt
@@ -1,0 +1,34 @@
+package stasis.test.client_android.lib.discovery
+
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.shouldBe
+import stasis.client_android.lib.discovery.ClientDiscoveryAttributes
+import stasis.client_android.lib.discovery.ServiceDiscoveryRequest
+import stasis.client_android.lib.model.core.NodeId
+import stasis.client_android.lib.model.server.devices.DeviceId
+import stasis.client_android.lib.model.server.users.UserId
+
+class ClientDiscoveryAttributesSpec : WordSpec({
+    "ClientDiscoveryAttributes" should {
+        "support providing its attributes as a service discovery request" {
+            val user = UserId.randomUUID()
+            val device = DeviceId.randomUUID()
+            val node = NodeId.randomUUID()
+
+            val attributes = ClientDiscoveryAttributes(user = user, device = device, node = node)
+
+            val expected = ServiceDiscoveryRequest(
+                isInitialRequest = true,
+                attributes = mapOf(
+                    "user" to user.toString(),
+                    "device" to device.toString(),
+                    "node" to node.toString()
+                )
+            )
+
+            val actual = attributes.asServiceDiscoveryRequest(isInitialRequest = true)
+
+            actual shouldBe (expected)
+        }
+    }
+})

--- a/client-android/lib/src/test/kotlin/stasis/test/client_android/lib/discovery/ServiceApiEndpointSpec.kt
+++ b/client-android/lib/src/test/kotlin/stasis/test/client_android/lib/discovery/ServiceApiEndpointSpec.kt
@@ -1,0 +1,22 @@
+package stasis.test.client_android.lib.discovery
+
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.shouldBe
+import stasis.client_android.lib.discovery.ServiceApiEndpoint
+import stasis.client_android.lib.model.core.networking.EndpointAddress
+
+class ServiceApiEndpointSpec : WordSpec({
+    "A ServiceApiEndpoint" should {
+        "support providing an ID" {
+            ServiceApiEndpoint.Api(uri = "test-uri").id shouldBe ("api__test-uri")
+
+            ServiceApiEndpoint.Core(
+                address = EndpointAddress.HttpEndpointAddress(uri = "test-uri")
+            ).id shouldBe ("core_http__test-uri")
+
+            ServiceApiEndpoint.Core(
+                address = EndpointAddress.GrpcEndpointAddress(host = "test-host", port = 1234, tlsEnabled = false)
+            ).id shouldBe ("core_grpc__test-host:1234")
+        }
+    }
+})

--- a/client-android/lib/src/test/kotlin/stasis/test/client_android/lib/discovery/ServiceDiscoveryRequestSpec.kt
+++ b/client-android/lib/src/test/kotlin/stasis/test/client_android/lib/discovery/ServiceDiscoveryRequestSpec.kt
@@ -1,0 +1,22 @@
+package stasis.test.client_android.lib.discovery
+
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.shouldBe
+import stasis.client_android.lib.discovery.ServiceDiscoveryRequest
+
+class ServiceDiscoveryRequestSpec : WordSpec({
+    "A ServiceDiscoveryRequest" should {
+        "support converting its attributes to a request ID" {
+            val request = ServiceDiscoveryRequest(
+                isInitialRequest = false,
+                attributes = mapOf(
+                    "b" to "42",
+                    "c" to "false",
+                    "a" to "test-string"
+                )
+            )
+
+            request.id shouldBe ("a=test-string::b=42::c=false")
+        }
+    }
+})

--- a/client-android/lib/src/test/kotlin/stasis/test/client_android/lib/discovery/ServiceDiscoveryResultSpec.kt
+++ b/client-android/lib/src/test/kotlin/stasis/test/client_android/lib/discovery/ServiceDiscoveryResultSpec.kt
@@ -1,0 +1,40 @@
+package stasis.test.client_android.lib.discovery
+
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.shouldBe
+import stasis.client_android.lib.discovery.ServiceApiEndpoint
+import stasis.client_android.lib.discovery.ServiceDiscoveryResult
+import stasis.client_android.lib.model.core.networking.EndpointAddress
+
+class ServiceDiscoveryResultSpec : WordSpec({
+    "A ServiceDiscoveryResult" should {
+        "support rendering as a string" {
+            ServiceDiscoveryResult.KeepExisting.asString shouldBe ("result=keep-existing")
+
+            ServiceDiscoveryResult.SwitchTo(
+                endpoints = ServiceDiscoveryResult.Endpoints(
+                    api = ServiceApiEndpoint.Api(uri = "test-api"),
+                    core = ServiceApiEndpoint.Core(address = EndpointAddress.HttpEndpointAddress(uri = "test-core")),
+                    discovery = ServiceApiEndpoint.Discovery(uri = "test-discovery")
+                ),
+                recreateExisting = false
+            ).asString shouldBe (
+                    "result=switch-to,endpoints=api__test-api;" +
+                            "core_http__test-core;" +
+                            "discovery__test-discovery,recreate-existing=false"
+                    )
+        }
+    }
+
+    "ServiceDiscoveryResult Endpoints" should {
+        "support rendering as a string" {
+            val endpoints = ServiceDiscoveryResult.Endpoints(
+                api = ServiceApiEndpoint.Api(uri = "test-api"),
+                core = ServiceApiEndpoint.Core(address = EndpointAddress.HttpEndpointAddress(uri = "test-core")),
+                discovery = ServiceApiEndpoint.Discovery(uri = "test-discovery")
+            )
+
+            endpoints.asString shouldBe ("api__test-api;core_http__test-core;discovery__test-discovery")
+        }
+    }
+})

--- a/client-android/lib/src/test/kotlin/stasis/test/client_android/lib/discovery/http/HttpServiceDiscoveryClientSpec.kt
+++ b/client-android/lib/src/test/kotlin/stasis/test/client_android/lib/discovery/http/HttpServiceDiscoveryClientSpec.kt
@@ -1,0 +1,49 @@
+package stasis.test.client_android.lib.discovery.http
+
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.shouldBe
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import stasis.client_android.lib.discovery.ServiceDiscoveryClient
+import stasis.client_android.lib.discovery.ServiceDiscoveryRequest
+import stasis.client_android.lib.discovery.ServiceDiscoveryResult
+import stasis.client_android.lib.discovery.http.HttpServiceDiscoveryClient
+import stasis.client_android.lib.security.HttpCredentials
+import stasis.client_android.lib.utils.Try.Success
+
+class HttpServiceDiscoveryClientSpec : WordSpec({
+    "A HttpServiceDiscoveryClient" should {
+
+        fun createServer(withResponse: MockResponse? = null): MockWebServer {
+            val server = MockWebServer()
+            withResponse?.let { server.enqueue(it) }
+            server.start()
+
+            return server
+        }
+
+        "support retrieving latest service discovery information" {
+            val apiCredentials = HttpCredentials.BasicHttpCredentials(
+                username = "some-user",
+                password = "some-password"
+            )
+
+            val attributes = object : ServiceDiscoveryClient.Attributes {
+                override fun asServiceDiscoveryRequest(isInitialRequest: Boolean): ServiceDiscoveryRequest =
+                    ServiceDiscoveryRequest(isInitialRequest = isInitialRequest, attributes = emptyMap())
+            }
+
+            val api = createServer(
+                withResponse = MockResponse().setBody("""{"result":"keep-existing"}""")
+            )
+
+            val client = HttpServiceDiscoveryClient(
+                apiUrl = api.url("/").toString(),
+                credentials = { apiCredentials },
+                attributes = attributes
+            )
+
+            client.latest(isInitialRequest = false) shouldBe (Success(ServiceDiscoveryResult.KeepExisting))
+        }
+    }
+})

--- a/client-android/lib/src/test/kotlin/stasis/test/client_android/lib/discovery/providers/client/ServiceDiscoveryProviderSpec.kt
+++ b/client-android/lib/src/test/kotlin/stasis/test/client_android/lib/discovery/providers/client/ServiceDiscoveryProviderSpec.kt
@@ -1,0 +1,367 @@
+package stasis.test.client_android.lib.discovery.providers.client
+
+import io.kotest.assertions.throwables.shouldNotThrow
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.ints.shouldBeGreaterThanOrEqual
+import io.kotest.matchers.should
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.types.beInstanceOf
+import kotlinx.coroutines.delay
+import stasis.client_android.lib.discovery.ServiceApiClient
+import stasis.client_android.lib.discovery.ServiceApiEndpoint
+import stasis.client_android.lib.discovery.ServiceDiscoveryClient
+import stasis.client_android.lib.discovery.ServiceDiscoveryResult
+import stasis.client_android.lib.discovery.exceptions.DiscoveryFailure
+import stasis.client_android.lib.discovery.providers.client.ServiceDiscoveryProvider
+import stasis.client_android.lib.model.core.networking.EndpointAddress
+import stasis.client_android.lib.utils.Try
+import stasis.client_android.lib.utils.Try.Failure
+import stasis.test.client_android.lib.eventually
+import stasis.test.client_android.lib.mocks.MockServiceDiscoveryClient
+import java.time.Duration
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicReference
+
+class ServiceDiscoveryProviderSpec : WordSpec({
+    "A ServiceDiscoveryProvider" should {
+
+        class TestApiClient : ServiceApiClient
+
+        class TestCoreClient : ServiceApiClient
+
+        fun createClients(
+            initialDiscoveryResult: ServiceDiscoveryResult,
+            nextDiscoveryResult: ServiceDiscoveryResult
+        ): List<ServiceApiClient> = listOf(
+            MockServiceDiscoveryClient(
+                initialDiscoveryResult = initialDiscoveryResult,
+                nextDiscoveryResult = nextDiscoveryResult
+            )
+        )
+
+        fun createClientFactory(
+            nextDiscoveryResult: ServiceDiscoveryResult = ServiceDiscoveryResult.KeepExisting
+        ): ServiceApiClient.Factory =
+            object : ServiceApiClient.Factory {
+                override fun create(endpoint: ServiceApiEndpoint.Api, coreClient: ServiceApiClient): ServiceApiClient =
+                    TestApiClient()
+
+                override fun create(endpoint: ServiceApiEndpoint.Core): ServiceApiClient =
+                    TestCoreClient()
+
+                override fun create(endpoint: ServiceApiEndpoint.Discovery): ServiceApiClient =
+                    MockServiceDiscoveryClient(
+                        initialDiscoveryResult = nextDiscoveryResult,
+                        nextDiscoveryResult = nextDiscoveryResult
+                    )
+            }
+
+        suspend fun <T> managedProvider(provider: ServiceDiscoveryProvider, block: suspend () -> T): T =
+            try {
+                block()
+            } finally {
+                provider.stop()
+            }
+
+        "support providing existing clients when discovery is not active" {
+            val provider = ServiceDiscoveryProvider(
+                initialDelay = Duration.ofSeconds(3),
+                interval = Duration.ofSeconds(3),
+                initialClients = createClients(
+                    initialDiscoveryResult = ServiceDiscoveryResult.KeepExisting,
+                    nextDiscoveryResult = ServiceDiscoveryResult.KeepExisting
+                ),
+                clientFactory = createClientFactory(),
+                coroutineScope = testScope
+            ).get()
+
+            managedProvider(provider) {
+                provider should beInstanceOf<ServiceDiscoveryProvider.Disabled>()
+
+                provider.latest(ServiceDiscoveryClient::class.java) should beInstanceOf<MockServiceDiscoveryClient>()
+
+                shouldThrow<DiscoveryFailure> { provider.latest(TestApiClient::class.java) }
+                shouldThrow<DiscoveryFailure> { provider.latest(TestCoreClient::class.java) }
+            }
+        }
+
+        "support providing new clients when discovery is active" {
+            val provider = ServiceDiscoveryProvider(
+                initialDelay = Duration.ofSeconds(3),
+                interval = Duration.ofSeconds(3),
+                initialClients = createClients(
+                    initialDiscoveryResult = ServiceDiscoveryResult.SwitchTo(
+                        endpoints = ServiceDiscoveryResult.Endpoints(
+                            api = ServiceApiEndpoint.Api(uri = "test-rui"),
+                            core = ServiceApiEndpoint.Core(address = EndpointAddress.HttpEndpointAddress(uri = "test-rui")),
+                            discovery = ServiceApiEndpoint.Discovery(uri = "test-rui")
+                        ),
+                        recreateExisting = false
+                    ),
+                    nextDiscoveryResult = ServiceDiscoveryResult.KeepExisting
+                ),
+                clientFactory = createClientFactory(),
+                coroutineScope = testScope
+            ).get()
+
+            managedProvider(provider) {
+                provider should beInstanceOf<ServiceDiscoveryProvider.Default>()
+
+                provider.latest(ServiceDiscoveryClient::class.java) should beInstanceOf<MockServiceDiscoveryClient>()
+
+                shouldNotThrow<Throwable> { provider.latest(TestApiClient::class.java) }
+                shouldNotThrow<Throwable> { provider.latest(TestCoreClient::class.java) }
+            }
+        }
+
+        "periodically refresh list of endpoints and clients (with result=keep-existing)" {
+            fun createResult(recreateExisting: Boolean = false): ServiceDiscoveryResult =
+                ServiceDiscoveryResult.SwitchTo(
+                    endpoints = ServiceDiscoveryResult.Endpoints(
+                        api = ServiceApiEndpoint.Api(uri = java.util.UUID.randomUUID().toString()),
+                        core = ServiceApiEndpoint.Core(
+                            address = EndpointAddress.HttpEndpointAddress(
+                                uri = java.util.UUID.randomUUID().toString()
+                            )
+                        ),
+                        discovery = ServiceApiEndpoint.Discovery(uri = java.util.UUID.randomUUID().toString())
+                    ),
+                    recreateExisting = recreateExisting
+                )
+
+            val provider = ServiceDiscoveryProvider(
+                initialDelay = Duration.ofMillis(200),
+                interval = Duration.ofMillis(200),
+                initialClients = createClients(
+                    initialDiscoveryResult = createResult(),
+                    nextDiscoveryResult = createResult()
+                ),
+                clientFactory = createClientFactory(),
+                coroutineScope = testScope
+            ).get()
+
+            managedProvider(provider) {
+                provider should beInstanceOf<ServiceDiscoveryProvider.Default>()
+
+                val initialDiscoveryClient = provider.latest(ServiceDiscoveryClient::class.java)
+                val initialApiClient = provider.latest(TestApiClient::class.java)
+                val initialCoreClient = provider.latest(TestCoreClient::class.java)
+
+                delay(timeMillis = 100)
+
+                provider.latest(ServiceDiscoveryClient::class.java) shouldBe (initialDiscoveryClient)
+                provider.latest(TestApiClient::class.java) shouldBe (initialApiClient)
+                provider.latest(TestCoreClient::class.java) shouldBe (initialCoreClient)
+            }
+        }
+
+        "periodically refresh list of endpoints and clients (with result=switch-to)" {
+            fun createResult(recreateExisting: Boolean = false): ServiceDiscoveryResult =
+                ServiceDiscoveryResult.SwitchTo(
+                    endpoints = ServiceDiscoveryResult.Endpoints(
+                        api = ServiceApiEndpoint.Api(uri = java.util.UUID.randomUUID().toString()),
+                        core = ServiceApiEndpoint.Core(
+                            address = EndpointAddress.HttpEndpointAddress(
+                                uri = java.util.UUID.randomUUID().toString()
+                            )
+                        ),
+                        discovery = ServiceApiEndpoint.Discovery(uri = java.util.UUID.randomUUID().toString())
+                    ),
+                    recreateExisting = recreateExisting
+                )
+
+            val provider = ServiceDiscoveryProvider(
+                initialDelay = Duration.ofMillis(200),
+                interval = Duration.ofMillis(200),
+                initialClients = createClients(
+                    initialDiscoveryResult = createResult(),
+                    nextDiscoveryResult = createResult()
+                ),
+                clientFactory = createClientFactory(nextDiscoveryResult = createResult(recreateExisting = true)),
+                coroutineScope = testScope
+            ).get()
+
+            managedProvider(provider) {
+                provider should beInstanceOf<ServiceDiscoveryProvider.Default>()
+
+                val initialDiscoveryClient = provider.latest(ServiceDiscoveryClient::class.java)
+                val initialApiClient = provider.latest(TestApiClient::class.java)
+                val initialCoreClient = provider.latest(TestCoreClient::class.java)
+
+                delay(timeMillis = 100)
+
+                provider.latest(ServiceDiscoveryClient::class.java) shouldBe (initialDiscoveryClient)
+                provider.latest(TestApiClient::class.java) shouldBe (initialApiClient)
+                provider.latest(TestCoreClient::class.java) shouldBe (initialCoreClient)
+
+                eventually {
+                    provider.latest(ServiceDiscoveryClient::class.java) shouldNotBe (initialDiscoveryClient)
+                    provider.latest(TestApiClient::class.java) shouldNotBe (initialApiClient)
+                    provider.latest(TestCoreClient::class.java) shouldNotBe (initialCoreClient)
+                }
+            }
+        }
+
+        "not recreate clients for same endpoints" {
+            fun createResult(recreateExisting: Boolean = false): ServiceDiscoveryResult =
+                ServiceDiscoveryResult.SwitchTo(
+                    endpoints = ServiceDiscoveryResult.Endpoints(
+                        api = ServiceApiEndpoint.Api(uri = java.util.UUID.randomUUID().toString()),
+                        core = ServiceApiEndpoint.Core(
+                            address = EndpointAddress.HttpEndpointAddress(
+                                uri = java.util.UUID.randomUUID().toString()
+                            )
+                        ),
+                        discovery = ServiceApiEndpoint.Discovery(uri = java.util.UUID.randomUUID().toString())
+                    ),
+                    recreateExisting = recreateExisting
+                )
+
+            val provider = ServiceDiscoveryProvider(
+                initialDelay = Duration.ofMillis(100),
+                interval = Duration.ofMillis(100),
+                initialClients = createClients(
+                    initialDiscoveryResult = createResult(),
+                    nextDiscoveryResult = createResult()
+                ),
+                clientFactory = createClientFactory(nextDiscoveryResult = createResult()),
+                coroutineScope = testScope
+            ).get()
+
+            managedProvider(provider) {
+                provider should beInstanceOf<ServiceDiscoveryProvider.Default>()
+
+                val initialDiscoveryClient = provider.latest(ServiceDiscoveryClient::class.java)
+                val initialApiClient = provider.latest(TestApiClient::class.java)
+                val initialCoreClient = provider.latest(TestCoreClient::class.java)
+
+                delay(timeMillis = 200)
+
+                provider.latest(ServiceDiscoveryClient::class.java) shouldNotBe (initialDiscoveryClient)
+                provider.latest(TestApiClient::class.java) shouldNotBe (initialApiClient)
+                provider.latest(TestCoreClient::class.java) shouldNotBe (initialCoreClient)
+
+                val latestDiscoveryClient = provider.latest(ServiceDiscoveryClient::class.java)
+                val latestApiClient = provider.latest(TestApiClient::class.java)
+                val latestCoreClient = provider.latest(TestCoreClient::class.java)
+
+                delay(timeMillis = 200)
+
+                eventually {
+                    latestDiscoveryClient shouldNotBe initialDiscoveryClient
+                    latestApiClient shouldNotBe initialApiClient
+                    latestCoreClient shouldNotBe initialCoreClient
+
+                    provider.latest(ServiceDiscoveryClient::class.java) shouldBe (latestDiscoveryClient)
+                    provider.latest(TestApiClient::class.java) shouldBe (latestApiClient)
+                    provider.latest(TestCoreClient::class.java) shouldBe (latestCoreClient)
+                }
+            }
+        }
+
+        "fail to retrieve unsupported client types" {
+            val provider = ServiceDiscoveryProvider(
+                initialDelay = Duration.ofSeconds(3),
+                interval = Duration.ofSeconds(3),
+                initialClients = createClients(
+                    initialDiscoveryResult = ServiceDiscoveryResult.KeepExisting,
+                    nextDiscoveryResult = ServiceDiscoveryResult.KeepExisting
+                ),
+                clientFactory = createClientFactory(),
+                coroutineScope = testScope
+            ).get()
+
+
+            managedProvider(provider) {
+                provider should beInstanceOf<ServiceDiscoveryProvider.Disabled>()
+
+                val e = shouldThrow<DiscoveryFailure> { provider.latest(TestApiClient::class.java) }
+
+                e.message shouldBe ("Service client [${TestApiClient::class.java.name}] was not found")
+            }
+        }
+
+        "handle discovery failures" {
+            val clientCalls = AtomicInteger(0)
+
+            val provider = ServiceDiscoveryProvider(
+                initialDelay = Duration.ofMillis(100),
+                interval = Duration.ofMillis(200),
+                initialClients = createClients(
+                    initialDiscoveryResult = ServiceDiscoveryResult.SwitchTo(
+                        endpoints = ServiceDiscoveryResult.Endpoints(
+                            api = ServiceApiEndpoint.Api(uri = "test-rui"),
+                            core = ServiceApiEndpoint.Core(address = EndpointAddress.HttpEndpointAddress(uri = "test-rui")),
+                            discovery = ServiceApiEndpoint.Discovery(uri = "test-rui")
+                        ),
+                        recreateExisting = false
+                    ),
+                    nextDiscoveryResult = ServiceDiscoveryResult.KeepExisting
+                ),
+                clientFactory = object : ServiceApiClient.Factory {
+                    override fun create(
+                        endpoint: ServiceApiEndpoint.Api,
+                        coreClient: ServiceApiClient
+                    ): ServiceApiClient =
+                        TestApiClient()
+
+                    override fun create(endpoint: ServiceApiEndpoint.Core): ServiceApiClient =
+                        TestCoreClient()
+
+                    override fun create(endpoint: ServiceApiEndpoint.Discovery): ServiceApiClient =
+                        object : ServiceDiscoveryClient {
+                            override val attributes: ServiceDiscoveryClient.Attributes =
+                                MockServiceDiscoveryClient.TestAttributes(a = "b")
+
+                            override suspend fun latest(isInitialRequest: Boolean): Try<ServiceDiscoveryResult> {
+                                clientCalls.incrementAndGet()
+                                return Failure(RuntimeException("Test failure"))
+                            }
+                        }
+                },
+                coroutineScope = testScope
+            ).get()
+
+            managedProvider(provider) {
+                clientCalls.get() shouldBe (0)
+
+                delay(timeMillis = 100)
+
+                clientCalls.get() shouldBe (0)
+
+                delay(timeMillis = 400)
+
+                clientCalls.get() shouldBeGreaterThanOrEqual (3) // the interval is reduced so more requests should be made
+            }
+        }
+
+        "support creating the provider asynchronously" {
+            val providerRef = AtomicReference<Try<ServiceDiscoveryProvider>?>(null)
+
+            ServiceDiscoveryProvider.create(
+                initialDelay = Duration.ofSeconds(3),
+                interval = Duration.ofSeconds(3),
+                initialClients = createClients(
+                    initialDiscoveryResult = ServiceDiscoveryResult.KeepExisting,
+                    nextDiscoveryResult = ServiceDiscoveryResult.KeepExisting
+                ),
+                clientFactory = createClientFactory(),
+                onCreated = { providerRef.set(it) },
+                coroutineScope = testScope
+            )
+
+            providerRef.get() shouldBe (null)
+
+            eventually {
+                val provider = providerRef.get()?.get()
+                provider shouldNotBe (null)
+
+                managedProvider(provider!!) {
+                    provider should beInstanceOf<ServiceDiscoveryProvider.Disabled>()
+                }
+            }
+        }
+    }
+})

--- a/client-android/lib/src/test/kotlin/stasis/test/client_android/lib/mocks/MockServiceDiscoveryClient.kt
+++ b/client-android/lib/src/test/kotlin/stasis/test/client_android/lib/mocks/MockServiceDiscoveryClient.kt
@@ -1,0 +1,33 @@
+package stasis.test.client_android.lib.mocks
+
+import stasis.client_android.lib.discovery.ServiceDiscoveryClient
+import stasis.client_android.lib.discovery.ServiceDiscoveryRequest
+import stasis.client_android.lib.discovery.ServiceDiscoveryResult
+import stasis.client_android.lib.utils.Try
+import stasis.client_android.lib.utils.Try.Success
+
+class MockServiceDiscoveryClient(
+    private val initialDiscoveryResult: ServiceDiscoveryResult,
+    private val nextDiscoveryResult: ServiceDiscoveryResult
+) : ServiceDiscoveryClient {
+    override val attributes: ServiceDiscoveryClient.Attributes = TestAttributes(a = "b")
+
+    override suspend fun latest(isInitialRequest: Boolean): Try<ServiceDiscoveryResult> =
+        Success(
+            value = if (isInitialRequest) initialDiscoveryResult
+            else nextDiscoveryResult
+        )
+
+    data class TestAttributes(val a: String) : ServiceDiscoveryClient.Attributes {
+        override fun asServiceDiscoveryRequest(isInitialRequest: Boolean): ServiceDiscoveryRequest =
+            ServiceDiscoveryRequest(isInitialRequest = isInitialRequest, attributes = mapOf("a" to a))
+    }
+
+    companion object {
+        operator fun invoke(): MockServiceDiscoveryClient =
+            MockServiceDiscoveryClient(
+                initialDiscoveryResult = ServiceDiscoveryResult.KeepExisting,
+                nextDiscoveryResult = ServiceDiscoveryResult.KeepExisting
+            )
+    }
+}

--- a/client-android/lib/src/test/kotlin/stasis/test/client_android/lib/model/DatasetMetadataSpec.kt
+++ b/client-android/lib/src/test/kotlin/stasis/test/client_android/lib/model/DatasetMetadataSpec.kt
@@ -7,6 +7,7 @@ import io.kotest.matchers.shouldBe
 import okio.Buffer
 import okio.ByteString.Companion.decodeBase64
 import okio.ByteString.Companion.toByteString
+import stasis.client_android.lib.api.clients.Clients
 import stasis.client_android.lib.encryption.Aes
 import stasis.client_android.lib.encryption.secrets.DeviceSecret
 import stasis.client_android.lib.encryption.secrets.Secret
@@ -19,6 +20,7 @@ import stasis.client_android.lib.utils.Try
 import stasis.client_android.lib.utils.Try.Success
 import stasis.test.client_android.lib.Fixtures
 import stasis.test.client_android.lib.mocks.MockServerApiEndpointClient
+import stasis.test.client_android.lib.mocks.MockServerCoreEndpointClient
 import java.io.IOException
 import java.util.UUID
 
@@ -141,8 +143,14 @@ class DatasetMetadataSpec : WordSpec({
                 )
             )
 
-            val fileOneMetadata = metadata.collect(entity = Fixtures.Metadata.FileOneMetadata.path, api = mockApiClient)
-            val fileTwoMetadata = metadata.collect(entity = Fixtures.Metadata.FileTwoMetadata.path, api = mockApiClient)
+            val fileOneMetadata = metadata.collect(
+                entity = Fixtures.Metadata.FileOneMetadata.path,
+                clients = Clients(api = mockApiClient, core = MockServerCoreEndpointClient())
+            )
+            val fileTwoMetadata = metadata.collect(
+                entity = Fixtures.Metadata.FileTwoMetadata.path,
+                clients = Clients(api = mockApiClient, core = MockServerCoreEndpointClient())
+            )
 
             mockApiClient.statistics[MockServerApiEndpointClient.Statistic.DatasetMetadataWithEntryIdRetrieved] shouldBe (0)
             mockApiClient.statistics[MockServerApiEndpointClient.Statistic.DatasetMetadataWithEntryRetrieved] shouldBe (0)
@@ -168,14 +176,20 @@ class DatasetMetadataSpec : WordSpec({
             )
 
             val fileOneFailure = shouldThrow<IllegalArgumentException> {
-                metadata.collect(entity = Fixtures.Metadata.FileOneMetadata.path, api = mockApiClient)
+                metadata.collect(
+                    entity = Fixtures.Metadata.FileOneMetadata.path,
+                    clients = Clients(api = mockApiClient, core = MockServerCoreEndpointClient())
+                )
             }
 
             fileOneFailure
                 .message shouldBe ("Metadata for entity [${Fixtures.Metadata.FileOneMetadata.path.toAbsolutePath()}] not found")
 
             val fileTwoFailure = shouldThrow<IllegalArgumentException> {
-                metadata.collect(entity = Fixtures.Metadata.FileTwoMetadata.path, api = mockApiClient)
+                metadata.collect(
+                    entity = Fixtures.Metadata.FileTwoMetadata.path,
+                    clients = Clients(api = mockApiClient, core = MockServerCoreEndpointClient())
+                )
             }
 
             fileTwoFailure
@@ -226,9 +240,15 @@ class DatasetMetadataSpec : WordSpec({
             }
 
             val fileOneMetadata =
-                currentMetadata.collect(entity = Fixtures.Metadata.FileOneMetadata.path, api = mockApiClient)
+                currentMetadata.collect(
+                    entity = Fixtures.Metadata.FileOneMetadata.path,
+                    clients = Clients(api = mockApiClient, core = MockServerCoreEndpointClient())
+                )
             val fileTwoMetadata =
-                currentMetadata.collect(entity = Fixtures.Metadata.FileTwoMetadata.path, api = mockApiClient)
+                currentMetadata.collect(
+                    entity = Fixtures.Metadata.FileTwoMetadata.path,
+                    clients = Clients(api = mockApiClient, core = MockServerCoreEndpointClient())
+                )
 
             mockApiClient.statistics[MockServerApiEndpointClient.Statistic.DatasetMetadataWithEntryIdRetrieved] shouldBe (2)
             mockApiClient.statistics[MockServerApiEndpointClient.Statistic.DatasetMetadataWithEntryRetrieved] shouldBe (0)
@@ -254,7 +274,10 @@ class DatasetMetadataSpec : WordSpec({
             )
 
             val fileOneFailure = shouldThrow<IllegalArgumentException> {
-                currentMetadata.collect(entity = Fixtures.Metadata.FileOneMetadata.path, api = mockApiClient)
+                currentMetadata.collect(
+                    entity = Fixtures.Metadata.FileOneMetadata.path,
+                    clients = Clients(api = mockApiClient, core = MockServerCoreEndpointClient())
+                )
             }
 
             fileOneFailure.message shouldBe (
@@ -263,7 +286,10 @@ class DatasetMetadataSpec : WordSpec({
                     )
 
             val fileTwoFailure = shouldThrow<IllegalArgumentException> {
-                currentMetadata.collect(entity = Fixtures.Metadata.FileTwoMetadata.path, api = mockApiClient)
+                currentMetadata.collect(
+                    entity = Fixtures.Metadata.FileTwoMetadata.path,
+                    clients = Clients(api = mockApiClient, core = MockServerCoreEndpointClient())
+                )
             }
 
             fileTwoFailure.message shouldBe (
@@ -293,8 +319,14 @@ class DatasetMetadataSpec : WordSpec({
                 )
             )
 
-            val fileOneMetadata = metadata.require(entity = Fixtures.Metadata.FileOneMetadata.path, api = mockApiClient)
-            val fileTwoMetadata = metadata.require(entity = Fixtures.Metadata.FileTwoMetadata.path, api = mockApiClient)
+            val fileOneMetadata = metadata.require(
+                entity = Fixtures.Metadata.FileOneMetadata.path,
+                clients = Clients(api = mockApiClient, core = MockServerCoreEndpointClient())
+            )
+            val fileTwoMetadata = metadata.require(
+                entity = Fixtures.Metadata.FileTwoMetadata.path,
+                clients = Clients(api = mockApiClient, core = MockServerCoreEndpointClient())
+            )
 
             mockApiClient.statistics[MockServerApiEndpointClient.Statistic.DatasetMetadataWithEntryIdRetrieved] shouldBe (0)
             mockApiClient.statistics[MockServerApiEndpointClient.Statistic.DatasetMetadataWithEntryRetrieved] shouldBe (0)
@@ -309,7 +341,10 @@ class DatasetMetadataSpec : WordSpec({
             val metadata = DatasetMetadata.empty()
 
             val fileOneFailure = shouldThrow<IllegalArgumentException> {
-                metadata.require(entity = Fixtures.Metadata.FileOneMetadata.path, api = mockApiClient)
+                metadata.require(
+                    entity = Fixtures.Metadata.FileOneMetadata.path,
+                    clients = Clients(api = mockApiClient, core = MockServerCoreEndpointClient())
+                )
             }
 
             fileOneFailure.message shouldBe (
@@ -317,7 +352,10 @@ class DatasetMetadataSpec : WordSpec({
                     )
 
             val fileTwoFailure = shouldThrow<IllegalArgumentException> {
-                metadata.require(entity = Fixtures.Metadata.FileTwoMetadata.path, api = mockApiClient)
+                metadata.require(
+                    entity = Fixtures.Metadata.FileTwoMetadata.path,
+                    clients = Clients(api = mockApiClient, core = MockServerCoreEndpointClient())
+                )
             }
 
             fileTwoFailure.message shouldBe (

--- a/client/src/main/resources/reference.conf
+++ b/client/src/main/resources/reference.conf
@@ -301,6 +301,11 @@ stasis {
           }
         }
       }
+
+      discovery {
+        interval = 15 minutes
+        interval = ${?STASIS_CLIENT_SERVER_DISCOVERY_INTERVAL}
+      }
     }
 
     service {

--- a/client/src/main/scala/stasis/client/api/clients/Clients.scala
+++ b/client/src/main/scala/stasis/client/api/clients/Clients.scala
@@ -1,6 +1,28 @@
 package stasis.client.api.clients
 
-final case class Clients(
-  api: ServerApiEndpointClient,
-  core: ServerCoreEndpointClient
-)
+import stasis.core.discovery.providers.client.ServiceDiscoveryProvider
+
+sealed trait Clients {
+  def api: ServerApiEndpointClient
+  def core: ServerCoreEndpointClient
+}
+
+object Clients {
+  final case class Static(
+    override val api: ServerApiEndpointClient,
+    override val core: ServerCoreEndpointClient
+  ) extends Clients
+
+  final case class Discovered(
+    discovery: ServiceDiscoveryProvider
+  ) extends Clients {
+    override def api: ServerApiEndpointClient = discovery.latest[ServerApiEndpointClient]
+    override def core: ServerCoreEndpointClient = discovery.latest[ServerCoreEndpointClient]
+  }
+
+  def apply(api: ServerApiEndpointClient, core: ServerCoreEndpointClient): Clients =
+    Clients.Static(api = api, core = core)
+
+  def apply(discovery: ServiceDiscoveryProvider): Clients =
+    Clients.Discovered(discovery = discovery)
+}

--- a/client/src/main/scala/stasis/client/api/clients/ServerApiEndpointClient.scala
+++ b/client/src/main/scala/stasis/client/api/clients/ServerApiEndpointClient.scala
@@ -9,6 +9,7 @@ import org.apache.pekko.util.ByteString
 
 import stasis.client.model.DatasetMetadata
 import stasis.core.commands.proto.Command
+import stasis.core.discovery.ServiceApiClient
 import stasis.shared.api.requests.CreateDatasetDefinition
 import stasis.shared.api.requests.CreateDatasetEntry
 import stasis.shared.api.requests.ResetUserPassword
@@ -23,7 +24,7 @@ import stasis.shared.model.devices.Device
 import stasis.shared.model.schedules.Schedule
 import stasis.shared.model.users.User
 
-trait ServerApiEndpointClient {
+trait ServerApiEndpointClient extends ServiceApiClient {
   def self: Device.Id
   def server: String
 

--- a/client/src/main/scala/stasis/client/api/clients/ServerCoreEndpointClient.scala
+++ b/client/src/main/scala/stasis/client/api/clients/ServerCoreEndpointClient.scala
@@ -7,11 +7,12 @@ import org.apache.pekko.util.ByteString
 import org.apache.pekko.Done
 import org.apache.pekko.NotUsed
 
+import stasis.core.discovery.ServiceApiClient
 import stasis.core.packaging.Crate
 import stasis.core.packaging.Manifest
 import stasis.core.routing.Node
 
-trait ServerCoreEndpointClient {
+trait ServerCoreEndpointClient extends ServiceApiClient {
   def self: Node.Id
   def server: String
 

--- a/client/src/main/scala/stasis/client/ops/backup/stages/EntityDiscovery.scala
+++ b/client/src/main/scala/stasis/client/ops/backup/stages/EntityDiscovery.scala
@@ -10,10 +10,10 @@ import org.apache.pekko.NotUsed
 import org.apache.pekko.stream.Materializer
 import org.apache.pekko.stream.scaladsl.Source
 
-import stasis.client.collection.rules.Rule
-import stasis.client.collection.rules.Specification
 import stasis.client.collection.BackupCollector
 import stasis.client.collection.BackupMetadataCollector
+import stasis.client.collection.rules.Rule
+import stasis.client.collection.rules.Specification
 import stasis.client.model.DatasetMetadata
 import stasis.client.ops.ParallelismConfig
 import stasis.client.ops.backup.Providers
@@ -60,7 +60,7 @@ trait EntityDiscovery {
             checksum = providers.checksum,
             compression = providers.compression
           ),
-          api = providers.clients.api
+          clients = providers.clients
         )(ec, parallelism)
       }
   }

--- a/client/src/main/scala/stasis/client/ops/recovery/Recovery.scala
+++ b/client/src/main/scala/stasis/client/ops/recovery/Recovery.scala
@@ -117,7 +117,7 @@ object Recovery {
         keep = (entity, _) => query.forall(_.matches(entity.toAbsolutePath)),
         destination = destination.toTargetEntityDestination,
         metadataCollector = RecoveryMetadataCollector.Default(checksum = providers.checksum),
-        api = providers.clients.api
+        clients = providers.clients
       )
   }
 

--- a/client/src/main/scala/stasis/client/ops/search/DefaultSearch.scala
+++ b/client/src/main/scala/stasis/client/ops/search/DefaultSearch.scala
@@ -5,13 +5,15 @@ import java.time.Instant
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 
-import stasis.client.api.clients.ServerApiEndpointClient
+import stasis.client.api.clients.Clients
 
 class DefaultSearch(
-  api: ServerApiEndpointClient
+  clients: Clients
 )(implicit ec: ExecutionContext)
     extends Search {
   override def search(query: Search.Query, until: Option[Instant]): Future[Search.Result] = {
+    val api = clients.api
+
     val metadataResult = for {
       definitions <- api.datasetDefinitions()
       entries <-

--- a/client/src/main/scala/stasis/client/service/components/ApiClients.scala
+++ b/client/src/main/scala/stasis/client/service/components/ApiClients.scala
@@ -8,8 +8,16 @@ import scala.util.Try
 
 import stasis.client.api.clients._
 import stasis.core.api.PoolClient
+import stasis.core.discovery.ServiceApiClient
+import stasis.core.discovery.ServiceApiEndpoint
+import stasis.core.discovery.ServiceDiscoveryClient
+import stasis.core.discovery.http.HttpServiceDiscoveryClient
+import stasis.core.discovery.providers.client.ServiceDiscoveryProvider
 import stasis.core.networking.http.HttpEndpointAddress
+import stasis.core.routing.Node
 import stasis.layers.security.tls.EndpointContext
+import stasis.shared.model.devices.Device
+import stasis.shared.model.users.User
 
 trait ApiClients {
   def clients: Clients
@@ -20,59 +28,145 @@ object ApiClients {
     import base._
     import secrets._
 
-    Future.fromTry(
-      Try {
-        val coreClient: ServerCoreEndpointClient = DefaultServerCoreEndpointClient(
-          address = HttpEndpointAddress(rawConfig.getString("server.core.address")),
-          credentials = credentialsProvider.core,
-          self = UUID.fromString(rawConfig.getString("server.core.node-id")),
-          context = EndpointContext(rawConfig.getConfig("server.core.context")),
-          maxChunkSize = rawConfig.getInt("server.core.max-chunk-size"),
-          config = PoolClient.Config(
-            minBackoff = rawConfig.getDuration("server.core.retry.min-backoff").toMillis.millis,
-            maxBackoff = rawConfig.getDuration("server.core.retry.max-backoff").toMillis.millis,
-            randomFactor = rawConfig.getDouble("server.core.retry.random-factor"),
-            maxRetries = rawConfig.getInt("server.core.retry.max-retries"),
-            requestBufferSize = rawConfig.getInt("server.core.request-buffer-size")
+    Future
+      .fromTry(
+        Try {
+          val user = UUID.fromString(rawConfig.getString("server.api.user"))
+          val device = UUID.fromString(rawConfig.getString("server.api.device"))
+          val node = UUID.fromString(rawConfig.getString("server.core.node-id"))
+
+          def createServerCoreEndpointClient(address: HttpEndpointAddress): ServerCoreEndpointClient =
+            DefaultServerCoreEndpointClient(
+              address = address,
+              credentials = credentialsProvider.core,
+              self = node,
+              context = EndpointContext(rawConfig.getConfig("server.core.context")),
+              maxChunkSize = rawConfig.getInt("server.core.max-chunk-size"),
+              config = PoolClient.Config(
+                minBackoff = rawConfig.getDuration("server.core.retry.min-backoff").toMillis.millis,
+                maxBackoff = rawConfig.getDuration("server.core.retry.max-backoff").toMillis.millis,
+                randomFactor = rawConfig.getDouble("server.core.retry.random-factor"),
+                maxRetries = rawConfig.getInt("server.core.retry.max-retries"),
+                requestBufferSize = rawConfig.getInt("server.core.request-buffer-size")
+              )
+            )
+
+          def createServerApiEndpointClient(apiUrl: String, coreClient: ServerCoreEndpointClient): ServerApiEndpointClient = {
+            val apiClient = DefaultServerApiEndpointClient(
+              apiUrl = apiUrl,
+              credentials = credentialsProvider.api,
+              decryption = DefaultServerApiEndpointClient.DecryptionContext(
+                core = coreClient,
+                deviceSecret = deviceSecret,
+                decoder = encryption
+              ),
+              self = deviceSecret.device,
+              context = EndpointContext(rawConfig.getConfig("server.api.context")),
+              config = PoolClient.Config(
+                minBackoff = rawConfig.getDuration("server.api.retry.min-backoff").toMillis.millis,
+                maxBackoff = rawConfig.getDuration("server.api.retry.max-backoff").toMillis.millis,
+                randomFactor = rawConfig.getDouble("server.api.retry.random-factor"),
+                maxRetries = rawConfig.getInt("server.api.retry.max-retries"),
+                requestBufferSize = rawConfig.getInt("server.api.request-buffer-size")
+              )
+            )
+
+            CachedServerApiEndpointClient(
+              config = CachedServerApiEndpointClient.Config(
+                initialCapacity = rawConfig.getInt("server.api.cache.initial-capacity"),
+                maximumCapacity = rawConfig.getInt("server.api.cache.maximum-capacity"),
+                timeToLive = rawConfig.getDuration("server.api.cache.time-to-live").toMillis.millis,
+                timeToIdle = rawConfig.getDuration("server.api.cache.time-to-idle").toMillis.millis
+              ),
+              underlying = apiClient
+            )
+          }
+
+          def createServiceDiscoveryClient(apiUrl: String): ServiceDiscoveryClient =
+            HttpServiceDiscoveryClient(
+              apiUrl = apiUrl,
+              credentials = credentialsProvider.api,
+              attributes = ClientDiscoveryAttributes(
+                user = user,
+                device = device,
+                node = node
+              ),
+              context = EndpointContext(rawConfig.getConfig("server.api.context"))
+            )
+
+          val coreClient: ServerCoreEndpointClient = createServerCoreEndpointClient(
+            address = HttpEndpointAddress(rawConfig.getString("server.core.address"))
           )
-        )
 
-        val apiClient: ServerApiEndpointClient = DefaultServerApiEndpointClient(
-          apiUrl = rawConfig.getString("server.api.url"),
-          credentials = credentialsProvider.api,
-          decryption = DefaultServerApiEndpointClient.DecryptionContext(
-            core = coreClient,
-            deviceSecret = deviceSecret,
-            decoder = encryption
-          ),
-          self = deviceSecret.device,
-          context = EndpointContext(rawConfig.getConfig("server.api.context")),
-          config = PoolClient.Config(
-            minBackoff = rawConfig.getDuration("server.api.retry.min-backoff").toMillis.millis,
-            maxBackoff = rawConfig.getDuration("server.api.retry.max-backoff").toMillis.millis,
-            randomFactor = rawConfig.getDouble("server.api.retry.random-factor"),
-            maxRetries = rawConfig.getInt("server.api.retry.max-retries"),
-            requestBufferSize = rawConfig.getInt("server.api.request-buffer-size")
+          val apiClient: ServerApiEndpointClient = createServerApiEndpointClient(
+            apiUrl = rawConfig.getString("server.api.url"),
+            coreClient = coreClient
           )
-        )
 
-        val cachedApiClient = CachedServerApiEndpointClient(
-          config = CachedServerApiEndpointClient.Config(
-            initialCapacity = rawConfig.getInt("server.api.cache.initial-capacity"),
-            maximumCapacity = rawConfig.getInt("server.api.cache.maximum-capacity"),
-            timeToLive = rawConfig.getDuration("server.api.cache.time-to-live").toMillis.millis,
-            timeToIdle = rawConfig.getDuration("server.api.cache.time-to-idle").toMillis.millis
-          ),
-          underlying = apiClient
-        )
+          val discoveryClient: ServiceDiscoveryClient = createServiceDiscoveryClient(
+            apiUrl = rawConfig.getString("server.api.url")
+          )
 
-        new ApiClients {
-          override val clients: Clients = Clients(
-            api = cachedApiClient,
-            core = coreClient
+          val clientFactory = new ServiceApiClientFactory(
+            createServerCoreEndpointClient = createServerCoreEndpointClient,
+            createServerApiEndpointClient = createServerApiEndpointClient,
+            createServiceDiscoveryClient = createServiceDiscoveryClient
+          )
+
+          ServiceDiscoveryProvider(
+            interval = rawConfig.getDuration("server.discovery.interval").toMillis.millis,
+            initialClients = Seq(coreClient, apiClient, discoveryClient),
+            clientFactory = clientFactory
           )
         }
+      )
+      .flatten
+      .map { provider =>
+        new ApiClients {
+          override val clients: Clients = Clients(provider)
+        }
       }
-    )
+  }
+
+  final case class ClientDiscoveryAttributes(
+    user: User.Id,
+    device: Device.Id,
+    node: Node.Id
+  ) extends ServiceDiscoveryClient.Attributes
+
+  class ServiceApiClientFactory(
+    createServerCoreEndpointClient: HttpEndpointAddress => ServerCoreEndpointClient,
+    createServerApiEndpointClient: (String, ServerCoreEndpointClient) => ServerApiEndpointClient,
+    createServiceDiscoveryClient: String => ServiceDiscoveryClient
+  ) extends ServiceApiClient.Factory {
+    @SuppressWarnings(Array("org.wartremover.warts.Throw"))
+    override def create(endpoint: ServiceApiEndpoint.Api, coreClient: ServiceApiClient): ServiceApiClient =
+      createServerApiEndpointClient(
+        endpoint.uri,
+        coreClient match {
+          case client: ServerCoreEndpointClient =>
+            client
+
+          case other =>
+            throw new IllegalArgumentException(
+              s"Cannot create API endpoint client with core client of type [${other.getClass.getSimpleName}]"
+            )
+        }
+      )
+
+    @SuppressWarnings(Array("org.wartremover.warts.Throw"))
+    override def create(endpoint: ServiceApiEndpoint.Core): ServiceApiClient =
+      endpoint.address match {
+        case address: HttpEndpointAddress =>
+          createServerCoreEndpointClient(address)
+
+        case address =>
+          throw new IllegalArgumentException(
+            s"Cannot create core endpoint client for address of type [${address.getClass.getSimpleName}]"
+          )
+      }
+
+    override def create(endpoint: ServiceApiEndpoint.Discovery): ServiceApiClient =
+      createServiceDiscoveryClient(endpoint.uri)
   }
 }

--- a/client/src/main/scala/stasis/client/service/components/ApiClients.scala
+++ b/client/src/main/scala/stasis/client/service/components/ApiClients.scala
@@ -107,7 +107,7 @@ object ApiClients {
             apiUrl = rawConfig.getString("server.api.url")
           )
 
-          val clientFactory = new ServiceApiClientFactory(
+          val clientFactory = ServiceApiClientFactory(
             createServerCoreEndpointClient = createServerCoreEndpointClient,
             createServerApiEndpointClient = createServerApiEndpointClient,
             createServiceDiscoveryClient = createServiceDiscoveryClient
@@ -168,5 +168,17 @@ object ApiClients {
 
     override def create(endpoint: ServiceApiEndpoint.Discovery): ServiceApiClient =
       createServiceDiscoveryClient(endpoint.uri)
+  }
+
+  object ServiceApiClientFactory {
+    def apply(
+      createServerCoreEndpointClient: HttpEndpointAddress => ServerCoreEndpointClient,
+      createServerApiEndpointClient: (String, ServerCoreEndpointClient) => ServerApiEndpointClient,
+      createServiceDiscoveryClient: String => ServiceDiscoveryClient
+    ): ServiceApiClientFactory = new ServiceApiClientFactory(
+      createServerCoreEndpointClient = createServerCoreEndpointClient,
+      createServerApiEndpointClient = createServerApiEndpointClient,
+      createServiceDiscoveryClient = createServiceDiscoveryClient
+    )
   }
 }

--- a/client/src/main/scala/stasis/client/service/components/ApiEndpoint.scala
+++ b/client/src/main/scala/stasis/client/service/components/ApiEndpoint.scala
@@ -53,8 +53,8 @@ object ApiEndpoint {
             ) { Future.successful(base.terminateService()) }
           },
           verifyUserPassword = secrets.verifyUserPassword,
-          updateUserCredentials = secrets.updateUserCredentials(clients.api, _, _),
-          reEncryptDeviceSecret = secrets.reEncryptDeviceSecret(clients.api, _)
+          updateUserCredentials = secrets.updateUserCredentials(clients, _, _),
+          reEncryptDeviceSecret = secrets.reEncryptDeviceSecret(clients, _)
         ),
         commandProcessor = commandProcessor,
         secretsConfig = secrets.config,

--- a/client/src/main/scala/stasis/client/service/components/Ops.scala
+++ b/client/src/main/scala/stasis/client/service/components/Ops.scala
@@ -92,7 +92,7 @@ object Ops {
               minDelay = rawConfig.getDuration("ops.scheduling.min-delay").toMillis.millis,
               maxExtraDelay = rawConfig.getDuration("ops.scheduling.max-extra-delay").toMillis.millis
             ),
-            api = clients.api,
+            clients = clients,
             executor = executor
           )
 
@@ -100,18 +100,18 @@ object Ops {
           DefaultServerMonitor(
             initialDelay = rawConfig.getDuration("ops.monitoring.initial-delay").toMillis.millis,
             interval = rawConfig.getDuration("ops.monitoring.interval").toMillis.millis,
-            api = clients.api,
+            clients = clients,
             tracker = trackers.server
           )
 
         override val search: Search =
-          new DefaultSearch(api = clients.api)
+          new DefaultSearch(clients = clients)
 
         override val commandProcessor: CommandProcessor =
           DefaultCommandProcessor(
             initialDelay = rawConfig.getDuration("ops.commands.initial-delay").toMillis.millis,
             interval = rawConfig.getDuration("ops.commands.interval").toMillis.millis,
-            api = clients.api,
+            clients = clients,
             handlers = DefaultCommandProcessorHandlers(
               executeCommand = executeCommand(base, _),
               directory = directory

--- a/client/src/main/scala/stasis/client/service/components/bootstrap/Parameters.scala
+++ b/client/src/main/scala/stasis/client/service/components/bootstrap/Parameters.scala
@@ -20,6 +20,7 @@ import stasis.client.service.components.bootstrap.internal.SelfSignedCertificate
 import stasis.client.service.ApplicationDirectory
 import stasis.client.service.ApplicationTemplates
 import stasis.client.service.components
+import stasis.layers.security.tls.EndpointContext
 import stasis.shared.model.devices.DeviceBootstrapParameters
 
 trait Parameters {
@@ -139,14 +140,14 @@ object Parameters {
     }
 
   def storeContext(
-    context: DeviceBootstrapParameters.Context,
+    context: EndpointContext.Encoded,
     passwordSize: Int,
     parent: Path,
     file: String
   )(implicit log: Logger): Try[(String, String)] =
     if (context.enabled) {
       Try {
-        val store = DeviceBootstrapParameters.Context.decodeKeyStore(
+        val store = EndpointContext.Encoded.decodeKeyStore(
           content = context.storeContent,
           password = context.temporaryStorePassword,
           storeType = context.storeType

--- a/client/src/test/scala/stasis/test/specs/unit/client/api/clients/ClientsSpec.scala
+++ b/client/src/test/scala/stasis/test/specs/unit/client/api/clients/ClientsSpec.scala
@@ -1,0 +1,45 @@
+package stasis.test.specs.unit.client.api.clients
+
+import scala.reflect.ClassTag
+
+import org.apache.pekko.actor.typed.ActorSystem
+import org.apache.pekko.actor.typed.scaladsl.Behaviors
+
+import stasis.client.api.clients.Clients
+import stasis.client.api.clients.ServerApiEndpointClient
+import stasis.core.discovery.ServiceApiClient
+import stasis.core.discovery.providers.client.ServiceDiscoveryProvider
+import stasis.test.specs.unit.AsyncUnitSpec
+import stasis.test.specs.unit.client.mocks.MockServerApiEndpointClient
+import stasis.test.specs.unit.client.mocks.MockServerCoreEndpointClient
+
+class ClientsSpec extends AsyncUnitSpec {
+  "Clients" should "provide static and discovery-based clients" in {
+    val staticApiClient = MockServerApiEndpointClient()
+    val staticCoreClient = MockServerCoreEndpointClient()
+
+    val discoveryProvider = new ServiceDiscoveryProvider {
+      override def latest[T <: ServiceApiClient](implicit tag: ClassTag[T]): T =
+        if (tag.runtimeClass == classOf[ServerApiEndpointClient]) {
+          MockServerApiEndpointClient().asInstanceOf[T]
+        } else {
+          MockServerCoreEndpointClient().asInstanceOf[T]
+        }
+    }
+
+    val static = Clients(api = staticApiClient, core = staticCoreClient)
+    static should be(a[Clients.Static])
+    static.api should be(staticApiClient)
+    static.core should be(staticCoreClient)
+
+    val discovery = Clients(discovery = discoveryProvider)
+    discovery should be(a[Clients.Discovered])
+    discovery.api should not be staticApiClient
+    discovery.core should not be staticCoreClient
+  }
+
+  private implicit val typedSystem: ActorSystem[Nothing] = ActorSystem(
+    guardianBehavior = Behaviors.ignore,
+    name = "ClientsSpec"
+  )
+}

--- a/client/src/test/scala/stasis/test/specs/unit/client/api/clients/DefaultServerBootstrapEndpointClientSpec.scala
+++ b/client/src/test/scala/stasis/test/specs/unit/client/api/clients/DefaultServerBootstrapEndpointClientSpec.scala
@@ -141,19 +141,19 @@ class DefaultServerBootstrapEndpointClientSpec extends AsyncUnitSpec {
         api = "urn:stasis:identity:audience:server-api",
         core = s"urn:stasis:identity:audience:${Node.generateId().toString}"
       ),
-      context = DeviceBootstrapParameters.Context.disabled()
+      context = EndpointContext.Encoded.disabled()
     ),
     serverApi = DeviceBootstrapParameters.ServerApi(
       url = "http://localhost:5678",
       user = User.generateId().toString,
       userSalt = "test-salt",
       device = Device.generateId().toString,
-      context = DeviceBootstrapParameters.Context.disabled()
+      context = EndpointContext.Encoded.disabled()
     ),
     serverCore = DeviceBootstrapParameters.ServerCore(
       address = "http://localhost:5679",
       nodeId = Node.generateId().toString,
-      context = DeviceBootstrapParameters.Context.disabled()
+      context = EndpointContext.Encoded.disabled()
     ),
     secrets = Fixtures.Secrets.DefaultConfig,
     additionalConfig = Json.obj()

--- a/client/src/test/scala/stasis/test/specs/unit/client/collection/BackupCollectorSpec.scala
+++ b/client/src/test/scala/stasis/test/specs/unit/client/collection/BackupCollectorSpec.scala
@@ -5,6 +5,7 @@ import scala.concurrent.Future
 import org.apache.pekko.actor.ActorSystem
 
 import stasis.client.analysis.Checksum
+import stasis.client.api.clients.Clients
 import stasis.client.collection.BackupCollector
 import stasis.client.collection.BackupMetadataCollector
 import stasis.client.model.DatasetMetadata
@@ -29,7 +30,7 @@ class BackupCollectorSpec extends AsyncUnitSpec with ResourceHelpers {
       entities = List(file1, file2),
       latestMetadata = Some(DatasetMetadata.empty),
       metadataCollector = new BackupMetadataCollector.Default(checksum = Checksum.MD5, compression = MockCompression()),
-      api = mockApiClient
+      clients = Clients(api = mockApiClient, core = null)
     )
 
     collector
@@ -77,7 +78,7 @@ class BackupCollectorSpec extends AsyncUnitSpec with ResourceHelpers {
                 filesystem = FilesystemMetadata(entities = Map(file1 -> FilesystemMetadata.EntityState.New))
               )
             ),
-            api = mockApiClient
+            clients = Clients(api = mockApiClient, core = null)
           )
       ) { case (file, metadataFuture) => metadataFuture.map(metadata => (file, metadata)) }
       .map(_.toList)
@@ -106,7 +107,7 @@ class BackupCollectorSpec extends AsyncUnitSpec with ResourceHelpers {
           .collectEntityMetadata(
             entities = List(file1, file2),
             latestMetadata = None,
-            api = mockApiClient
+            clients = Clients(api = mockApiClient, core = null)
           )
       ) { case (file, metadataFuture) => metadataFuture.map(metadata => (file, metadata)) }
       .map(_.toList)

--- a/client/src/test/scala/stasis/test/specs/unit/client/collection/RecoveryCollectorSpec.scala
+++ b/client/src/test/scala/stasis/test/specs/unit/client/collection/RecoveryCollectorSpec.scala
@@ -7,6 +7,7 @@ import scala.concurrent.Future
 
 import org.apache.pekko.actor.ActorSystem
 
+import stasis.client.api.clients.Clients
 import stasis.client.collection.RecoveryCollector
 import stasis.client.model.DatasetMetadata
 import stasis.client.model.EntityMetadata
@@ -82,7 +83,7 @@ class RecoveryCollectorSpec extends AsyncUnitSpec with ResourceHelpers {
           file3Metadata.path -> file3Metadata
         )
       ),
-      api = MockServerApiEndpointClient()
+      clients = Clients(api = MockServerApiEndpointClient(), core = null)
     )
 
     collector
@@ -127,7 +128,7 @@ class RecoveryCollectorSpec extends AsyncUnitSpec with ResourceHelpers {
         RecoveryCollector.collectEntityMetadata(
           targetMetadata = targetMetadata,
           keep = (_, state) => state == FilesystemMetadata.EntityState.New,
-          api = MockServerApiEndpointClient()
+          clients = Clients(api = MockServerApiEndpointClient(), core = null)
         )
       )
       .map { actualMetadata =>

--- a/client/src/test/scala/stasis/test/specs/unit/client/mocks/MockServerApiEndpoint.scala
+++ b/client/src/test/scala/stasis/test/specs/unit/client/mocks/MockServerApiEndpoint.scala
@@ -23,6 +23,8 @@ import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
 import stasis.core.commands.proto.Command
+import stasis.core.discovery.ServiceDiscoveryRequest
+import stasis.core.discovery.ServiceDiscoveryResult
 import stasis.layers.persistence.memory.MemoryStore
 import stasis.layers.security.tls.EndpointContext
 import stasis.layers.telemetry.TelemetryContext
@@ -373,6 +375,21 @@ class MockServerApiEndpoint(
       complete(ping)
     }
 
+  private val discovery: Route =
+    path("provide") {
+      post {
+        import stasis.core.api.Formats._
+
+        entity(as[ServiceDiscoveryRequest]) { request =>
+          val result: ServiceDiscoveryResult = ServiceDiscoveryResult.KeepExisting
+
+          log.info("Responding to discovery request [{}] with [{}]", request.id, result.asString)
+
+          complete(result)
+        }
+      }
+    }
+
   private val routes: Route =
     (extractMethod & extractUri & extractRequest) { (method, uri, request) =>
       extractCredentials {
@@ -382,7 +399,8 @@ class MockServerApiEndpoint(
             pathPrefix("users") { users },
             pathPrefix("devices") { devices },
             pathPrefix("schedules") { schedules },
-            pathPrefix("service") { service }
+            pathPrefix("service") { service },
+            pathPrefix("discovery") { discovery }
           )
 
         case _ =>

--- a/client/src/test/scala/stasis/test/specs/unit/client/ops/commands/DefaultCommandProcessorSpec.scala
+++ b/client/src/test/scala/stasis/test/specs/unit/client/ops/commands/DefaultCommandProcessorSpec.scala
@@ -15,6 +15,7 @@ import org.scalatest.BeforeAndAfterAll
 import org.scalatest.concurrent.Eventually
 import org.slf4j.Logger
 
+import stasis.client.api.clients.Clients
 import stasis.client.ops.commands.CommandProcessor
 import stasis.client.ops.commands.DefaultCommandProcessor
 import stasis.core.commands.proto.Command
@@ -230,7 +231,7 @@ class DefaultCommandProcessorSpec extends AsyncUnitSpec with Eventually with Bef
     val processor = DefaultCommandProcessor(
       initialDelay = initialDelay,
       interval = defaultInterval,
-      api = mockApiClient,
+      clients = Clients(api = mockApiClient, core = null),
       handlers = new CommandProcessor.Handlers {
         override def persistLastProcessedCommand(sequenceId: Long): Future[Done] = {
           persistLastProcessedCommandCalls.incrementAndGet()
@@ -291,7 +292,7 @@ class DefaultCommandProcessorSpec extends AsyncUnitSpec with Eventually with Bef
     val processor = DefaultCommandProcessor(
       initialDelay = 0.millis,
       interval = defaultInterval,
-      api = mockApiClient,
+      clients = Clients(api = mockApiClient, core = null),
       handlers = new CommandProcessor.Handlers {
         override def persistLastProcessedCommand(sequenceId: Long): Future[Done] = {
           persistLastProcessedCommandCalls.incrementAndGet()
@@ -334,7 +335,7 @@ class DefaultCommandProcessorSpec extends AsyncUnitSpec with Eventually with Bef
     val processor = DefaultCommandProcessor(
       initialDelay = initialDelay,
       interval = defaultInterval,
-      api = mockApiClient,
+      clients = Clients(api = mockApiClient, core = null),
       handlers = new CommandProcessor.Handlers {
         override def persistLastProcessedCommand(sequenceId: Long): Future[Done] = {
           persistLastProcessedCommandCalls.incrementAndGet()
@@ -401,7 +402,7 @@ class DefaultCommandProcessorSpec extends AsyncUnitSpec with Eventually with Bef
     val processor = DefaultCommandProcessor(
       initialDelay = 50.millis,
       interval = defaultInterval,
-      api = mockApiClient,
+      clients = Clients(api = mockApiClient, core = null),
       handlers = new CommandProcessor.Handlers {
         override def persistLastProcessedCommand(sequenceId: Long): Future[Done] = {
           persistLastProcessedCommandCalls.incrementAndGet()
@@ -459,7 +460,7 @@ class DefaultCommandProcessorSpec extends AsyncUnitSpec with Eventually with Bef
     val processor = DefaultCommandProcessor(
       initialDelay = initialDelay,
       interval = defaultInterval,
-      api = mockApiClient,
+      clients = Clients(api = mockApiClient, core = null),
       handlers = new CommandProcessor.Handlers {
         override def persistLastProcessedCommand(sequenceId: Long): Future[Done] = {
           persistLastProcessedCommandCalls.incrementAndGet()
@@ -526,7 +527,7 @@ class DefaultCommandProcessorSpec extends AsyncUnitSpec with Eventually with Bef
     val processor = DefaultCommandProcessor(
       initialDelay = 50.millis,
       interval = defaultInterval,
-      api = mockApiClient,
+      clients = Clients(api = mockApiClient, core = null),
       handlers = new CommandProcessor.Handlers {
         override def persistLastProcessedCommand(sequenceId: Long): Future[Done] = {
           persistLastProcessedCommandCalls.incrementAndGet()
@@ -577,7 +578,7 @@ class DefaultCommandProcessorSpec extends AsyncUnitSpec with Eventually with Bef
     val processor = DefaultCommandProcessor(
       initialDelay = 50.millis,
       interval = defaultInterval,
-      api = mockApiClient,
+      clients = Clients(api = mockApiClient, core = null),
       handlers = new CommandProcessor.Handlers {
         override def persistLastProcessedCommand(sequenceId: Long): Future[Done] = Future.successful(Done)
         override def retrieveLastProcessedCommand(): Future[Option[Long]] = Future.successful(None)

--- a/client/src/test/scala/stasis/test/specs/unit/client/ops/monitoring/DefaultServerMonitorSpec.scala
+++ b/client/src/test/scala/stasis/test/specs/unit/client/ops/monitoring/DefaultServerMonitorSpec.scala
@@ -11,6 +11,7 @@ import org.scalatest.Assertion
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.concurrent.Eventually
 
+import stasis.client.api.clients.Clients
 import stasis.client.ops.monitoring.DefaultServerMonitor
 import stasis.shared.api.responses.Ping
 import stasis.shared.model.devices.Device
@@ -201,7 +202,7 @@ class DefaultServerMonitorSpec extends AsyncUnitSpec with Eventually with Before
     DefaultServerMonitor(
       initialDelay = initialDelay,
       interval = interval,
-      api = api,
+      clients = Clients(api = api, core = null),
       tracker = tracker
     )
 

--- a/client/src/test/scala/stasis/test/specs/unit/client/ops/scheduling/DefaultOperationSchedulerSpec.scala
+++ b/client/src/test/scala/stasis/test/specs/unit/client/ops/scheduling/DefaultOperationSchedulerSpec.scala
@@ -14,6 +14,7 @@ import org.scalatest.Assertion
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.concurrent.Eventually
 
+import stasis.client.api.clients.Clients
 import stasis.client.ops.exceptions.ScheduleRetrievalFailure
 import stasis.client.ops.scheduling.DefaultOperationScheduler
 import stasis.client.ops.scheduling.OperationScheduleAssignment
@@ -640,7 +641,7 @@ class DefaultOperationSchedulerSpec extends AsyncUnitSpec with ResourceHelpers w
         minDelay = minDelay,
         maxExtraDelay = maxAdditionalDelay
       ),
-      api = api,
+      clients = Clients(api = api, core = null),
       executor = executor
     )
 

--- a/client/src/test/scala/stasis/test/specs/unit/client/ops/search/DefaultSearchSpec.scala
+++ b/client/src/test/scala/stasis/test/specs/unit/client/ops/search/DefaultSearchSpec.scala
@@ -5,6 +5,7 @@ import java.time.Instant
 
 import scala.concurrent.Future
 
+import stasis.client.api.clients.Clients
 import stasis.client.model.DatasetMetadata
 import stasis.client.model.FilesystemMetadata
 import stasis.client.ops.search.DefaultSearch
@@ -65,7 +66,7 @@ class DefaultSearchSpec extends AsyncUnitSpec {
         }
     }
 
-    val search = new DefaultSearch(api = mockApiClient)
+    val search = new DefaultSearch(clients = Clients(api = mockApiClient, core = null))
 
     search
       .search(

--- a/client/src/test/scala/stasis/test/specs/unit/client/service/ApplicationTemplatesSpec.scala
+++ b/client/src/test/scala/stasis/test/specs/unit/client/service/ApplicationTemplatesSpec.scala
@@ -12,6 +12,7 @@ import play.api.libs.json.Json
 import stasis.client.service.ApplicationTemplates
 import stasis.client.service.components
 import stasis.core.routing.Node
+import stasis.layers.security.tls.EndpointContext
 import stasis.shared.model.devices.Device
 import stasis.shared.model.devices.DeviceBootstrapParameters
 import stasis.shared.model.users.User
@@ -190,19 +191,19 @@ class ApplicationTemplatesSpec extends UnitSpec {
         api = "urn:stasis:identity:audience:server-api",
         core = s"urn:stasis:identity:audience:${Node.generateId().toString}"
       ),
-      context = DeviceBootstrapParameters.Context.disabled()
+      context = EndpointContext.Encoded.disabled()
     ),
     serverApi = DeviceBootstrapParameters.ServerApi(
       url = "http://localhost:5678",
       user = User.generateId().toString,
       userSalt = "test-salt",
       device = Device.generateId().toString,
-      context = DeviceBootstrapParameters.Context.disabled()
+      context = EndpointContext.Encoded.disabled()
     ),
     serverCore = DeviceBootstrapParameters.ServerCore(
       address = "http://localhost:5679",
       nodeId = Node.generateId().toString,
-      context = DeviceBootstrapParameters.Context.disabled()
+      context = EndpointContext.Encoded.disabled()
     ),
     secrets = Fixtures.Secrets.DefaultConfig,
     additionalConfig = Json.obj(

--- a/client/src/test/scala/stasis/test/specs/unit/client/service/ServiceSpec.scala
+++ b/client/src/test/scala/stasis/test/specs/unit/client/service/ServiceSpec.scala
@@ -495,19 +495,19 @@ class ServiceSpec extends AsyncUnitSpec with ResourceHelpers with EncodingHelper
         api = "urn:stasis:identity:audience:server-api",
         core = s"urn:stasis:identity:audience:${Node.generateId().toString}"
       ),
-      context = DeviceBootstrapParameters.Context.disabled()
+      context = EndpointContext.Encoded.disabled()
     ),
     serverApi = DeviceBootstrapParameters.ServerApi(
       url = "http://localhost:5678",
       user = User.generateId().toString,
       userSalt = "test-salt",
       device = Device.generateId().toString,
-      context = DeviceBootstrapParameters.Context.disabled()
+      context = EndpointContext.Encoded.disabled()
     ),
     serverCore = DeviceBootstrapParameters.ServerCore(
       address = "http://localhost:5679",
       nodeId = Node.generateId().toString,
-      context = DeviceBootstrapParameters.Context.disabled()
+      context = EndpointContext.Encoded.disabled()
     ),
     secrets = Fixtures.Secrets.DefaultConfig,
     additionalConfig = Json.obj()

--- a/client/src/test/scala/stasis/test/specs/unit/client/service/components/ApiClientsSpec.scala
+++ b/client/src/test/scala/stasis/test/specs/unit/client/service/components/ApiClientsSpec.scala
@@ -2,7 +2,9 @@ package stasis.test.specs.unit.client.service.components
 
 import java.util.UUID
 
+import scala.collection.mutable
 import scala.concurrent.Future
+import scala.concurrent.duration._
 
 import org.apache.pekko.Done
 import org.apache.pekko.actor.typed.ActorSystem
@@ -14,24 +16,40 @@ import org.apache.pekko.util.ByteString
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
-import stasis.client.api.clients.ServerApiEndpointClient
+import stasis.client.api.clients.Clients
 import stasis.client.encryption.Aes
 import stasis.client.encryption.secrets.DeviceSecret
 import stasis.client.security.CredentialsProvider
 import stasis.client.service.ApplicationTray
 import stasis.client.service.components.ApiClients
 import stasis.client.service.components.Base
+import stasis.client.service.components.Files
 import stasis.client.service.components.Secrets
+import stasis.core.discovery.ServiceApiClient
+import stasis.core.discovery.ServiceApiEndpoint
+import stasis.core.networking.grpc.GrpcEndpointAddress
+import stasis.core.networking.http.HttpEndpointAddress
 import stasis.core.packaging.Crate
 import stasis.shared.model.users.User
 import stasis.shared.secrets.SecretsConfig
 import stasis.test.specs.unit.AsyncUnitSpec
 import stasis.test.specs.unit.client.ResourceHelpers
+import stasis.test.specs.unit.client.mocks.MockServerApiEndpoint
+import stasis.test.specs.unit.client.mocks.MockServerApiEndpointClient
+import stasis.test.specs.unit.client.mocks.MockServerCoreEndpointClient
+import stasis.test.specs.unit.core.discovery.mocks.MockServiceDiscoveryClient
+import stasis.test.specs.unit.core.telemetry.MockTelemetryContext
 
 class ApiClientsSpec extends AsyncUnitSpec with ResourceHelpers {
   "An ApiClients component" should "create itself from config" in {
+    val serverApiCredentials = OAuth2BearerToken(token = "test-token")
+
+    val serverApiEndpointPort = ports.dequeue()
+    val serverApiEndpoint = new MockServerApiEndpoint(expectedCredentials = serverApiCredentials)
+      .start(port = serverApiEndpointPort)
+
     val deviceId = UUID.fromString("bc3b2b9a-3d04-4c8c-a6bb-b4ee428d1a99")
-    val apiUrl = "http://localhost:19090"
+    val apiUrl = s"http://localhost:$serverApiEndpointPort"
 
     val coreNodeId = UUID.fromString("31f7c5b1-3d47-4731-8c2b-19f6416eb2e3")
     val coreAddress = "http://localhost:19091"
@@ -41,7 +59,17 @@ class ApiClientsSpec extends AsyncUnitSpec with ResourceHelpers {
       ivSize = Aes.IvSize
     )
 
-    val directory = createApplicationDirectory(init = _ => ())
+    val directory = createApplicationDirectory(
+      init = dir => {
+        val path = dir.config.get
+        java.nio.file.Files.createDirectories(path)
+
+        java.nio.file.Files.writeString(
+          path.resolve(Files.ConfigOverride),
+          s"""{$serverApiEndpointConfigEntry: "$apiUrl"}"""
+        )
+      }
+    )
 
     for {
       apiClients <- ApiClients(
@@ -56,40 +84,130 @@ class ApiClientsSpec extends AsyncUnitSpec with ResourceHelpers {
 
           override def credentialsProvider: CredentialsProvider =
             new CredentialsProvider {
-              override def core: Future[HttpCredentials] = Future.successful(OAuth2BearerToken(token = "test-token"))
-              override def api: Future[HttpCredentials] = Future.successful(OAuth2BearerToken(token = "test-token"))
+              override def core: Future[HttpCredentials] = Future.successful(serverApiCredentials)
+              override def api: Future[HttpCredentials] = Future.successful(serverApiCredentials)
             }
 
           override def config: SecretsConfig = secretsConfig
 
           override def verifyUserPassword: Array[Char] => Boolean = _ => false
 
-          override def updateUserCredentials: (ServerApiEndpointClient, Array[Char], String) => Future[Done] =
+          override def updateUserCredentials: (Clients, Array[Char], String) => Future[Done] =
             (_, _, _) => Future.successful(Done)
 
-          override def reEncryptDeviceSecret: (ServerApiEndpointClient, Array[Char]) => Future[Done] =
+          override def reEncryptDeviceSecret: (Clients, Array[Char]) => Future[Done] =
             (_, _) => Future.successful(Done)
         }
       )
-      pingFailure <- apiClients.clients.api.ping().failed
+      _ <- apiClients.clients.api.ping() // expected to succeed
       pullFailure <- apiClients.clients.core.pull(Crate.generateId()).failed
+      _ <- serverApiEndpoint.map(_.terminate(100.millis))
     } yield {
       apiClients.clients.api.self should be(deviceId)
       apiClients.clients.api.server should be(apiUrl)
-      pingFailure shouldBe a[StreamTcpException]
-      pingFailure.getMessage should include("Connection refused")
 
       apiClients.clients.core.self should be(coreNodeId)
       apiClients.clients.core.server should be(coreAddress)
+
       pullFailure shouldBe a[StreamTcpException]
-      pingFailure.getMessage should include("Connection refused")
+      pullFailure.getMessage should include("Connection refused")
     }
   }
 
+  "An ApiClients ServiceApiClientFactory" should "support creating API clients" in {
+    val expectedClient = MockServerApiEndpointClient()
+
+    val factory = new ApiClients.ServiceApiClientFactory(
+      createServerCoreEndpointClient = _ => throw new UnsupportedOperationException(),
+      createServerApiEndpointClient = (_, _) => expectedClient,
+      createServiceDiscoveryClient = _ => throw new UnsupportedOperationException()
+    )
+
+    val actualClient = factory.create(
+      endpoint = ServiceApiEndpoint.Api(uri = "test-uri"),
+      coreClient = MockServerCoreEndpointClient()
+    )
+
+    actualClient should be(expectedClient)
+  }
+
+  it should "fail to create API clients if an invalid core client is provided" in {
+    val factory = new ApiClients.ServiceApiClientFactory(
+      createServerCoreEndpointClient = _ => throw new UnsupportedOperationException(),
+      createServerApiEndpointClient = (_, _) => MockServerApiEndpointClient(),
+      createServiceDiscoveryClient = _ => throw new UnsupportedOperationException()
+    )
+
+    val e = intercept[IllegalArgumentException](
+      factory.create(
+        endpoint = ServiceApiEndpoint.Api(uri = "test-uri"),
+        coreClient = new ServiceApiClient {}
+      )
+    )
+
+    e.getMessage should be("Cannot create API endpoint client with core client of type []") // anonymous class; name is empty
+  }
+
+  it should "support creating core clients" in {
+    val expectedClient = MockServerCoreEndpointClient()
+
+    val factory = new ApiClients.ServiceApiClientFactory(
+      createServerCoreEndpointClient = _ => expectedClient,
+      createServerApiEndpointClient = (_, _) => throw new UnsupportedOperationException(),
+      createServiceDiscoveryClient = _ => throw new UnsupportedOperationException()
+    )
+
+    val actualClient = factory.create(
+      endpoint = ServiceApiEndpoint.Core(address = HttpEndpointAddress(uri = "test-uri"))
+    )
+
+    actualClient should be(expectedClient)
+  }
+
+  it should "fail to create core clients if an unsupported core address is provided" in {
+    val expectedClient = MockServerCoreEndpointClient()
+
+    val factory = new ApiClients.ServiceApiClientFactory(
+      createServerCoreEndpointClient = _ => expectedClient,
+      createServerApiEndpointClient = (_, _) => throw new UnsupportedOperationException(),
+      createServiceDiscoveryClient = _ => throw new UnsupportedOperationException()
+    )
+
+    val e = intercept[IllegalArgumentException](
+      factory.create(
+        endpoint = ServiceApiEndpoint.Core(address = GrpcEndpointAddress(host = "localhost", port = 1234, tlsEnabled = false))
+      )
+    )
+
+    e.getMessage should be("Cannot create core endpoint client for address of type [GrpcEndpointAddress]")
+  }
+
+  it should "support creating discovery clients" in {
+    val expectedClient = MockServiceDiscoveryClient()
+
+    val factory = new ApiClients.ServiceApiClientFactory(
+      createServerCoreEndpointClient = _ => throw new UnsupportedOperationException(),
+      createServerApiEndpointClient = (_, _) => throw new UnsupportedOperationException(),
+      createServiceDiscoveryClient = _ => expectedClient
+    )
+
+    val actualClient = factory.create(
+      endpoint = ServiceApiEndpoint.Discovery(uri = "test-uri")
+    )
+
+    actualClient should be(expectedClient)
+  }
+
   private implicit val typedSystem: ActorSystem[Nothing] = ActorSystem(
-    Behaviors.ignore,
-    "ApiClientsSpec"
+    guardianBehavior = Behaviors.ignore,
+    name = "ApiClientsSpec"
   )
 
   private implicit val log: Logger = LoggerFactory.getLogger(this.getClass.getName)
+
+  private implicit val telemetry: MockTelemetryContext = MockTelemetryContext()
+
+  private val ports: mutable.Queue[Int] = (44000 to 44100).to(mutable.Queue)
+
+  private val serverApiEndpointConfigEntry = "stasis.client.server.api.url"
 }

--- a/client/src/test/scala/stasis/test/specs/unit/client/service/components/ApiClientsSpec.scala
+++ b/client/src/test/scala/stasis/test/specs/unit/client/service/components/ApiClientsSpec.scala
@@ -117,7 +117,7 @@ class ApiClientsSpec extends AsyncUnitSpec with ResourceHelpers {
   "An ApiClients ServiceApiClientFactory" should "support creating API clients" in {
     val expectedClient = MockServerApiEndpointClient()
 
-    val factory = new ApiClients.ServiceApiClientFactory(
+    val factory = ApiClients.ServiceApiClientFactory(
       createServerCoreEndpointClient = _ => throw new UnsupportedOperationException(),
       createServerApiEndpointClient = (_, _) => expectedClient,
       createServiceDiscoveryClient = _ => throw new UnsupportedOperationException()
@@ -132,7 +132,7 @@ class ApiClientsSpec extends AsyncUnitSpec with ResourceHelpers {
   }
 
   it should "fail to create API clients if an invalid core client is provided" in {
-    val factory = new ApiClients.ServiceApiClientFactory(
+    val factory = ApiClients.ServiceApiClientFactory(
       createServerCoreEndpointClient = _ => throw new UnsupportedOperationException(),
       createServerApiEndpointClient = (_, _) => MockServerApiEndpointClient(),
       createServiceDiscoveryClient = _ => throw new UnsupportedOperationException()
@@ -151,7 +151,7 @@ class ApiClientsSpec extends AsyncUnitSpec with ResourceHelpers {
   it should "support creating core clients" in {
     val expectedClient = MockServerCoreEndpointClient()
 
-    val factory = new ApiClients.ServiceApiClientFactory(
+    val factory = ApiClients.ServiceApiClientFactory(
       createServerCoreEndpointClient = _ => expectedClient,
       createServerApiEndpointClient = (_, _) => throw new UnsupportedOperationException(),
       createServiceDiscoveryClient = _ => throw new UnsupportedOperationException()
@@ -167,7 +167,7 @@ class ApiClientsSpec extends AsyncUnitSpec with ResourceHelpers {
   it should "fail to create core clients if an unsupported core address is provided" in {
     val expectedClient = MockServerCoreEndpointClient()
 
-    val factory = new ApiClients.ServiceApiClientFactory(
+    val factory = ApiClients.ServiceApiClientFactory(
       createServerCoreEndpointClient = _ => expectedClient,
       createServerApiEndpointClient = (_, _) => throw new UnsupportedOperationException(),
       createServiceDiscoveryClient = _ => throw new UnsupportedOperationException()
@@ -185,7 +185,7 @@ class ApiClientsSpec extends AsyncUnitSpec with ResourceHelpers {
   it should "support creating discovery clients" in {
     val expectedClient = MockServiceDiscoveryClient()
 
-    val factory = new ApiClients.ServiceApiClientFactory(
+    val factory = ApiClients.ServiceApiClientFactory(
       createServerCoreEndpointClient = _ => throw new UnsupportedOperationException(),
       createServerApiEndpointClient = (_, _) => throw new UnsupportedOperationException(),
       createServiceDiscoveryClient = _ => expectedClient

--- a/client/src/test/scala/stasis/test/specs/unit/client/service/components/ApiEndpointSpec.scala
+++ b/client/src/test/scala/stasis/test/specs/unit/client/service/components/ApiEndpointSpec.scala
@@ -22,7 +22,6 @@ import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
 import stasis.client.api.clients.Clients
-import stasis.client.api.clients.ServerApiEndpointClient
 import stasis.client.encryption.Aes
 import stasis.client.encryption.secrets.DeviceSecret
 import stasis.client.ops.commands.CommandProcessor
@@ -234,10 +233,9 @@ class ApiEndpointSpec extends AsyncUnitSpec with ResourceHelpers {
         override def commandProcessor: CommandProcessor = MockCommandProcessor()
       },
       secrets = new MockSecrets {
-        override def updateUserCredentials: (ServerApiEndpointClient, Array[Char], String) => Future[Done] = {
-          case (api, password, salt) =>
-            val _ = credentialsUpdated.set(true)
-            super.updateUserCredentials(api, password, salt)
+        override def updateUserCredentials: (Clients, Array[Char], String) => Future[Done] = { case (clients, password, salt) =>
+          val _ = credentialsUpdated.set(true)
+          super.updateUserCredentials(clients, password, salt)
         }
       }
     ).map { endpoint =>
@@ -283,9 +281,9 @@ class ApiEndpointSpec extends AsyncUnitSpec with ResourceHelpers {
         override def commandProcessor: CommandProcessor = MockCommandProcessor()
       },
       secrets = new MockSecrets {
-        override def reEncryptDeviceSecret: (ServerApiEndpointClient, Array[Char]) => Future[Done] = { case (api, password) =>
+        override def reEncryptDeviceSecret: (Clients, Array[Char]) => Future[Done] = { case (clients, password) =>
           val _ = secretReEncrypted.set(true)
-          super.reEncryptDeviceSecret(api, password)
+          super.reEncryptDeviceSecret(clients, password)
         }
       }
     ).map { endpoint =>
@@ -411,9 +409,8 @@ class ApiEndpointSpec extends AsyncUnitSpec with ResourceHelpers {
 
     override def verifyUserPassword: Array[Char] => Boolean = _ => false
 
-    override def updateUserCredentials: (ServerApiEndpointClient, Array[Char], String) => Future[Done] = (_, _, _) =>
-      Future.successful(Done)
+    override def updateUserCredentials: (Clients, Array[Char], String) => Future[Done] = (_, _, _) => Future.successful(Done)
 
-    override def reEncryptDeviceSecret: (ServerApiEndpointClient, Array[Char]) => Future[Done] = (_, _) => Future.successful(Done)
+    override def reEncryptDeviceSecret: (Clients, Array[Char]) => Future[Done] = (_, _) => Future.successful(Done)
   }
 }

--- a/client/src/test/scala/stasis/test/specs/unit/client/service/components/OpsSpec.scala
+++ b/client/src/test/scala/stasis/test/specs/unit/client/service/components/OpsSpec.scala
@@ -18,7 +18,6 @@ import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
 import stasis.client.api.clients.Clients
-import stasis.client.api.clients.ServerApiEndpointClient
 import stasis.client.encryption.Aes
 import stasis.client.encryption.secrets.DeviceSecret
 import stasis.client.security.CredentialsProvider
@@ -86,10 +85,10 @@ class OpsSpec extends AsyncUnitSpec with ResourceHelpers with Eventually {
 
         override def verifyUserPassword: Array[Char] => Boolean = _ => false
 
-        override def updateUserCredentials: (ServerApiEndpointClient, Array[Char], String) => Future[Done] =
+        override def updateUserCredentials: (Clients, Array[Char], String) => Future[Done] =
           (_, _, _) => Future.successful(Done)
 
-        override def reEncryptDeviceSecret: (ServerApiEndpointClient, Array[Char]) => Future[Done] =
+        override def reEncryptDeviceSecret: (Clients, Array[Char]) => Future[Done] =
           (_, _) => Future.successful(Done)
       }
     ).map { ops =>

--- a/client/src/test/scala/stasis/test/specs/unit/client/service/components/SecretsSpec.scala
+++ b/client/src/test/scala/stasis/test/specs/unit/client/service/components/SecretsSpec.scala
@@ -12,6 +12,7 @@ import org.apache.pekko.util.ByteString
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
+import stasis.client.api.clients.Clients
 import stasis.client.service.ApplicationDirectory
 import stasis.client.service.ApplicationTray
 import stasis.client.service.components.Base
@@ -91,7 +92,7 @@ class SecretsSpec extends AsyncUnitSpec with ResourceHelpers with EncodingHelper
       newPasswordValidBeforeUpdate = secrets.verifyUserPassword(newPassword)
       existingDeviceSecret <- directory.pullFile[ByteString](Files.DeviceSecret)
       existingSalt = ConfigOverride.load(directory).getString(userSaltConfigEntry)
-      _ <- secrets.updateUserCredentials(apiClient, newPassword, newSalt)
+      _ <- secrets.updateUserCredentials(Clients(api = apiClient, core = null), newPassword, newSalt)
       updatedDeviceSecret <- directory.pullFile[ByteString](Files.DeviceSecret)
       updatedSalt = ConfigOverride.load(directory).getString(userSaltConfigEntry)
       currentPasswordValidAfterUpdate = secrets.verifyUserPassword(password)
@@ -131,7 +132,7 @@ class SecretsSpec extends AsyncUnitSpec with ResourceHelpers with EncodingHelper
       newPasswordValidBeforeUpdate = secrets.verifyUserPassword(newPassword)
       existingDeviceSecret <- directory.pullFile[ByteString](Files.DeviceSecret)
       existingSalt = ConfigOverride.load(directory).getString(userSaltConfigEntry)
-      _ <- secrets.updateUserCredentials(apiClient, newPassword, newSalt)
+      _ <- secrets.updateUserCredentials(Clients(api = apiClient, core = null), newPassword, newSalt)
       updatedDeviceSecret <- directory.pullFile[ByteString](Files.DeviceSecret)
       updatedSalt = ConfigOverride.load(directory).getString(userSaltConfigEntry)
       currentPasswordValidAfterUpdate = secrets.verifyUserPassword(password)
@@ -168,7 +169,7 @@ class SecretsSpec extends AsyncUnitSpec with ResourceHelpers with EncodingHelper
       base <- Base(applicationDirectory = directory, applicationTray = ApplicationTray.NoOp(), terminate = () => ())
       secrets <- Secrets(base = base, init = () => Future.successful((username, password)))
       existingDeviceSecret <- directory.pullFile[ByteString](Files.DeviceSecret)
-      _ <- secrets.reEncryptDeviceSecret(apiClient, newPassword)
+      _ <- secrets.reEncryptDeviceSecret(Clients(api = apiClient, core = null), newPassword)
       updatedDeviceSecret <- directory.pullFile[ByteString](Files.DeviceSecret)
     } yield {
       endpoint.stop()
@@ -195,7 +196,7 @@ class SecretsSpec extends AsyncUnitSpec with ResourceHelpers with EncodingHelper
       base <- Base(applicationDirectory = directory, applicationTray = ApplicationTray.NoOp(), terminate = () => ())
       secrets <- Secrets(base = base, init = () => Future.successful((username, password)))
       existingDeviceSecret <- directory.pullFile[ByteString](Files.DeviceSecret)
-      _ <- secrets.reEncryptDeviceSecret(apiClient, newPassword)
+      _ <- secrets.reEncryptDeviceSecret(Clients(api = apiClient, core = null), newPassword)
       updatedDeviceSecret <- directory.pullFile[ByteString](Files.DeviceSecret)
     } yield {
       endpoint.stop()

--- a/client/src/test/scala/stasis/test/specs/unit/client/service/components/bootstrap/BootstrapSpec.scala
+++ b/client/src/test/scala/stasis/test/specs/unit/client/service/components/bootstrap/BootstrapSpec.scala
@@ -124,19 +124,19 @@ class BootstrapSpec extends AsyncUnitSpec with ResourceHelpers with AsyncMockito
         api = "urn:stasis:identity:audience:server-api",
         core = s"urn:stasis:identity:audience:${Node.generateId().toString}"
       ),
-      context = DeviceBootstrapParameters.Context.disabled()
+      context = EndpointContext.Encoded.disabled()
     ),
     serverApi = DeviceBootstrapParameters.ServerApi(
       url = "http://localhost:5678",
       user = User.generateId().toString,
       userSalt = "test-salt",
       device = Device.generateId().toString,
-      context = DeviceBootstrapParameters.Context.disabled()
+      context = EndpointContext.Encoded.disabled()
     ),
     serverCore = DeviceBootstrapParameters.ServerCore(
       address = "http://localhost:5679",
       nodeId = Node.generateId().toString,
-      context = DeviceBootstrapParameters.Context.disabled()
+      context = EndpointContext.Encoded.disabled()
     ),
     secrets = Fixtures.Secrets.DefaultConfig,
     additionalConfig = Json.obj()

--- a/client/src/test/scala/stasis/test/specs/unit/client/service/components/bootstrap/ParametersSpec.scala
+++ b/client/src/test/scala/stasis/test/specs/unit/client/service/components/bootstrap/ParametersSpec.scala
@@ -159,9 +159,9 @@ class ParametersSpec extends AsyncUnitSpec with ResourceHelpers {
     val temporaryPassword = "test-password"
 
     val original = EndpointContext.loadStore(config)
-    val encoded = DeviceBootstrapParameters.Context.encodeKeyStore(original, temporaryPassword, config.storeType)
+    val encoded = EndpointContext.Encoded.encodeKeyStore(original, temporaryPassword, config.storeType)
 
-    val context = DeviceBootstrapParameters.Context(
+    val context = EndpointContext.Encoded(
       enabled = true,
       protocol = "TLS",
       storeType = config.storeType,
@@ -200,9 +200,9 @@ class ParametersSpec extends AsyncUnitSpec with ResourceHelpers {
     val temporaryPassword = "test-password"
 
     val original = EndpointContext.loadStore(config)
-    val encoded = DeviceBootstrapParameters.Context.encodeKeyStore(original, temporaryPassword, config.storeType)
+    val encoded = EndpointContext.Encoded.encodeKeyStore(original, temporaryPassword, config.storeType)
 
-    val context = DeviceBootstrapParameters.Context(
+    val context = EndpointContext.Encoded(
       enabled = true,
       protocol = "TLS",
       storeType = config.storeType,
@@ -305,9 +305,9 @@ class ParametersSpec extends AsyncUnitSpec with ResourceHelpers {
     val temporaryPassword = "test-password"
 
     val original = EndpointContext.loadStore(config)
-    val encoded = DeviceBootstrapParameters.Context.encodeKeyStore(original, temporaryPassword, config.storeType)
+    val encoded = EndpointContext.Encoded.encodeKeyStore(original, temporaryPassword, config.storeType)
 
-    val context = DeviceBootstrapParameters.Context(
+    val context = EndpointContext.Encoded(
       enabled = false,
       protocol = "TLS",
       storeType = config.storeType,
@@ -344,19 +344,19 @@ class ParametersSpec extends AsyncUnitSpec with ResourceHelpers {
         api = "urn:stasis:identity:audience:server-api",
         core = s"urn:stasis:identity:audience:${Node.generateId().toString}"
       ),
-      context = DeviceBootstrapParameters.Context.disabled()
+      context = EndpointContext.Encoded.disabled()
     ),
     serverApi = DeviceBootstrapParameters.ServerApi(
       url = "http://localhost:5678",
       user = User.generateId().toString,
       userSalt = "test-salt",
       device = Device.generateId().toString,
-      context = DeviceBootstrapParameters.Context.disabled()
+      context = EndpointContext.Encoded.disabled()
     ),
     serverCore = DeviceBootstrapParameters.ServerCore(
       address = "http://localhost:5679",
       nodeId = Node.generateId().toString,
-      context = DeviceBootstrapParameters.Context.disabled()
+      context = EndpointContext.Encoded.disabled()
     ),
     secrets = Fixtures.Secrets.DefaultConfig,
     additionalConfig = Json.obj()

--- a/core/src/main/scala/stasis/core/discovery/ServiceApiClient.scala
+++ b/core/src/main/scala/stasis/core/discovery/ServiceApiClient.scala
@@ -1,0 +1,11 @@
+package stasis.core.discovery
+
+trait ServiceApiClient
+
+object ServiceApiClient {
+  trait Factory {
+    def create(endpoint: ServiceApiEndpoint.Api, coreClient: ServiceApiClient): ServiceApiClient
+    def create(endpoint: ServiceApiEndpoint.Core): ServiceApiClient
+    def create(endpoint: ServiceApiEndpoint.Discovery): ServiceApiClient
+  }
+}

--- a/core/src/main/scala/stasis/core/discovery/ServiceApiEndpoint.scala
+++ b/core/src/main/scala/stasis/core/discovery/ServiceApiEndpoint.scala
@@ -1,0 +1,28 @@
+package stasis.core.discovery
+
+import stasis.core.networking.EndpointAddress
+import stasis.core.networking.grpc.GrpcEndpointAddress
+import stasis.core.networking.http.HttpEndpointAddress
+
+sealed trait ServiceApiEndpoint {
+  def id: String
+}
+
+object ServiceApiEndpoint {
+  final case class Api(uri: String) extends ServiceApiEndpoint {
+    override lazy val id: String = s"api__$uri"
+  }
+
+  final case class Core(address: EndpointAddress) extends ServiceApiEndpoint {
+    @SuppressWarnings(Array("org.wartremover.warts.Throw"))
+    override lazy val id: String = address match {
+      case HttpEndpointAddress(uri)           => s"core_http__${uri.toString}"
+      case GrpcEndpointAddress(host, port, _) => s"core_grpc__$host:${port.toString}"
+      case other => throw new IllegalArgumentException(s"Unexpected address provided: [${other.getClass.getSimpleName}]")
+    }
+  }
+
+  final case class Discovery(uri: String) extends ServiceApiEndpoint {
+    override lazy val id: String = s"discovery__$uri"
+  }
+}

--- a/core/src/main/scala/stasis/core/discovery/ServiceDiscoveryClient.scala
+++ b/core/src/main/scala/stasis/core/discovery/ServiceDiscoveryClient.scala
@@ -1,0 +1,20 @@
+package stasis.core.discovery
+
+import scala.concurrent.Future
+
+trait ServiceDiscoveryClient extends ServiceApiClient {
+  def attributes: ServiceDiscoveryClient.Attributes
+  def latest(isInitialRequest: Boolean): Future[ServiceDiscoveryResult]
+}
+
+object ServiceDiscoveryClient {
+  trait Attributes { self: Product =>
+    def asServiceDiscoveryRequest(isInitialRequest: Boolean): ServiceDiscoveryRequest =
+      ServiceDiscoveryRequest(
+        isInitialRequest = isInitialRequest,
+        attributes = productIterator.zipWithIndex.map { case (value, i) =>
+          productElementName(i) -> value.toString
+        }.toMap
+      )
+  }
+}

--- a/core/src/main/scala/stasis/core/discovery/ServiceDiscoveryRequest.scala
+++ b/core/src/main/scala/stasis/core/discovery/ServiceDiscoveryRequest.scala
@@ -1,0 +1,11 @@
+package stasis.core.discovery
+
+final case class ServiceDiscoveryRequest(
+  isInitialRequest: Boolean,
+  attributes: Map[String, String]
+) {
+  lazy val id: String = attributes.toList
+    .sortBy(_._1)
+    .map { case (k, v) => s"$k=$v" }
+    .mkString("::")
+}

--- a/core/src/main/scala/stasis/core/discovery/ServiceDiscoveryResult.scala
+++ b/core/src/main/scala/stasis/core/discovery/ServiceDiscoveryResult.scala
@@ -1,0 +1,29 @@
+package stasis.core.discovery
+
+sealed trait ServiceDiscoveryResult {
+  def asString: String
+}
+
+object ServiceDiscoveryResult {
+  final case object KeepExisting extends ServiceDiscoveryResult {
+    override lazy val asString: String = "result=keep-existing"
+  }
+
+  final case class SwitchTo(
+    endpoints: Endpoints,
+    recreateExisting: Boolean
+  ) extends ServiceDiscoveryResult {
+    override lazy val asString: String =
+      s"result=switch-to," +
+        s"endpoints=${endpoints.asString}," +
+        s"recreate-existing=${recreateExisting.toString}"
+  }
+
+  final case class Endpoints(
+    api: ServiceApiEndpoint.Api,
+    core: ServiceApiEndpoint.Core,
+    discovery: ServiceApiEndpoint.Discovery
+  ) {
+    lazy val asString: String = Seq(api.id, core.id, discovery.id).mkString(";")
+  }
+}

--- a/core/src/main/scala/stasis/core/discovery/exceptions/DiscoveryFailure.scala
+++ b/core/src/main/scala/stasis/core/discovery/exceptions/DiscoveryFailure.scala
@@ -1,0 +1,3 @@
+package stasis.core.discovery.exceptions
+
+class DiscoveryFailure(val message: String) extends Exception(message)

--- a/core/src/main/scala/stasis/core/discovery/http/HttpServiceDiscoveryClient.scala
+++ b/core/src/main/scala/stasis/core/discovery/http/HttpServiceDiscoveryClient.scala
@@ -1,0 +1,120 @@
+package stasis.core.discovery.http
+
+import scala.concurrent.Future
+import scala.util.control.NonFatal
+
+import org.apache.pekko.actor.typed.ActorSystem
+import org.apache.pekko.http.scaladsl.marshalling.Marshal
+import org.apache.pekko.http.scaladsl.model._
+import org.apache.pekko.http.scaladsl.model.headers.HttpCredentials
+import org.apache.pekko.http.scaladsl.unmarshalling.Unmarshal
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import play.api.libs.json.Format
+
+import stasis.core.api.PoolClient
+import stasis.core.discovery.ServiceDiscoveryClient
+import stasis.core.discovery.ServiceDiscoveryResult
+import stasis.core.discovery.exceptions.DiscoveryFailure
+import stasis.layers.security.tls.EndpointContext
+import stasis.layers.streaming.Operators.ExtendedSource
+
+class HttpServiceDiscoveryClient(
+  apiUrl: String,
+  credentials: => Future[HttpCredentials],
+  override val attributes: ServiceDiscoveryClient.Attributes,
+  override protected val context: Option[EndpointContext],
+  override protected val config: PoolClient.Config
+)(
+  override protected implicit val system: ActorSystem[Nothing]
+) extends ServiceDiscoveryClient
+    with PoolClient {
+  import system.executionContext
+
+  import HttpServiceDiscoveryClient._
+  import stasis.core.api.Formats.serviceDiscoveryRequestFormat
+  import stasis.core.api.Formats.serviceDiscoveryResultFormat
+
+  override protected val log: Logger = LoggerFactory.getLogger(this.getClass.getName)
+
+  override def latest(isInitialRequest: Boolean): Future[ServiceDiscoveryResult] = {
+    import com.github.pjfanning.pekkohttpplayjson.PlayJsonSupport._
+
+    for {
+      credentials <- credentials
+      entity <- Marshal(attributes.asServiceDiscoveryRequest(isInitialRequest)).to[RequestEntity]
+      response <- offer(
+        request = HttpRequest(
+          method = HttpMethods.POST,
+          uri = s"$apiUrl/v1/discovery/provide",
+          entity = entity
+        ).addCredentials(credentials = credentials)
+      )
+      result <- response.to[ServiceDiscoveryResult]
+    } yield {
+      result
+    }
+  }
+}
+
+object HttpServiceDiscoveryClient {
+  def apply(
+    apiUrl: String,
+    credentials: => Future[HttpCredentials],
+    attributes: ServiceDiscoveryClient.Attributes,
+    context: Option[EndpointContext]
+  )(implicit system: ActorSystem[Nothing]): HttpServiceDiscoveryClient =
+    HttpServiceDiscoveryClient(
+      apiUrl = apiUrl,
+      credentials = credentials,
+      attributes = attributes,
+      context = context,
+      config = PoolClient.Config.Default
+    )
+
+  def apply(
+    apiUrl: String,
+    credentials: => Future[HttpCredentials],
+    attributes: ServiceDiscoveryClient.Attributes,
+    context: Option[EndpointContext],
+    config: PoolClient.Config
+  )(implicit system: ActorSystem[Nothing]): HttpServiceDiscoveryClient =
+    new HttpServiceDiscoveryClient(
+      apiUrl = apiUrl,
+      credentials = credentials,
+      attributes = attributes,
+      context = context,
+      config = config
+    )
+
+  implicit class ExtendedResponseEntity(response: HttpResponse) {
+    def to[M](implicit format: Format[M], system: ActorSystem[Nothing]): Future[M] = {
+      import system.executionContext
+
+      if (response.status.isSuccess()) {
+        import com.github.pjfanning.pekkohttpplayjson.PlayJsonSupport._
+        Unmarshal(response)
+          .to[M]
+          .recoverWith { case NonFatal(e) =>
+            response.entity.dataBytes.cancelled().flatMap { _ =>
+              Future.failed(
+                new DiscoveryFailure(
+                  message = s"Discovery API request unmarshalling failed with: [${e.getMessage}]"
+                )
+              )
+            }
+          }
+      } else {
+        Unmarshal(response)
+          .to[String]
+          .flatMap { responseContent =>
+            Future.failed(
+              new DiscoveryFailure(
+                message = s"Discovery API request failed with [${response.status.value}]: [$responseContent]"
+              )
+            )
+          }
+      }
+    }
+  }
+}

--- a/core/src/main/scala/stasis/core/discovery/http/HttpServiceDiscoveryEndpoint.scala
+++ b/core/src/main/scala/stasis/core/discovery/http/HttpServiceDiscoveryEndpoint.scala
@@ -1,0 +1,39 @@
+package stasis.core.discovery.http
+
+import org.apache.pekko.actor.typed.scaladsl.LoggerOps
+import org.apache.pekko.http.scaladsl.server.Directives._
+import org.apache.pekko.http.scaladsl.server._
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+
+import stasis.core.discovery.ServiceDiscoveryRequest
+import stasis.core.discovery.providers.server.ServiceDiscoveryProvider
+import stasis.layers.api.directives.EntityDiscardingDirectives
+
+class HttpServiceDiscoveryEndpoint(
+  provider: ServiceDiscoveryProvider
+) extends EntityDiscardingDirectives {
+  import com.github.pjfanning.pekkohttpplayjson.PlayJsonSupport._
+
+  import stasis.core.api.Formats.serviceDiscoveryRequestFormat
+  import stasis.core.api.Formats.serviceDiscoveryResultFormat
+
+  private val log: Logger = LoggerFactory.getLogger(this.getClass.getName)
+
+  val routes: Route = concat(
+    path("provide") {
+      post {
+        entity(as[ServiceDiscoveryRequest]) { request =>
+          onSuccess(provider.provide(request)) { result =>
+            log.debugN(
+              "Successfully retrieved service discovery information [{}] for request [{}]",
+              result.asString,
+              request.id
+            )
+            discardEntity & complete(result)
+          }
+        }
+      }
+    }
+  )
+}

--- a/core/src/main/scala/stasis/core/discovery/providers/client/ServiceDiscoveryProvider.scala
+++ b/core/src/main/scala/stasis/core/discovery/providers/client/ServiceDiscoveryProvider.scala
@@ -1,0 +1,169 @@
+package stasis.core.discovery.providers.client
+
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.ThreadLocalRandom
+
+import scala.concurrent.Future
+import scala.concurrent.duration.FiniteDuration
+import scala.concurrent.duration._
+import scala.jdk.CollectionConverters._
+import scala.reflect.ClassTag
+import scala.util.Failure
+import scala.util.Random
+import scala.util.Success
+
+import org.apache.pekko.actor.typed.ActorSystem
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+
+import stasis.core.discovery.ServiceApiClient
+import stasis.core.discovery.ServiceDiscoveryClient
+import stasis.core.discovery.ServiceDiscoveryResult
+import stasis.core.discovery.exceptions.DiscoveryFailure
+
+trait ServiceDiscoveryProvider {
+  def latest[T <: ServiceApiClient](implicit tag: ClassTag[T]): T
+}
+
+object ServiceDiscoveryProvider {
+  class Disabled(
+    initialClients: Seq[ServiceApiClient]
+  ) extends ServiceDiscoveryProvider {
+    override def latest[T <: ServiceApiClient](implicit tag: ClassTag[T]): T =
+      extractClient[T](from = initialClients)
+  }
+
+  class Default(
+    interval: FiniteDuration,
+    initialClients: Map[String, ServiceApiClient],
+    clientFactory: ServiceApiClient.Factory
+  )(implicit system: ActorSystem[Nothing], log: Logger)
+      extends ServiceDiscoveryProvider {
+    import system.executionContext
+
+    private val clients: ConcurrentHashMap[String, ServiceApiClient] = new ConcurrentHashMap(initialClients.asJava)
+
+    scheduleNext(after = fullInterval())
+
+    override def latest[T <: ServiceApiClient](implicit tag: ClassTag[T]): T = {
+      val rnd = Random.javaRandomToRandom(ThreadLocalRandom.current())
+
+      val collected = clients.asScala.values.collect { case client: T => client }
+
+      extractClient[T](from = rnd.shuffle(collected))
+    }
+
+    private def scheduleNext(after: FiniteDuration): Unit = {
+      log.debug("Scheduling next service discovery in [{}] second(s)", after.toSeconds)
+
+      org.apache.pekko.pattern
+        .after(duration = after)(
+          discoverServices(
+            client = extractClient[ServiceDiscoveryClient](from = clients.values().asScala),
+            isInitialRequest = false
+          )
+        )
+        .onComplete {
+          case Success(ServiceDiscoveryResult.KeepExisting) =>
+            log.debug("Service discovery did not provide new endpoints")
+
+            scheduleNext(fullInterval())
+
+          case Success(ServiceDiscoveryResult.SwitchTo(endpoints, recreateExisting)) =>
+            log.debug(
+              "Service discovery provided endpoints [api={},core={},discovery={}] with [recreateExisting={}]",
+              endpoints.api.id,
+              endpoints.core.id,
+              endpoints.discovery.id,
+              recreateExisting
+            )
+
+            if (recreateExisting) {
+              clients.clear()
+
+              val core = clientFactory.create(endpoints.core)
+              val _ = clients.put(endpoints.core.id, core)
+              val _ = clients.put(endpoints.api.id, clientFactory.create(endpoints.api, core))
+              val _ = clients.put(endpoints.discovery.id, clientFactory.create(endpoints.discovery))
+            } else {
+              val core = clients.computeIfAbsent(endpoints.core.id, _ => clientFactory.create(endpoints.core))
+              val _ = clients.computeIfAbsent(endpoints.api.id, _ => clientFactory.create(endpoints.api, core))
+              val _ = clients.computeIfAbsent(endpoints.discovery.id, _ => clientFactory.create(endpoints.discovery))
+
+              clients.keySet.asScala
+                .filter(k => k != endpoints.core.id && k != endpoints.api.id && k != endpoints.discovery.id)
+                .foreach(clients.remove)
+            }
+
+            scheduleNext(fullInterval())
+
+          case Failure(e) =>
+            log.error("Service discovery failed with [{} - {}]", e.getClass.getSimpleName, e.getMessage)
+
+            scheduleNext(reducedInterval())
+        }
+    }
+
+    private def fullInterval(): FiniteDuration =
+      fuzzyInterval(interval = interval)
+
+    private def reducedInterval(): FiniteDuration =
+      fuzzyInterval(interval = interval / FailureIntervalReduction)
+
+    private def fuzzyInterval(interval: FiniteDuration): FiniteDuration = {
+      val intervalMs = interval.toMillis
+      val low = (intervalMs - (intervalMs * 0.02)).toLong
+      val high = (intervalMs + (intervalMs * 0.03)).toLong
+
+      ThreadLocalRandom.current().nextLong(low, high).millis
+    }
+  }
+
+  def apply(
+    interval: FiniteDuration,
+    initialClients: Seq[ServiceApiClient],
+    clientFactory: ServiceApiClient.Factory
+  )(implicit system: ActorSystem[Nothing]): Future[ServiceDiscoveryProvider] = {
+    import system.executionContext
+
+    implicit val log: Logger = LoggerFactory.getLogger(this.getClass.getName)
+
+    discoverServices(client = extractClient[ServiceDiscoveryClient](from = initialClients), isInitialRequest = true).map {
+      case ServiceDiscoveryResult.KeepExisting =>
+        log.debug("Initial service discovery did not provide any endpoints; discovery disabled")
+        new Disabled(initialClients = initialClients)
+
+      case ServiceDiscoveryResult.SwitchTo(endpoints, _) =>
+        log.debug(
+          "Initial service discovery provided endpoints [api={},core={},discovery={}]",
+          endpoints.api.id,
+          endpoints.core.id,
+          endpoints.discovery.id
+        )
+
+        val core = clientFactory.create(endpoints.core)
+
+        new Default(
+          interval = interval,
+          initialClients = Map(
+            endpoints.core.id -> core,
+            endpoints.api.id -> clientFactory.create(endpoints.api, core),
+            endpoints.discovery.id -> clientFactory.create(endpoints.discovery)
+          ),
+          clientFactory = clientFactory
+        )
+    }
+  }
+
+  private def discoverServices(client: ServiceDiscoveryClient, isInitialRequest: Boolean): Future[ServiceDiscoveryResult] =
+    client.latest(isInitialRequest)
+
+  @SuppressWarnings(Array("org.wartremover.warts.Throw"))
+  private def extractClient[T <: ServiceApiClient](from: Iterable[ServiceApiClient])(implicit tag: ClassTag[T]): T =
+    from.collectFirst { case client: T => client } match {
+      case Some(client) => client
+      case None         => throw new DiscoveryFailure(s"Service client [${tag.toString()}] was not found")
+    }
+
+  final val FailureIntervalReduction: Long = 10L
+}

--- a/core/src/main/scala/stasis/core/discovery/providers/server/ServiceDiscoveryProvider.scala
+++ b/core/src/main/scala/stasis/core/discovery/providers/server/ServiceDiscoveryProvider.scala
@@ -1,0 +1,141 @@
+package stasis.core.discovery.providers.server
+
+import java.io.File
+import java.util.concurrent.ConcurrentHashMap
+
+import scala.concurrent.Future
+import scala.jdk.CollectionConverters._
+
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import stasis.core.discovery.ServiceApiEndpoint
+import stasis.core.discovery.ServiceDiscoveryRequest
+import stasis.core.discovery.ServiceDiscoveryResult
+import stasis.core.networking.grpc.GrpcEndpointAddress
+import stasis.core.networking.http.HttpEndpointAddress
+
+trait ServiceDiscoveryProvider {
+  def provide(request: ServiceDiscoveryRequest): Future[ServiceDiscoveryResult]
+}
+
+object ServiceDiscoveryProvider {
+  @SuppressWarnings(Array("org.wartremover.warts.Throw"))
+  def apply(config: com.typesafe.config.Config): ServiceDiscoveryProvider =
+    config.getString("type").trim.toLowerCase match {
+      case "disabled" =>
+        new Disabled()
+
+      case "static" =>
+        val configFile = config.getString("static.config").trim
+        require(configFile.nonEmpty, "Static discovery enabled but no config file was provided")
+
+        val endpointsConfig = com.typesafe.config.ConfigFactory
+          .parseFile(
+            Option(getClass.getClassLoader.getResource(configFile))
+              .map(resource => new File(resource.getFile))
+              .getOrElse(new File(configFile))
+          )
+          .resolve()
+          .getConfig("endpoints")
+
+        new Static(endpoints = Static.Endpoints(config = endpointsConfig))
+
+      case other =>
+        throw new IllegalArgumentException(s"Unexpected provider type specified: [$other]")
+    }
+
+  class Disabled extends ServiceDiscoveryProvider {
+    override def provide(request: ServiceDiscoveryRequest): Future[ServiceDiscoveryResult] =
+      Future.successful(ServiceDiscoveryResult.KeepExisting)
+  }
+
+  class Static(endpoints: Static.Endpoints) extends ServiceDiscoveryProvider {
+    private val clients: ConcurrentHashMap.KeySetView[String, _] = ConcurrentHashMap.newKeySet()
+
+    private val log: Logger = LoggerFactory.getLogger(this.getClass.getName)
+
+    log.debug(
+      "Service discovery enabled with endpoints [{}]",
+      (endpoints.api.map(_.id) ++ endpoints.core.map(_.id) ++ endpoints.discovery.map(_.id))
+        .mkString("\n\t", "\n\t", "\n")
+    )
+
+    override def provide(request: ServiceDiscoveryRequest): Future[ServiceDiscoveryResult] =
+      Future.successful(
+        if (request.isInitialRequest || !clients.contains(request.id)) {
+          val _ = clients.add(request.id)
+          ServiceDiscoveryResult.SwitchTo(
+            endpoints = endpoints.select(forRequestId = request.id),
+            recreateExisting = false
+          )
+        } else {
+          ServiceDiscoveryResult.KeepExisting
+        }
+      )
+  }
+
+  object Static {
+    final case class Endpoints(
+      api: Seq[ServiceApiEndpoint.Api],
+      core: Seq[ServiceApiEndpoint.Core],
+      discovery: Seq[ServiceApiEndpoint.Discovery]
+    ) {
+      require(api.nonEmpty, "At least one API endpoint must be configured")
+      require(core.nonEmpty, "At least one core endpoint must be configured")
+
+      def select(forRequestId: String): ServiceDiscoveryResult.Endpoints = {
+        val hash = forRequestId.hashCode
+
+        val selectedApi = api(Math.abs(hash % api.length))
+        val selectedCore = core(Math.abs(hash % core.length))
+        val selectedDiscovery = if (discovery.isEmpty) {
+          ServiceApiEndpoint.Discovery(uri = selectedApi.uri)
+        } else {
+          discovery(Math.abs(hash % discovery.length))
+        }
+
+        ServiceDiscoveryResult.Endpoints(
+          api = selectedApi,
+          core = selectedCore,
+          discovery = selectedDiscovery
+        )
+      }
+    }
+
+    object Endpoints {
+      @SuppressWarnings(Array("org.wartremover.warts.Throw"))
+      def apply(config: com.typesafe.config.Config): Endpoints =
+        Endpoints(
+          api = config.getConfigList("api").asScala.toSeq.map { endpointConfig =>
+            ServiceApiEndpoint.Api(uri = endpointConfig.getString("uri"))
+          },
+          core = config.getConfigList("core").asScala.toSeq.map { endpointConfig =>
+            endpointConfig.getString("type").trim.toLowerCase match {
+              case "http" =>
+                ServiceApiEndpoint.Core(
+                  address = HttpEndpointAddress(
+                    uri = endpointConfig.getString("http.uri")
+                  )
+                )
+
+              case "grpc" =>
+                ServiceApiEndpoint.Core(
+                  address = GrpcEndpointAddress(
+                    host = endpointConfig.getString("grpc.host"),
+                    port = endpointConfig.getInt("grpc.port"),
+                    tlsEnabled = endpointConfig.getBoolean("grpc.tls-enabled")
+                  )
+                )
+
+              case other =>
+                throw new IllegalArgumentException(s"Unexpected endpoint type specified: [$other]")
+
+            }
+          },
+          discovery = config.getConfigList("discovery").asScala.toSeq.map { endpointConfig =>
+            ServiceApiEndpoint.Discovery(uri = endpointConfig.getString("uri"))
+          }
+        )
+    }
+  }
+}

--- a/core/src/test/resources/application.conf
+++ b/core/src/test/resources/application.conf
@@ -104,6 +104,34 @@ stasis {
           }
         }
       }
+
+      discovery {
+        server {
+          provider-disabled {
+            type = "disabled"
+          }
+
+          provider-static {
+            type = "static"
+
+            static {
+              config = "discovery-static.conf"
+            }
+          }
+
+          provider-static-no-config {
+            type = "static"
+
+            static {
+              config = ""
+            }
+          }
+
+          provider-invalid {
+            type = "other"
+          }
+        }
+      }
     }
   }
 }

--- a/core/src/test/resources/discovery-static-invalid.conf
+++ b/core/src/test/resources/discovery-static-invalid.conf
@@ -1,0 +1,22 @@
+endpoints {
+  api = [
+    {
+      uri = "http://localhost:10000"
+    }
+  ]
+
+  core = [
+    {
+      type = "http"
+
+      http {
+        uri = "http://localhost:20001"
+      }
+    },
+    {
+      type = "other"
+    }
+  ]
+
+  discovery = []
+}

--- a/core/src/test/resources/discovery-static.conf
+++ b/core/src/test/resources/discovery-static.conf
@@ -1,0 +1,54 @@
+endpoints {
+  api = [
+    {
+      uri = "http://localhost:10000"
+    },
+    {
+      uri = "http://localhost:20000"
+    },
+    {
+      uri = "http://localhost:30000"
+    }
+  ]
+
+  core = [
+    {
+      type = "http"
+
+      http {
+        uri = "http://localhost:10001"
+      }
+
+      grpc {
+        host = "localhost"
+        port = 10001
+        tls-enabled = false
+      }
+    },
+    {
+      type = "http"
+
+      http {
+        uri = "http://localhost:20001"
+      }
+    },
+    {
+      type = "grpc"
+
+      grpc {
+        host = "localhost"
+        port = 30001
+        tls-enabled = false
+      }
+    }
+  ]
+
+  discovery = [
+    {
+      uri = "http://localhost:10002"
+    },
+    {
+      uri = "http://localhost:20002"
+    },
+  ]
+}

--- a/core/src/test/scala/stasis/test/specs/unit/core/discovery/ServiceApiEndpointSpec.scala
+++ b/core/src/test/scala/stasis/test/specs/unit/core/discovery/ServiceApiEndpointSpec.scala
@@ -1,0 +1,29 @@
+package stasis.test.specs.unit.core.discovery
+
+import stasis.core.discovery.ServiceApiEndpoint
+import stasis.core.networking.EndpointAddress
+import stasis.core.networking.grpc.GrpcEndpointAddress
+import stasis.core.networking.http.HttpEndpointAddress
+import stasis.layers.UnitSpec
+
+class ServiceApiEndpointSpec extends UnitSpec {
+  "A ServiceApiEndpoint" should "support providing an ID" in {
+    ServiceApiEndpoint.Api(uri = "test-uri").id should be("api__test-uri")
+
+    ServiceApiEndpoint
+      .Core(
+        address = HttpEndpointAddress(uri = "test-uri")
+      )
+      .id should be("core_http__test-uri")
+
+    ServiceApiEndpoint
+      .Core(
+        address = GrpcEndpointAddress(host = "test-host", port = 1234, tlsEnabled = false)
+      )
+      .id should be("core_grpc__test-host:1234")
+
+    an[IllegalArgumentException] should be thrownBy (ServiceApiEndpoint.Core(address = new EndpointAddress {}).id)
+
+    ServiceApiEndpoint.Discovery(uri = "test-uri").id should be("discovery__test-uri")
+  }
+}

--- a/core/src/test/scala/stasis/test/specs/unit/core/discovery/ServiceDiscoveryClientSpec.scala
+++ b/core/src/test/scala/stasis/test/specs/unit/core/discovery/ServiceDiscoveryClientSpec.scala
@@ -1,0 +1,32 @@
+package stasis.test.specs.unit.core.discovery
+
+import stasis.core.discovery.ServiceDiscoveryClient
+import stasis.core.discovery.ServiceDiscoveryRequest
+import stasis.layers.UnitSpec
+
+class ServiceDiscoveryClientSpec extends UnitSpec {
+  import ServiceDiscoveryClientSpec.TestAttributes
+
+  "ServiceDiscoveryClient Attributes" should "support conversion to a discovery requesst" in {
+    val expected = ServiceDiscoveryRequest(
+      isInitialRequest = false,
+      attributes = Map(
+        "a" -> "test-string",
+        "b" -> "42",
+        "c" -> "false"
+      )
+    )
+
+    val actual = TestAttributes(
+      a = "test-string",
+      b = 42,
+      c = false
+    ).asServiceDiscoveryRequest(isInitialRequest = false)
+
+    actual should be(expected)
+  }
+}
+
+object ServiceDiscoveryClientSpec {
+  final case class TestAttributes(a: String, b: Int, c: Boolean) extends ServiceDiscoveryClient.Attributes
+}

--- a/core/src/test/scala/stasis/test/specs/unit/core/discovery/ServiceDiscoveryRequestSpec.scala
+++ b/core/src/test/scala/stasis/test/specs/unit/core/discovery/ServiceDiscoveryRequestSpec.scala
@@ -1,0 +1,19 @@
+package stasis.test.specs.unit.core.discovery
+
+import stasis.core.discovery.ServiceDiscoveryRequest
+import stasis.layers.UnitSpec
+
+class ServiceDiscoveryRequestSpec extends UnitSpec {
+  "A ServiceDiscoveryRequest" should "support converting its attributes to a request ID" in {
+    val request = ServiceDiscoveryRequest(
+      isInitialRequest = false,
+      attributes = Map(
+        "b" -> "42",
+        "c" -> "false",
+        "a" -> "test-string"
+      )
+    )
+
+    request.id should be("a=test-string::b=42::c=false")
+  }
+}

--- a/core/src/test/scala/stasis/test/specs/unit/core/discovery/ServiceDiscoveryResultSpec.scala
+++ b/core/src/test/scala/stasis/test/specs/unit/core/discovery/ServiceDiscoveryResultSpec.scala
@@ -1,0 +1,35 @@
+package stasis.test.specs.unit.core.discovery
+
+import stasis.core.discovery.ServiceApiEndpoint
+import stasis.core.discovery.ServiceDiscoveryResult
+import stasis.core.networking.http.HttpEndpointAddress
+import stasis.layers.UnitSpec
+
+class ServiceDiscoveryResultSpec extends UnitSpec {
+  "A ServiceDiscoveryResult" should "support rendering as a string" in {
+    ServiceDiscoveryResult.KeepExisting.asString should be("result=keep-existing")
+
+    ServiceDiscoveryResult
+      .SwitchTo(
+        endpoints = ServiceDiscoveryResult.Endpoints(
+          api = ServiceApiEndpoint.Api(uri = "test-api"),
+          core = ServiceApiEndpoint.Core(address = HttpEndpointAddress(uri = "test-core")),
+          discovery = ServiceApiEndpoint.Discovery(uri = "test-discovery")
+        ),
+        recreateExisting = false
+      )
+      .asString should be(
+      "result=switch-to,endpoints=api__test-api;core_http__test-core;discovery__test-discovery,recreate-existing=false"
+    )
+  }
+
+  "ServiceDiscoveryResult Endpoints" should "support rendering as a string" in {
+    val endpoints = ServiceDiscoveryResult.Endpoints(
+      api = ServiceApiEndpoint.Api(uri = "test-api"),
+      core = ServiceApiEndpoint.Core(address = HttpEndpointAddress(uri = "test-core")),
+      discovery = ServiceApiEndpoint.Discovery(uri = "test-discovery")
+    )
+
+    endpoints.asString should be("api__test-api;core_http__test-core;discovery__test-discovery")
+  }
+}

--- a/core/src/test/scala/stasis/test/specs/unit/core/discovery/http/HttpServiceDiscoveryClientSpec.scala
+++ b/core/src/test/scala/stasis/test/specs/unit/core/discovery/http/HttpServiceDiscoveryClientSpec.scala
@@ -1,0 +1,100 @@
+package stasis.test.specs.unit.core.discovery.http
+
+import scala.collection.mutable
+import scala.concurrent.Future
+import scala.util.control.NonFatal
+
+import org.apache.pekko.actor.typed.ActorSystem
+import org.apache.pekko.actor.typed.scaladsl.Behaviors
+import org.apache.pekko.http.scaladsl.model.HttpResponse
+import org.apache.pekko.http.scaladsl.model.StatusCodes
+import org.apache.pekko.http.scaladsl.model.headers.BasicHttpCredentials
+
+import stasis.core.discovery.ServiceDiscoveryClient
+import stasis.core.discovery.ServiceDiscoveryResult
+import stasis.core.discovery.exceptions.DiscoveryFailure
+import stasis.core.discovery.http.HttpServiceDiscoveryClient
+import stasis.layers.UnitSpec
+import stasis.layers.security.tls.EndpointContext
+import stasis.test.specs.unit.core.discovery.http.HttpServiceDiscoveryClientSpec.TestAttributes
+import stasis.test.specs.unit.core.discovery.mocks.MockDiscoveryApiEndpoint
+
+class HttpServiceDiscoveryClientSpec extends UnitSpec {
+  "A HttpServiceDiscoveryClient" should "support retrieving latest service discovery information" in {
+    val apiPort = ports.dequeue()
+    val api = new MockDiscoveryApiEndpoint(expectedCredentials = apiCredentials)
+    api.start(port = apiPort)
+
+    val apiClient = createClient(apiPort)
+
+    apiClient.latest(isInitialRequest = false).map { result =>
+      result should be(ServiceDiscoveryResult.KeepExisting)
+    }
+  }
+
+  it should "handle unexpected responses" in {
+    import stasis.core.api.Formats._
+    import stasis.core.discovery.http.HttpServiceDiscoveryClient._
+
+    val response = HttpResponse(status = StatusCodes.OK, entity = "unexpected-response-entity")
+
+    response
+      .to[ServiceDiscoveryResult]
+      .map { result =>
+        fail(s"Unexpected result received: [$result]")
+      }
+      .recover { case NonFatal(e: DiscoveryFailure) =>
+        e.getMessage should be(
+          "Discovery API request unmarshalling failed with: [Unsupported Content-Type [Some(text/plain; charset=UTF-8)], supported: application/json]"
+        )
+      }
+  }
+
+  it should "handle endpoint failures" in {
+    import stasis.core.api.Formats._
+    import stasis.core.discovery.http.HttpServiceDiscoveryClient._
+
+    val status = StatusCodes.NotFound
+    val message = "Test Failure"
+    val response = HttpResponse(status = status, entity = message)
+
+    response
+      .to[ServiceDiscoveryResult]
+      .map { result =>
+        fail(s"Unexpected result received: [$result]")
+      }
+      .recover { case NonFatal(e: DiscoveryFailure) =>
+        e.getMessage should be(s"Discovery API request failed with [$status]: [$message]")
+      }
+  }
+
+  private def createClient(
+    apiPort: Int,
+    context: Option[EndpointContext] = None
+  ): HttpServiceDiscoveryClient = {
+    val client = HttpServiceDiscoveryClient(
+      apiUrl = context match {
+        case Some(_) => s"https://localhost:$apiPort"
+        case None    => s"http://localhost:$apiPort"
+      },
+      credentials = Future.successful(apiCredentials),
+      attributes = TestAttributes(a = "test-attribute"),
+      context = context
+    )
+
+    client
+  }
+
+  private implicit val typedSystem: ActorSystem[Nothing] = ActorSystem(
+    guardianBehavior = Behaviors.ignore,
+    name = "HttpServiceDiscoveryClientSpec"
+  )
+
+  private val ports: mutable.Queue[Int] = (43000 to 43100).to(mutable.Queue)
+
+  private val apiCredentials = BasicHttpCredentials(username = "some-user", password = "some-password")
+}
+
+object HttpServiceDiscoveryClientSpec {
+  final case class TestAttributes(a: String) extends ServiceDiscoveryClient.Attributes
+}

--- a/core/src/test/scala/stasis/test/specs/unit/core/discovery/http/HttpServiceDiscoveryEndpointSpec.scala
+++ b/core/src/test/scala/stasis/test/specs/unit/core/discovery/http/HttpServiceDiscoveryEndpointSpec.scala
@@ -1,0 +1,43 @@
+package stasis.test.specs.unit.core.discovery.http
+
+import scala.concurrent.Future
+
+import org.apache.pekko.http.scaladsl.marshalling.Marshal
+import org.apache.pekko.http.scaladsl.model.RequestEntity
+import org.apache.pekko.http.scaladsl.model.StatusCodes
+import org.apache.pekko.http.scaladsl.testkit.ScalatestRouteTest
+
+import stasis.core.discovery.ServiceDiscoveryRequest
+import stasis.core.discovery.ServiceDiscoveryResult
+import stasis.core.discovery.http.HttpServiceDiscoveryEndpoint
+import stasis.core.discovery.providers.server.ServiceDiscoveryProvider
+import stasis.layers.UnitSpec
+
+class HttpServiceDiscoveryEndpointSpec extends UnitSpec with ScalatestRouteTest {
+  import com.github.pjfanning.pekkohttpplayjson.PlayJsonSupport._
+
+  import stasis.core.api.Formats._
+
+  "A HttpServiceDiscoveryEndpoint" should "provide service discovery results" in {
+    val request = ServiceDiscoveryRequest(isInitialRequest = false, attributes = Map("a" -> "b"))
+
+    val expectedResult = ServiceDiscoveryResult.KeepExisting
+
+    val provider = new ServiceDiscoveryProvider {
+      override def provide(request: ServiceDiscoveryRequest): Future[ServiceDiscoveryResult] =
+        Future.successful(expectedResult)
+    }
+
+    val endpoint = new HttpServiceDiscoveryEndpoint(provider)
+
+    Post("/provide").withEntity(request) ~> endpoint.routes ~> check {
+      status should be(StatusCodes.OK)
+      responseAs[ServiceDiscoveryResult] should be(expectedResult)
+    }
+  }
+
+  import scala.language.implicitConversions
+
+  private implicit def createRequestToEntity(request: ServiceDiscoveryRequest): RequestEntity =
+    Marshal(request).to[RequestEntity].await
+}

--- a/core/src/test/scala/stasis/test/specs/unit/core/discovery/mocks/MockDiscoveryApiEndpoint.scala
+++ b/core/src/test/scala/stasis/test/specs/unit/core/discovery/mocks/MockDiscoveryApiEndpoint.scala
@@ -1,0 +1,72 @@
+package stasis.test.specs.unit.core.discovery.mocks
+
+import scala.concurrent.Future
+
+import org.apache.pekko.actor.typed.ActorSystem
+import org.apache.pekko.actor.typed.scaladsl.LoggerOps
+import org.apache.pekko.http.scaladsl.Http
+import org.apache.pekko.http.scaladsl.model.StatusCodes
+import org.apache.pekko.http.scaladsl.model.headers.HttpCredentials
+import org.apache.pekko.http.scaladsl.server.Directives._
+import org.apache.pekko.http.scaladsl.server.Route
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+
+import stasis.core.discovery.ServiceDiscoveryRequest
+import stasis.core.discovery.ServiceDiscoveryResult
+import stasis.layers.security.tls.EndpointContext
+
+class MockDiscoveryApiEndpoint(
+  expectedCredentials: HttpCredentials,
+  result: ServiceDiscoveryResult = ServiceDiscoveryResult.KeepExisting
+)(implicit system: ActorSystem[Nothing]) {
+  import stasis.core.api.Formats._
+
+  private val log: Logger = LoggerFactory.getLogger(this.getClass.getName)
+
+  private val routes: Route =
+    (extractMethod & extractUri & extractRequest) { (method, uri, request) =>
+      extractCredentials {
+        case Some(`expectedCredentials`) =>
+          path("discovery" / "provide") {
+            post {
+              import com.github.pjfanning.pekkohttpplayjson.PlayJsonSupport._
+
+              entity(as[ServiceDiscoveryRequest]) { request =>
+                log.info(
+                  "Responding to service discovery request [{}] with [{}]",
+                  request.id,
+                  result.asString
+                )
+
+                complete(result)
+              }
+            }
+          }
+
+        case _ =>
+          val _ = request.discardEntityBytes()
+
+          log.warnN(
+            "Rejecting [{}] request for [{}] with no/invalid credentials",
+            method.value,
+            uri
+          )
+
+          complete(StatusCodes.Unauthorized)
+      }
+    }
+
+  def start(port: Int, context: Option[EndpointContext] = None): Future[Http.ServerBinding] = {
+    val server = {
+      val builder = Http().newServerAt(interface = "localhost", port = port)
+
+      context match {
+        case Some(httpsContext) => builder.enableHttps(httpsContext.connection)
+        case None               => builder
+      }
+    }
+
+    server.bindFlow(handlerFlow = pathPrefix("v1") { routes })
+  }
+}

--- a/core/src/test/scala/stasis/test/specs/unit/core/discovery/mocks/MockServiceDiscoveryClient.scala
+++ b/core/src/test/scala/stasis/test/specs/unit/core/discovery/mocks/MockServiceDiscoveryClient.scala
@@ -1,0 +1,47 @@
+package stasis.test.specs.unit.core.discovery.mocks
+
+import java.util.concurrent.atomic.AtomicInteger
+
+import scala.concurrent.Future
+
+import stasis.core.discovery.ServiceDiscoveryClient
+import stasis.core.discovery.ServiceDiscoveryResult
+
+class MockServiceDiscoveryClient(
+  initialDiscoveryResult: ServiceDiscoveryResult,
+  nextDiscoveryResult: ServiceDiscoveryResult
+) extends ServiceDiscoveryClient {
+  private val counterRef: AtomicInteger = new AtomicInteger(0)
+
+  override val attributes: ServiceDiscoveryClient.Attributes =
+    MockServiceDiscoveryClient.TestAttributes(a = "b")
+
+  override def latest(isInitialRequest: Boolean): Future[ServiceDiscoveryResult] = {
+    val _ = counterRef.incrementAndGet()
+
+    Future.successful(
+      if (isInitialRequest) initialDiscoveryResult
+      else nextDiscoveryResult
+    )
+  }
+
+  def results: Int = counterRef.get()
+}
+
+object MockServiceDiscoveryClient {
+  def apply(): MockServiceDiscoveryClient =
+    new MockServiceDiscoveryClient(
+      initialDiscoveryResult = ServiceDiscoveryResult.KeepExisting,
+      nextDiscoveryResult = ServiceDiscoveryResult.KeepExisting
+    )
+
+  def apply(
+    initialDiscoveryResult: ServiceDiscoveryResult,
+    nextDiscoveryResult: ServiceDiscoveryResult
+  ): MockServiceDiscoveryClient = new MockServiceDiscoveryClient(
+    initialDiscoveryResult = initialDiscoveryResult,
+    nextDiscoveryResult = nextDiscoveryResult
+  )
+
+  final case class TestAttributes(a: String) extends ServiceDiscoveryClient.Attributes
+}

--- a/core/src/test/scala/stasis/test/specs/unit/core/discovery/providers/client/ServiceDiscoveryProviderSpec.scala
+++ b/core/src/test/scala/stasis/test/specs/unit/core/discovery/providers/client/ServiceDiscoveryProviderSpec.scala
@@ -1,0 +1,280 @@
+package stasis.test.specs.unit.core.discovery.providers.client
+
+import java.util.concurrent.atomic.AtomicInteger
+
+import scala.concurrent.Future
+import scala.concurrent.duration._
+
+import org.apache.pekko.actor.typed.ActorSystem
+import org.apache.pekko.actor.typed.scaladsl.Behaviors
+import org.scalatest.Assertion
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.concurrent.Eventually
+
+import stasis.core.discovery.ServiceApiClient
+import stasis.core.discovery.ServiceApiEndpoint
+import stasis.core.discovery.ServiceDiscoveryClient
+import stasis.core.discovery.ServiceDiscoveryResult
+import stasis.core.discovery.exceptions.DiscoveryFailure
+import stasis.core.discovery.providers.client.ServiceDiscoveryProvider
+import stasis.core.networking.http.HttpEndpointAddress
+import stasis.layers.UnitSpec
+import stasis.test.specs.unit.core.discovery.mocks.MockServiceDiscoveryClient
+import stasis.test.specs.unit.core.discovery.providers.client.ServiceDiscoveryProviderSpec.TestApiClient
+import stasis.test.specs.unit.core.discovery.providers.client.ServiceDiscoveryProviderSpec.TestCoreClient
+
+class ServiceDiscoveryProviderSpec extends UnitSpec with Eventually with BeforeAndAfterAll {
+  "A ServiceDiscoveryProvider" should "support providing existing clients when discovery is not active" in {
+    val provider = ServiceDiscoveryProvider(
+      interval = 3.seconds,
+      initialClients = createClients(
+        initialDiscoveryResult = ServiceDiscoveryResult.KeepExisting,
+        nextDiscoveryResult = ServiceDiscoveryResult.KeepExisting
+      ),
+      clientFactory = createClientFactory()
+    ).await
+
+    provider should be(a[ServiceDiscoveryProvider.Disabled])
+
+    provider.latest[ServiceDiscoveryClient] should be(a[MockServiceDiscoveryClient])
+    a[DiscoveryFailure] should be thrownBy provider.latest[TestApiClient]
+    a[DiscoveryFailure] should be thrownBy provider.latest[TestCoreClient]
+  }
+
+  it should "support providing new clients when discovery is active" in {
+    val provider = ServiceDiscoveryProvider(
+      interval = 3.seconds,
+      initialClients = createClients(
+        initialDiscoveryResult = ServiceDiscoveryResult.SwitchTo(
+          endpoints = ServiceDiscoveryResult.Endpoints(
+            api = ServiceApiEndpoint.Api(uri = "test-rui"),
+            core = ServiceApiEndpoint.Core(address = HttpEndpointAddress(uri = "test-rui")),
+            discovery = ServiceApiEndpoint.Discovery(uri = "test-rui")
+          ),
+          recreateExisting = false
+        ),
+        nextDiscoveryResult = ServiceDiscoveryResult.KeepExisting
+      ),
+      clientFactory = createClientFactory()
+    ).await
+
+    provider should be(a[ServiceDiscoveryProvider.Default])
+
+    provider.latest[ServiceDiscoveryClient] should be(a[MockServiceDiscoveryClient])
+    noException should be thrownBy provider.latest[TestApiClient]
+    noException should be thrownBy provider.latest[TestCoreClient]
+  }
+
+  it should "periodically refresh list of endpoints and clients (with result=keep-existing)" in {
+    def createResult(recreateExisting: Boolean = false): ServiceDiscoveryResult = ServiceDiscoveryResult.SwitchTo(
+      endpoints = ServiceDiscoveryResult.Endpoints(
+        api = ServiceApiEndpoint.Api(uri = java.util.UUID.randomUUID().toString),
+        core = ServiceApiEndpoint.Core(address = HttpEndpointAddress(uri = java.util.UUID.randomUUID().toString)),
+        discovery = ServiceApiEndpoint.Discovery(uri = java.util.UUID.randomUUID().toString)
+      ),
+      recreateExisting = recreateExisting
+    )
+
+    val provider = ServiceDiscoveryProvider(
+      interval = 200.millis,
+      initialClients = createClients(initialDiscoveryResult = createResult(), nextDiscoveryResult = createResult()),
+      clientFactory = createClientFactory()
+    ).await
+
+    provider should be(a[ServiceDiscoveryProvider.Default])
+
+    val initialDiscoveryClient = provider.latest[ServiceDiscoveryClient]
+    val initialApiClient = provider.latest[TestApiClient]
+    val initialCoreClient = provider.latest[TestCoreClient]
+
+    await(delay = 100.millis, withSystem = typedSystem)
+
+    provider.latest[ServiceDiscoveryClient] should be(initialDiscoveryClient)
+    provider.latest[TestApiClient] should be(initialApiClient)
+    provider.latest[TestCoreClient] should be(initialCoreClient)
+  }
+
+  it should "periodically refresh list of endpoints and clients (with result=switch-to)" in {
+    def createResult(recreateExisting: Boolean = false): ServiceDiscoveryResult = ServiceDiscoveryResult.SwitchTo(
+      endpoints = ServiceDiscoveryResult.Endpoints(
+        api = ServiceApiEndpoint.Api(uri = java.util.UUID.randomUUID().toString),
+        core = ServiceApiEndpoint.Core(address = HttpEndpointAddress(uri = java.util.UUID.randomUUID().toString)),
+        discovery = ServiceApiEndpoint.Discovery(uri = java.util.UUID.randomUUID().toString)
+      ),
+      recreateExisting = recreateExisting
+    )
+
+    val provider = ServiceDiscoveryProvider(
+      interval = 200.millis,
+      initialClients = createClients(initialDiscoveryResult = createResult(), nextDiscoveryResult = createResult()),
+      clientFactory = createClientFactory(nextDiscoveryResult = createResult(recreateExisting = true))
+    ).await
+
+    provider should be(a[ServiceDiscoveryProvider.Default])
+
+    val initialDiscoveryClient = provider.latest[ServiceDiscoveryClient]
+    val initialApiClient = provider.latest[TestApiClient]
+    val initialCoreClient = provider.latest[TestCoreClient]
+
+    await(delay = 100.millis, withSystem = typedSystem)
+
+    provider.latest[ServiceDiscoveryClient] should be(initialDiscoveryClient)
+    provider.latest[TestApiClient] should be(initialApiClient)
+    provider.latest[TestCoreClient] should be(initialCoreClient)
+
+    eventually[Assertion] {
+      provider.latest[ServiceDiscoveryClient] should not be initialDiscoveryClient
+      provider.latest[TestApiClient] should not be initialApiClient
+      provider.latest[TestCoreClient] should not be initialCoreClient
+    }
+  }
+
+  it should "not recreate clients for same endpoints" in {
+    def createResult(): ServiceDiscoveryResult = ServiceDiscoveryResult.SwitchTo(
+      endpoints = ServiceDiscoveryResult.Endpoints(
+        api = ServiceApiEndpoint.Api(uri = java.util.UUID.randomUUID().toString),
+        core = ServiceApiEndpoint.Core(address = HttpEndpointAddress(uri = java.util.UUID.randomUUID().toString)),
+        discovery = ServiceApiEndpoint.Discovery(uri = java.util.UUID.randomUUID().toString)
+      ),
+      recreateExisting = false
+    )
+
+    val provider = ServiceDiscoveryProvider(
+      interval = 100.millis,
+      initialClients = createClients(initialDiscoveryResult = createResult(), nextDiscoveryResult = createResult()),
+      clientFactory = createClientFactory(nextDiscoveryResult = createResult())
+    ).await
+
+    provider should be(a[ServiceDiscoveryProvider.Default])
+
+    val initialDiscoveryClient = provider.latest[ServiceDiscoveryClient]
+    val initialApiClient = provider.latest[TestApiClient]
+    val initialCoreClient = provider.latest[TestCoreClient]
+
+    await(delay = 200.millis, withSystem = typedSystem)
+
+    provider.latest[ServiceDiscoveryClient] should not be initialDiscoveryClient
+    provider.latest[TestApiClient] should not be initialApiClient
+    provider.latest[TestCoreClient] should not be initialCoreClient
+
+    val latestDiscoveryClient = provider.latest[ServiceDiscoveryClient]
+    val latestApiClient = provider.latest[TestApiClient]
+    val latestCoreClient = provider.latest[TestCoreClient]
+
+    await(delay = 200.millis, withSystem = typedSystem)
+
+    eventually[Assertion] {
+      latestDiscoveryClient should not be initialDiscoveryClient
+      latestApiClient should not be initialApiClient
+      latestCoreClient should not be initialCoreClient
+
+      provider.latest[ServiceDiscoveryClient] should be(latestDiscoveryClient)
+      provider.latest[TestApiClient] should be(latestApiClient)
+      provider.latest[TestCoreClient] should be(latestCoreClient)
+    }
+  }
+
+  it should "fail to retrieve unsupported client types" in {
+    val provider = ServiceDiscoveryProvider(
+      interval = 3.seconds,
+      initialClients = createClients(
+        initialDiscoveryResult = ServiceDiscoveryResult.KeepExisting,
+        nextDiscoveryResult = ServiceDiscoveryResult.KeepExisting
+      ),
+      clientFactory = createClientFactory()
+    ).await
+
+    provider should be(a[ServiceDiscoveryProvider.Disabled])
+
+    val e = intercept[DiscoveryFailure](provider.latest[TestApiClient])
+    e.getMessage should be(s"Service client [${classOf[TestApiClient].getName}] was not found")
+  }
+
+  it should "handle discovery failures" in {
+    val clientCalls = new AtomicInteger(0)
+
+    val _ = ServiceDiscoveryProvider(
+      interval = 200.millis,
+      initialClients = createClients(
+        initialDiscoveryResult = ServiceDiscoveryResult.SwitchTo(
+          endpoints = ServiceDiscoveryResult.Endpoints(
+            api = ServiceApiEndpoint.Api(uri = "test-rui"),
+            core = ServiceApiEndpoint.Core(address = HttpEndpointAddress(uri = "test-rui")),
+            discovery = ServiceApiEndpoint.Discovery(uri = "test-rui")
+          ),
+          recreateExisting = false
+        ),
+        nextDiscoveryResult = ServiceDiscoveryResult.KeepExisting
+      ),
+      clientFactory = new ServiceApiClient.Factory {
+        override def create(endpoint: ServiceApiEndpoint.Api, coreClient: ServiceApiClient): ServiceApiClient =
+          new TestApiClient {}
+
+        override def create(endpoint: ServiceApiEndpoint.Core): ServiceApiClient =
+          new TestCoreClient {}
+
+        override def create(endpoint: ServiceApiEndpoint.Discovery): ServiceApiClient =
+          new ServiceDiscoveryClient {
+            override val attributes: ServiceDiscoveryClient.Attributes =
+              MockServiceDiscoveryClient.TestAttributes(a = "b")
+
+            override def latest(isInitialRequest: Boolean): Future[ServiceDiscoveryResult] = {
+              val _ = clientCalls.incrementAndGet()
+              Future.failed(new RuntimeException("Test failure"))
+            }
+          }
+      }
+    ).await
+
+    clientCalls.get() should be(0)
+
+    await(delay = 100.millis, withSystem = typedSystem)
+
+    clientCalls.get() should be(0)
+
+    await(delay = 300.millis, withSystem = typedSystem)
+
+    clientCalls.get() should be >= 5 // the interval is reduced so more requests should be made
+  }
+
+  private def createClients(
+    initialDiscoveryResult: ServiceDiscoveryResult,
+    nextDiscoveryResult: ServiceDiscoveryResult
+  ): Seq[ServiceApiClient] = Seq(
+    new MockServiceDiscoveryClient(
+      initialDiscoveryResult = initialDiscoveryResult,
+      nextDiscoveryResult = nextDiscoveryResult
+    )
+  )
+
+  private def createClientFactory(
+    nextDiscoveryResult: ServiceDiscoveryResult = ServiceDiscoveryResult.KeepExisting
+  ): ServiceApiClient.Factory =
+    new ServiceApiClient.Factory {
+      override def create(endpoint: ServiceApiEndpoint.Api, coreClient: ServiceApiClient): ServiceApiClient =
+        new TestApiClient {}
+
+      override def create(endpoint: ServiceApiEndpoint.Core): ServiceApiClient =
+        new TestCoreClient {}
+
+      override def create(endpoint: ServiceApiEndpoint.Discovery): ServiceApiClient =
+        new MockServiceDiscoveryClient(
+          initialDiscoveryResult = nextDiscoveryResult,
+          nextDiscoveryResult = nextDiscoveryResult
+        )
+    }
+
+  override implicit val patienceConfig: PatienceConfig = PatienceConfig(5.seconds, 250.milliseconds)
+
+  private implicit val typedSystem: ActorSystem[Nothing] = ActorSystem(
+    guardianBehavior = Behaviors.ignore,
+    name = "ServiceDiscoveryProviderSpec"
+  )
+
+  override protected def afterAll(): Unit = typedSystem.terminate()
+}
+
+object ServiceDiscoveryProviderSpec {
+  class TestApiClient extends ServiceApiClient
+  class TestCoreClient extends ServiceApiClient
+}

--- a/core/src/test/scala/stasis/test/specs/unit/core/discovery/providers/server/ServiceDiscoveryProviderSpec.scala
+++ b/core/src/test/scala/stasis/test/specs/unit/core/discovery/providers/server/ServiceDiscoveryProviderSpec.scala
@@ -1,0 +1,138 @@
+package stasis.test.specs.unit.core.discovery.providers.server
+
+import stasis.core.discovery.ServiceApiEndpoint
+import stasis.core.discovery.ServiceDiscoveryRequest
+import stasis.core.discovery.ServiceDiscoveryResult
+import stasis.core.discovery.providers.server.ServiceDiscoveryProvider
+import stasis.core.networking.grpc.GrpcEndpointAddress
+import stasis.core.networking.http.HttpEndpointAddress
+import stasis.layers.UnitSpec
+
+class ServiceDiscoveryProviderSpec extends UnitSpec {
+  "A ServiceDiscoveryProvider" should "be created from config" in {
+    val config = com.typesafe.config.ConfigFactory.load().getConfig("stasis.test.core.discovery.server")
+
+    ServiceDiscoveryProvider(config = config.getConfig("provider-disabled")).getClass.getName should endWith(
+      "ServiceDiscoveryProvider$Disabled"
+    )
+
+    ServiceDiscoveryProvider(config = config.getConfig("provider-static")).getClass.getName should endWith(
+      "ServiceDiscoveryProvider$Static"
+    )
+
+    val e = intercept[IllegalArgumentException](ServiceDiscoveryProvider(config = config.getConfig("provider-invalid")))
+    e.getMessage should be("Unexpected provider type specified: [other]")
+  }
+
+  it should "fail if a static provided is enabled but no config file is provided" in {
+    val config = com.typesafe.config.ConfigFactory.load().getConfig("stasis.test.core.discovery.server")
+
+    val e = intercept[IllegalArgumentException](ServiceDiscoveryProvider(config = config.getConfig("provider-static-no-config")))
+
+    e.getMessage should include("Static discovery enabled but no config file was provided")
+  }
+
+  "A Disabled ServiceDiscoveryProvider" should "not respond with new endpoints" in {
+    val provider = new ServiceDiscoveryProvider.Disabled()
+
+    provider.provide(request = null).map { result =>
+      result should be(ServiceDiscoveryResult.KeepExisting)
+    }
+  }
+
+  "A Static ServiceDiscoveryProvider" should "respond with new or existing endpoints based on the client" in {
+    val provider = new ServiceDiscoveryProvider.Static(endpoints = endpoints)
+
+    val request = ServiceDiscoveryRequest(isInitialRequest = false, attributes = Map("client" -> "test-client"))
+
+    val switchToResult = ServiceDiscoveryResult.SwitchTo(
+      endpoints = ServiceDiscoveryResult.Endpoints(
+        api = ServiceApiEndpoint.Api(uri = "http://localhost:10000"),
+        core = ServiceApiEndpoint.Core(address = HttpEndpointAddress(uri = "http://localhost:10001")),
+        discovery = ServiceApiEndpoint.Discovery(uri = "http://localhost:10002")
+      ),
+      recreateExisting = false
+    )
+
+    for {
+      unknownClientResult <- provider.provide(request = request) // request is not set as initial but client is unknown
+      knownClientResult <- provider.provide(request = request) // client is known
+      knownClientButSetAsInitialResult <- provider.provide(
+        request = request.copy(isInitialRequest = true) // client is known but request is marked as initial
+      )
+    } yield {
+      unknownClientResult should be(switchToResult)
+      knownClientResult should be(ServiceDiscoveryResult.KeepExisting)
+      knownClientButSetAsInitialResult should be(switchToResult)
+    }
+  }
+
+  "Static ServiceDiscoveryProvider Endpoints" should "support loading from config" in {
+    val config = com.typesafe.config.ConfigFactory.load("discovery-static.conf").getConfig("endpoints")
+
+    val actual = ServiceDiscoveryProvider.Static.Endpoints(config = config)
+
+    actual should be(endpoints)
+  }
+
+  they should "fail if no API endpoints are provided" in {
+    an[IllegalArgumentException] should be thrownBy endpoints.copy(api = Seq.empty)
+  }
+
+  they should "fail if no core endpoints are provided" in {
+    an[IllegalArgumentException] should be thrownBy endpoints.copy(core = Seq.empty)
+  }
+
+  they should "fail if unexpected core endpoints are provided" in {
+    val config = com.typesafe.config.ConfigFactory.load("discovery-static-invalid.conf").getConfig("endpoints")
+
+    val e = intercept[IllegalArgumentException](ServiceDiscoveryProvider.Static.Endpoints(config = config))
+
+    e.getMessage should be("Unexpected endpoint type specified: [other]")
+  }
+
+  they should "support selecting endpoints based on requests" in {
+    endpoints.select(forRequestId = "client=test-client") should be(
+      ServiceDiscoveryResult.Endpoints(
+        api = ServiceApiEndpoint.Api(uri = "http://localhost:10000"),
+        core = ServiceApiEndpoint.Core(address = HttpEndpointAddress(uri = "http://localhost:10001")),
+        discovery = ServiceApiEndpoint.Discovery(uri = "http://localhost:10002")
+      )
+    )
+
+    endpoints.select(forRequestId = "other-request-id") should be(
+      ServiceDiscoveryResult.Endpoints(
+        api = ServiceApiEndpoint.Api(uri = "http://localhost:20000"),
+        core = ServiceApiEndpoint.Core(address = HttpEndpointAddress(uri = "http://localhost:20001")),
+        discovery = ServiceApiEndpoint.Discovery(uri = "http://localhost:10002")
+      )
+    )
+  }
+
+  they should "support selecting API endpoints as fallback when no discovery endpoints are available" in {
+    endpoints.copy(discovery = Seq.empty).select(forRequestId = "client=test-client") should be(
+      ServiceDiscoveryResult.Endpoints(
+        api = ServiceApiEndpoint.Api(uri = "http://localhost:10000"),
+        core = ServiceApiEndpoint.Core(address = HttpEndpointAddress(uri = "http://localhost:10001")),
+        discovery = ServiceApiEndpoint.Discovery(uri = "http://localhost:10000")
+      )
+    )
+  }
+
+  private val endpoints = ServiceDiscoveryProvider.Static.Endpoints(
+    api = Seq(
+      ServiceApiEndpoint.Api(uri = "http://localhost:10000"),
+      ServiceApiEndpoint.Api(uri = "http://localhost:20000"),
+      ServiceApiEndpoint.Api(uri = "http://localhost:30000")
+    ),
+    core = Seq(
+      ServiceApiEndpoint.Core(address = HttpEndpointAddress(uri = "http://localhost:10001")),
+      ServiceApiEndpoint.Core(address = HttpEndpointAddress(uri = "http://localhost:20001")),
+      ServiceApiEndpoint.Core(address = GrpcEndpointAddress(host = "localhost", port = 30001, tlsEnabled = false))
+    ),
+    discovery = Seq(
+      ServiceApiEndpoint.Discovery(uri = "http://localhost:10002"),
+      ServiceApiEndpoint.Discovery(uri = "http://localhost:20002")
+    )
+  )
+}

--- a/deployment/dev/config/server-discovery.conf
+++ b/deployment/dev/config/server-discovery.conf
@@ -1,0 +1,23 @@
+endpoints {
+  # at least one API endpoint must be provided
+  api = [
+    {
+      uri = "http://server:20000"
+    }
+  ]
+
+  # at least one core endpoint must be provided
+  core = [
+    {
+      type = "http" # one of [http, grpc]
+
+      http {
+        uri = "http://server:20001"
+      }
+    }
+  ]
+
+  # if no discovery endpoints are explicitly provided here,
+  # the API endpoints will also be used for discovery
+  discovery = []
+}

--- a/deployment/dev/docker-compose.yml
+++ b/deployment/dev/docker-compose.yml
@@ -78,6 +78,8 @@ services:
     environment:
       - STASIS_SERVER_SERVICE_BOOTSTRAP_MODE=init-and-start
       - STASIS_SERVER_SERVICE_BOOTSTRAP_CONFIG=/opt/docker/config/server-bootstrap.conf
+      - STASIS_SERVER_SERVICE_DISCOVERY_TYPE=disabled
+      - STASIS_SERVER_SERVICE_DISCOVERY_STATIC_CONFIG=/opt/docker/config/server-discovery.conf
       - STASIS_SERVER_LOGLEVEL=DEBUG
       - STASIS_SERVER_SERVICE_API_INTERFACE=0.0.0.0
       - STASIS_SERVER_SERVICE_API_PORT=20000
@@ -128,6 +130,7 @@ services:
       - PEKKO_HTTP_CORS_ALLOWED_ORIGINS=*
     volumes:
       - ./config/server-bootstrap.conf:/opt/docker/config/server-bootstrap.conf
+      - ./config/server-discovery.conf:/opt/docker/config/server-discovery.conf
       - ./secrets/identity.p12:/opt/docker/certs/identity.p12
       - ./secrets/server.p12:/opt/docker/certs/server.p12
 

--- a/layers/src/main/scala/stasis/layers/api/Formats.scala
+++ b/layers/src/main/scala/stasis/layers/api/Formats.scala
@@ -1,10 +1,14 @@
 package stasis.layers.api
 
+import java.nio.charset.StandardCharsets
 import java.util.UUID
 
 import scala.concurrent.duration._
 
 import org.apache.pekko.http.scaladsl.model.Uri
+import org.apache.pekko.util.ByteString
+
+import stasis.layers.security.tls.EndpointContext
 
 object Formats {
   import play.api.libs.json._
@@ -32,4 +36,13 @@ object Formats {
     fjs = _.validate[String].map(Uri.apply),
     tjs = uri => Json.toJson(uri.toString)
   )
+
+  implicit val byteStringFormat: Format[ByteString] =
+    Format(
+      fjs = _.validate[String].map(ByteString.fromString(_, StandardCharsets.UTF_8).decodeBase64),
+      tjs = content => Json.toJson(content.encodeBase64.utf8String)
+    )
+
+  implicit val endpointContextFormat: Format[EndpointContext.Encoded] =
+    Json.format[EndpointContext.Encoded]
 }

--- a/layers/src/main/scala/stasis/layers/security/tls/EndpointContext.scala
+++ b/layers/src/main/scala/stasis/layers/security/tls/EndpointContext.scala
@@ -1,18 +1,24 @@
 package stasis.layers.security.tls
 
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
 import java.io.FileInputStream
 import java.io.FileNotFoundException
 import java.security.KeyStore
 import java.security.SecureRandom
+import java.util.concurrent.ThreadLocalRandom
 
 import javax.net.ssl._
 
+import scala.jdk.CollectionConverters._
+import scala.util.Random
 import scala.util.Try
 
 import com.typesafe.{config => typesafe}
 import org.apache.pekko.http.scaladsl.ConnectionContext
 import org.apache.pekko.http.scaladsl.HttpsConnectionContext
 import org.apache.pekko.http.scaladsl.ServerBuilder
+import org.apache.pekko.util.ByteString
 
 final case class EndpointContext(
   config: EndpointContext.Config,
@@ -91,6 +97,92 @@ object EndpointContext {
         storeType = storeConfig.getString("type"),
         storePassword = storeConfig.getString("password")
       )
+  }
+
+  final case class Encoded(
+    enabled: Boolean,
+    protocol: String,
+    storeType: String,
+    temporaryStorePassword: String,
+    storeContent: ByteString
+  )
+
+  object Encoded {
+    final val TemporaryPasswordSize: Int = 32
+
+    final val DefaultProtocol: String = "TLS"
+    final val DefaultStoreType: String = "PKCS12"
+
+    def apply(config: typesafe.Config): Encoded =
+      if (config.getBoolean("enabled")) {
+        enabled(
+          protocol = config.getString("protocol"),
+          config = StoreConfig(config.getConfig("truststore"))
+        )
+      } else {
+        disabled()
+      }
+
+    def disabled(): Encoded =
+      Encoded(
+        enabled = false,
+        protocol = DefaultProtocol,
+        storeType = DefaultStoreType,
+        temporaryStorePassword = "",
+        storeContent = ByteString.empty
+      )
+
+    def enabled(
+      protocol: String,
+      config: StoreConfig
+    ): Encoded = {
+      val store = loadStore(config)
+
+      val rnd: Random = ThreadLocalRandom.current()
+      val password = rnd.alphanumeric.take(TemporaryPasswordSize).mkString
+
+      Encoded(
+        enabled = true,
+        protocol = protocol,
+        storeType = config.storeType,
+        temporaryStorePassword = password,
+        storeContent = encodeKeyStore(store, password, config.storeType)
+      )
+    }
+
+    @SuppressWarnings(Array("org.wartremover.warts.Null"))
+    def encodeKeyStore(store: KeyStore, password: String, storeType: String): ByteString = {
+      val rebuiltStore = KeyStore.getInstance(storeType)
+      rebuiltStore.load(None.orNull, None.orNull)
+
+      store.aliases().asScala.foreach {
+        case alias if store.isKeyEntry(alias) =>
+          store.getCertificateChain(alias).zipWithIndex.foreach { case (certificate, index) =>
+            rebuiltStore.setCertificateEntry(s"$alias-${index.toString}", certificate)
+          }
+
+        case alias =>
+          require(store.isCertificateEntry(alias), s"Expected certificate entry for alias [$alias]")
+          rebuiltStore.setCertificateEntry(alias, store.getCertificate(alias))
+      }
+
+      val content = new ByteArrayOutputStream()
+      rebuiltStore.store(content, password.toCharArray)
+
+      ByteString.fromArray(content.toByteArray)
+    }
+
+    def decodeKeyStore(content: ByteString, password: String, storeType: String): KeyStore = {
+      val store = KeyStore.getInstance(storeType)
+      store.load(new ByteArrayInputStream(content.toArray), password.toCharArray)
+
+      require(
+        store.aliases().asScala.forall(store.isCertificateEntry),
+        "Expected certificate entries only but one or more keys were encountered."
+      )
+
+      store
+    }
   }
 
   @SuppressWarnings(Array("org.wartremover.warts.Throw"))

--- a/layers/src/test/resources/application.conf
+++ b/layers/src/test/resources/application.conf
@@ -46,6 +46,16 @@ stasis {
             }
           }
 
+          context-enabled {
+            enabled = true
+            protocol = "TLS"
+            truststore {
+              path = "./core/src/test/resources/certs/localhost.p12"
+              type = "PKCS12"
+              password = ""
+            }
+          }
+
           context-disabled {
             enabled = false
             type = "client"

--- a/layers/src/test/scala/stasis/layers/api/FormatsSpec.scala
+++ b/layers/src/test/scala/stasis/layers/api/FormatsSpec.scala
@@ -5,6 +5,7 @@ import java.util.UUID
 import scala.concurrent.duration._
 
 import org.apache.pekko.http.scaladsl.model.Uri
+import org.apache.pekko.util.ByteString
 import play.api.libs.json.Json
 
 import stasis.layers.UnitSpec
@@ -55,5 +56,13 @@ class FormatsSpec extends UnitSpec {
 
     uriFormat.writes(uri).toString should be(json)
     uriFormat.reads(Json.parse(json)).asOpt should be(Some(uri))
+  }
+
+  they should "convert ByteStrings to/from JSON" in {
+    val original = ByteString("test-string")
+    val json = "\"dGVzdC1zdHJpbmc=\""
+
+    byteStringFormat.writes(original).toString() should be(json)
+    byteStringFormat.reads(Json.parse(json)).asOpt should be(Some(original))
   }
 }

--- a/layers/src/test/scala/stasis/layers/security/tls/EndpointContextSpec.scala
+++ b/layers/src/test/scala/stasis/layers/security/tls/EndpointContextSpec.scala
@@ -1,8 +1,10 @@
 package stasis.layers.security.tls
 
+import java.io.ByteArrayOutputStream
 import java.io.FileNotFoundException
 
 import scala.collection.mutable
+import scala.jdk.CollectionConverters._
 
 import com.typesafe.config.Config
 import com.typesafe.config.ConfigFactory
@@ -14,6 +16,7 @@ import org.apache.pekko.http.scaladsl.model.HttpResponse
 import org.apache.pekko.http.scaladsl.model.StatusCodes
 import org.apache.pekko.http.scaladsl.server.Directives
 import org.apache.pekko.http.scaladsl.server.Directives._
+import org.apache.pekko.util.ByteString
 
 import stasis.layers.UnitSpec
 
@@ -122,6 +125,118 @@ class EndpointContextSpec extends UnitSpec {
 
   it should "not create contexts if not enabled" in {
     EndpointContext(config = config.getConfig("context-disabled")) should be(None)
+  }
+
+  it should "support encoding and decoding a KeyStore to/from ByteString without private keys" in {
+    val config = EndpointContext.StoreConfig(
+      storePath = "./core/src/test/resources/certs/localhost.p12",
+      storeType = "PKCS12",
+      storePassword = ""
+    )
+
+    val password = "test-password"
+
+    val original = EndpointContext.loadStore(config)
+
+    val encoded = EndpointContext.Encoded.encodeKeyStore(
+      store = original,
+      password = password,
+      storeType = config.storeType
+    )
+
+    val decoded = EndpointContext.Encoded.decodeKeyStore(
+      content = encoded,
+      password = password,
+      storeType = config.storeType
+    )
+
+    val encodedWithCertsOnly = EndpointContext.Encoded.encodeKeyStore(
+      store = decoded,
+      password = password,
+      storeType = config.storeType
+    )
+
+    val decodedWithCertsOnly = EndpointContext.Encoded.decodeKeyStore(
+      content = encodedWithCertsOnly,
+      password = password,
+      storeType = config.storeType
+    )
+
+    original.size should be > 0
+    original.aliases().asScala.toList.exists(original.isKeyEntry)
+
+    decoded.size should be > 0
+    decoded.aliases().asScala.toList.forall(decoded.isCertificateEntry) should be(true)
+
+    decodedWithCertsOnly.size should be > 0
+    decodedWithCertsOnly.aliases().asScala.toList.forall(decodedWithCertsOnly.isCertificateEntry) should be(true)
+  }
+
+  it should "fail to decode a KeyStore with private keys" in {
+    val config = EndpointContext.StoreConfig(
+      storePath = "./core/src/test/resources/certs/localhost.p12",
+      storeType = "PKCS12",
+      storePassword = ""
+    )
+
+    val password = "test-password"
+
+    val original = EndpointContext.loadStore(config)
+
+    val content = new ByteArrayOutputStream()
+    original.store(content, password.toCharArray)
+
+    val encoded = ByteString.fromArray(content.toByteArray)
+
+    an[IllegalArgumentException] should be thrownBy {
+      EndpointContext.Encoded.decodeKeyStore(encoded, password, config.storeType)
+    }
+  }
+
+  it should "support creating enabled contexts" in {
+    val config = EndpointContext.StoreConfig(
+      storePath = "./core/src/test/resources/certs/localhost.p12",
+      storeType = "PKCS12",
+      storePassword = ""
+    )
+
+    val actualContext = EndpointContext.Encoded.enabled(protocol = "TLS", config = config)
+
+    actualContext.enabled should be(true)
+    actualContext.protocol should be("TLS")
+    actualContext.storeType should be(config.storeType)
+    actualContext.temporaryStorePassword.length should be(EndpointContext.Encoded.TemporaryPasswordSize)
+    actualContext.storeContent should not be empty
+  }
+
+  it should "support creating disabled contexts" in {
+    EndpointContext.Encoded.disabled() should be(
+      EndpointContext.Encoded(
+        enabled = false,
+        protocol = "TLS",
+        storeType = "PKCS12",
+        temporaryStorePassword = "",
+        storeContent = ByteString.empty
+      )
+    )
+  }
+
+  it should "support creating contexts from config" in {
+    val enabledContext = EndpointContext.Encoded(config.getConfig("context-enabled"))
+
+    enabledContext.enabled should be(true)
+    enabledContext.protocol should be("TLS")
+    enabledContext.storeType should be("PKCS12")
+    enabledContext.temporaryStorePassword.length should be(EndpointContext.Encoded.TemporaryPasswordSize)
+    enabledContext.storeContent should not be empty
+
+    val disabledContext = EndpointContext.Encoded(config.getConfig("context-disabled"))
+
+    disabledContext.enabled should be(false)
+    disabledContext.protocol should be(EndpointContext.Encoded.DefaultProtocol)
+    disabledContext.storeType should be(EndpointContext.Encoded.DefaultStoreType)
+    disabledContext.temporaryStorePassword should be(empty)
+    disabledContext.storeContent should be(empty)
   }
 
   private val config: Config = ConfigFactory.load().getConfig("stasis.test.layers.security.tls")

--- a/server/src/main/resources/example-discovery-static.conf
+++ b/server/src/main/resources/example-discovery-static.conf
@@ -1,0 +1,58 @@
+endpoints {
+  # at least one API endpoint must be provided
+  api = [
+    {
+      uri = "http://localhost:10000"
+    },
+    {
+      uri = "http://localhost:20000"
+    },
+    {
+      uri = "http://localhost:30000"
+    }
+  ]
+
+  # at least one core endpoint must be provided
+  core = [
+    {
+      type = "http" # one of [http, grpc]
+
+      http {
+        uri = "http://localhost:10001"
+      }
+
+      grpc {
+        host = "localhost"
+        port = 10001
+        tls-enabled = false
+      }
+    },
+    {
+      type = "http"
+
+      http {
+        uri = "http://localhost:20001"
+      }
+    },
+    {
+      type = "grpc"
+
+      grpc {
+        host = "localhost"
+        port = 30001
+        tls-enabled = false
+      }
+    }
+  ]
+
+  # if no discovery endpoints are explicitly provided here,
+  # the API endpoints will also be used for discovery
+  discovery = [
+    {
+      uri = "http://localhost:10002"
+    },
+    {
+      uri = "http://localhost:20002"
+    },
+  ]
+}

--- a/server/src/main/resources/reference.conf
+++ b/server/src/main/resources/reference.conf
@@ -77,6 +77,17 @@ stasis {
         config = ${?STASIS_SERVER_SERVICE_BOOTSTRAP_CONFIG}
       }
 
+      discovery {
+        type = "disabled" # one of [disabled, static]
+        type = ${?STASIS_SERVER_SERVICE_DISCOVERY_TYPE}
+
+        static {
+          # path to discovery config file
+          config = ""
+          config = ${?STASIS_SERVER_SERVICE_DISCOVERY_STATIC_CONFIG}
+        }
+      }
+
       telemetry {
         metrics {
           # interface on which the metrics endpoint will listen for requests

--- a/server/src/main/scala/stasis/server/persistence/devices/DefaultDeviceKeyStore.scala
+++ b/server/src/main/scala/stasis/server/persistence/devices/DefaultDeviceKeyStore.scala
@@ -80,7 +80,7 @@ class DefaultDeviceKeyStore(
   override val migrations: Seq[Migration] = Seq(
     LegacyKeyValueStore(name, profile, database)
       .asMigration[DeviceKey, SlickStore](withVersion = 1, current = store) { e =>
-        import stasis.shared.api.Formats.byteStringFormat
+        import stasis.layers.api.Formats.byteStringFormat
         DeviceKey(
           value = (e \ "value").as[ByteString],
           owner = (e \ "owner").as[User.Id],

--- a/server/src/test/resources/application-device-bootstrap.conf
+++ b/server/src/test/resources/application-device-bootstrap.conf
@@ -48,6 +48,14 @@ stasis {
         config = "bootstrap-integration.conf"
       }
 
+      discovery {
+        type = "disabled"
+
+        static {
+          config = ""
+        }
+      }
+
       telemetry {
         metrics {
           interface = "localhost"

--- a/server/src/test/resources/application-invalid-bootstrap.conf
+++ b/server/src/test/resources/application-invalid-bootstrap.conf
@@ -33,6 +33,14 @@ stasis {
         mode = init-and-start
         config = "bootstrap-unit.conf"
       }
+
+      discovery {
+        type = "disabled"
+
+        static {
+          config = ""
+        }
+      }
     }
 
     authenticators {

--- a/server/src/test/resources/application-invalid-config.conf
+++ b/server/src/test/resources/application-invalid-config.conf
@@ -33,6 +33,14 @@ stasis {
         mode = init-and-start
         config = "bootstrap-unit.conf"
       }
+
+      discovery {
+        type = "disabled"
+
+        static {
+          config = ""
+        }
+      }
     }
 
     authenticators {

--- a/server/src/test/resources/application.conf
+++ b/server/src/test/resources/application.conf
@@ -48,6 +48,14 @@ stasis {
         config = "bootstrap-integration.conf"
       }
 
+      discovery {
+        type = "disabled"
+
+        static {
+          config = ""
+        }
+      }
+
       telemetry {
         metrics {
           interface = "localhost"

--- a/server/src/test/scala/stasis/server/api/BootstrapEndpointSpec.scala
+++ b/server/src/test/scala/stasis/server/api/BootstrapEndpointSpec.scala
@@ -19,6 +19,7 @@ import play.api.libs.json.Json
 
 import stasis.core.routing.Node
 import stasis.layers.api.MessageResponse
+import stasis.layers.security.tls.EndpointContext
 import stasis.layers.telemetry.TelemetryContext
 import stasis.server.Secrets
 import stasis.server.api.routes.DeviceBootstrap
@@ -222,19 +223,19 @@ class BootstrapEndpointSpec extends AsyncUnitSpec with ScalatestRouteTest with S
         api = "urn:stasis:identity:audience:server-api",
         core = s"urn:stasis:identity:audience:${Node.generateId().toString}"
       ),
-      context = DeviceBootstrapParameters.Context.disabled()
+      context = EndpointContext.Encoded.disabled()
     ),
     serverApi = DeviceBootstrapParameters.ServerApi(
       url = "http://localhost:5678",
       user = "",
       userSalt = "",
       device = "",
-      context = DeviceBootstrapParameters.Context.disabled()
+      context = EndpointContext.Encoded.disabled()
     ),
     serverCore = DeviceBootstrapParameters.ServerCore(
       address = "http://localhost:5679",
       nodeId = "",
-      context = DeviceBootstrapParameters.Context.disabled()
+      context = EndpointContext.Encoded.disabled()
     ),
     secrets = testSecretsConfig,
     additionalConfig = Json.obj()

--- a/server/src/test/scala/stasis/server/api/routes/DeviceBootstrapSpec.scala
+++ b/server/src/test/scala/stasis/server/api/routes/DeviceBootstrapSpec.scala
@@ -17,6 +17,7 @@ import org.slf4j.LoggerFactory
 import play.api.libs.json.Json
 
 import stasis.core.routing.Node
+import stasis.layers.security.tls.EndpointContext
 import stasis.layers.telemetry.TelemetryContext
 import stasis.server.Secrets
 import stasis.server.persistence.devices.DeviceBootstrapCodeStore
@@ -379,19 +380,19 @@ class DeviceBootstrapSpec extends AsyncUnitSpec with ScalatestRouteTest with Sec
         api = "urn:stasis:identity:audience:server-api",
         core = s"urn:stasis:identity:audience:${Node.generateId().toString}"
       ),
-      context = DeviceBootstrapParameters.Context.disabled()
+      context = EndpointContext.Encoded.disabled()
     ),
     serverApi = DeviceBootstrapParameters.ServerApi(
       url = "http://localhost:5678",
       user = "",
       userSalt = "",
       device = "",
-      context = DeviceBootstrapParameters.Context.disabled()
+      context = EndpointContext.Encoded.disabled()
     ),
     serverCore = DeviceBootstrapParameters.ServerCore(
       address = "http://localhost:5679",
       nodeId = "",
-      context = DeviceBootstrapParameters.Context.disabled()
+      context = EndpointContext.Encoded.disabled()
     ),
     secrets = testSecretsConfig,
     additionalConfig = Json.obj()

--- a/server/src/test/scala/stasis/server/persistence/devices/DefaultDeviceKeyStoreSpec.scala
+++ b/server/src/test/scala/stasis/server/persistence/devices/DefaultDeviceKeyStoreSpec.scala
@@ -8,10 +8,10 @@ import org.apache.pekko.actor.typed.ActorSystem
 import org.apache.pekko.actor.typed.scaladsl.Behaviors
 import org.apache.pekko.util.ByteString
 
+import stasis.core.persistence.backends.slick.LegacyKeyValueStore
 import stasis.layers.UnitSpec
 import stasis.layers.persistence.SlickTestDatabase
 import stasis.layers.telemetry.MockTelemetryContext
-import stasis.core.persistence.backends.slick.LegacyKeyValueStore
 import stasis.test.specs.unit.shared.model.Generators
 
 class DefaultDeviceKeyStoreSpec extends UnitSpec with SlickTestDatabase {
@@ -47,7 +47,7 @@ class DefaultDeviceKeyStoreSpec extends UnitSpec with SlickTestDatabase {
       withStore { (profile, database) =>
         import play.api.libs.json._
 
-        import stasis.shared.api.Formats._
+        import stasis.layers.api.Formats._
 
         val name = "TEST_DEVICE_KEYS"
         val legacy = LegacyKeyValueStore(name = name, profile = profile, database = database)
@@ -99,6 +99,6 @@ class DefaultDeviceKeyStoreSpec extends UnitSpec with SlickTestDatabase {
 
   private implicit val system: ActorSystem[Nothing] = ActorSystem(
     guardianBehavior = Behaviors.ignore,
-    "DefaultDeviceKeyStoreSpec"
+    name = "DefaultDeviceKeyStoreSpec"
   )
 }

--- a/shared/src/main/scala/stasis/shared/api/Formats.scala
+++ b/shared/src/main/scala/stasis/shared/api/Formats.scala
@@ -1,6 +1,5 @@
 package stasis.shared.api
 
-import java.nio.charset.StandardCharsets
 import java.time.Instant
 import java.time.temporal.ChronoUnit
 
@@ -42,6 +41,7 @@ object Formats {
   import stasis.core.api.Formats.grpcEndpointAddressFormat
   import stasis.core.api.Formats.httpEndpointAddressFormat
   import stasis.core.api.Formats.jsonConfig
+  import stasis.layers.api.Formats.endpointContextFormat
   import stasis.layers.api.Formats.finiteDurationFormat
 
   implicit val permissionFormat: Format[Permission] = Format(
@@ -133,17 +133,8 @@ object Formats {
     }
   )
 
-  implicit val byteStringFormat: Format[ByteString] =
-    Format(
-      fjs = _.validate[String].map(ByteString.fromString(_, StandardCharsets.UTF_8).decodeBase64),
-      tjs = content => Json.toJson(content.encodeBase64.utf8String)
-    )
-
   implicit val deviceBootstrapConfigScopesFormat: Format[DeviceBootstrapParameters.Scopes] =
     Json.format[DeviceBootstrapParameters.Scopes]
-
-  implicit val deviceBootstrapConfigContextFormat: Format[DeviceBootstrapParameters.Context] =
-    Json.format[DeviceBootstrapParameters.Context]
 
   implicit val deviceBootstrapConfigAuthenticationFormat: Format[DeviceBootstrapParameters.Authentication] =
     Json.format[DeviceBootstrapParameters.Authentication]

--- a/shared/src/main/scala/stasis/shared/model/devices/DeviceBootstrapParameters.scala
+++ b/shared/src/main/scala/stasis/shared/model/devices/DeviceBootstrapParameters.scala
@@ -1,16 +1,7 @@
 package stasis.shared.model.devices
 
-import java.io.ByteArrayInputStream
-import java.io.ByteArrayOutputStream
-import java.security.KeyStore
-import java.util.concurrent.ThreadLocalRandom
-
-import scala.jdk.CollectionConverters._
-import scala.util.Random
-
-import com.typesafe.{config => typesafe}
-import org.apache.pekko.util.ByteString
 import play.api.libs.json.JsObject
+
 import stasis.layers.security.tls.EndpointContext
 import stasis.shared.secrets.SecretsConfig
 
@@ -59,7 +50,7 @@ object DeviceBootstrapParameters {
     clientSecret: String,
     useQueryString: Boolean,
     scopes: Scopes,
-    context: Context
+    context: EndpointContext.Encoded
   )
 
   final case class ServerApi(
@@ -67,103 +58,17 @@ object DeviceBootstrapParameters {
     user: String,
     userSalt: String,
     device: String,
-    context: Context
+    context: EndpointContext.Encoded
   )
 
   final case class ServerCore(
     address: String,
     nodeId: String,
-    context: Context
+    context: EndpointContext.Encoded
   )
 
   final case class Scopes(
     api: String,
     core: String
   )
-
-  final case class Context(
-    enabled: Boolean,
-    protocol: String,
-    storeType: String,
-    temporaryStorePassword: String,
-    storeContent: ByteString
-  )
-
-  object Context {
-    final val TemporaryPasswordSize: Int = 32
-
-    final val DefaultProtocol: String = "TLS"
-    final val DefaultStoreType: String = "PKCS12"
-
-    def apply(config: typesafe.Config): Context =
-      if (config.getBoolean("enabled")) {
-        enabled(
-          protocol = config.getString("protocol"),
-          config = EndpointContext.StoreConfig(config.getConfig("truststore"))
-        )
-      } else {
-        disabled()
-      }
-
-    def disabled(): Context =
-      Context(
-        enabled = false,
-        protocol = DefaultProtocol,
-        storeType = DefaultStoreType,
-        temporaryStorePassword = "",
-        storeContent = ByteString.empty
-      )
-
-    def enabled(
-      protocol: String,
-      config: EndpointContext.StoreConfig
-    ): Context = {
-      val store = EndpointContext.loadStore(config)
-
-      val rnd: Random = ThreadLocalRandom.current()
-      val password = rnd.alphanumeric.take(TemporaryPasswordSize).mkString
-
-      Context(
-        enabled = true,
-        protocol = protocol,
-        storeType = config.storeType,
-        temporaryStorePassword = password,
-        storeContent = encodeKeyStore(store, password, config.storeType)
-      )
-    }
-
-    @SuppressWarnings(Array("org.wartremover.warts.Null"))
-    def encodeKeyStore(store: KeyStore, password: String, storeType: String): ByteString = {
-      val rebuiltStore = KeyStore.getInstance(storeType)
-      rebuiltStore.load(None.orNull, None.orNull)
-
-      store.aliases().asScala.foreach {
-        case alias if store.isKeyEntry(alias) =>
-          store.getCertificateChain(alias).zipWithIndex.foreach { case (certificate, index) =>
-            rebuiltStore.setCertificateEntry(s"$alias-${index.toString}", certificate)
-          }
-
-        case alias =>
-          require(store.isCertificateEntry(alias), s"Expected certificate entry for alias [$alias]")
-          rebuiltStore.setCertificateEntry(alias, store.getCertificate(alias))
-      }
-
-      val content = new ByteArrayOutputStream()
-      rebuiltStore.store(content, password.toCharArray)
-
-      ByteString.fromArray(content.toByteArray)
-    }
-
-    def decodeKeyStore(content: ByteString, password: String, storeType: String): KeyStore = {
-      val store = KeyStore.getInstance(storeType)
-      store.load(new ByteArrayInputStream(content.toArray), password.toCharArray)
-
-      require(
-        store.aliases().asScala.forall(store.isCertificateEntry),
-        "Expected certificate entries only but one or more keys were encountered."
-      )
-
-      store
-    }
-  }
 }

--- a/shared/src/test/resources/application.conf
+++ b/shared/src/test/resources/application.conf
@@ -1,22 +1,6 @@
 stasis {
   test {
     shared {
-      params {
-        context-enabled {
-          enabled = true
-          protocol = "TLS"
-          truststore {
-            path = "./core/src/test/resources/certs/localhost.p12"
-            type = "PKCS12"
-            password = ""
-          }
-        }
-
-        context-disabled {
-          enabled = false
-        }
-      }
-
       secrets {
         derivation {
           encryption {

--- a/shared/src/test/scala/stasis/test/specs/unit/shared/api/FormatsSpec.scala
+++ b/shared/src/test/scala/stasis/test/specs/unit/shared/api/FormatsSpec.scala
@@ -112,14 +112,6 @@ class FormatsSpec extends UnitSpec {
     deviceBootstrapCodeFormat.reads(Json.parse(jsonForNewDevice)).asOpt should be(Some(originalForNewDevice))
   }
 
-  they should "convert ByteStrings to/from JSON" in {
-    val original = ByteString("test-string")
-    val json = "\"dGVzdC1zdHJpbmc=\""
-
-    byteStringFormat.writes(original).toString() should be(json)
-    byteStringFormat.reads(Json.parse(json)).asOpt should be(Some(original))
-  }
-
   they should "convert device keys to/from JSON" in {
     val now = Instant.now()
 


### PR DESCRIPTION
Adds support for basic service discovery - the clients are now able to ask their initial server for their actual contact points (for the purposes of load balancing and failure recovery).